### PR TITLE
fix: blackout date frontend crash fix

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/utils.js
+++ b/src/pages-and-resources/discussions/app-config-form/utils.js
@@ -31,7 +31,7 @@ export const mergeDateTime = (date, time) => ((date && time) ? `${date}T${time}`
 export const isSameDay = (startDate, endDate) => moment(startDate).isSame(endDate, 'day');
 export const isSameMonth = (startDate, endDate) => moment(startDate).isSame(endDate, 'month');
 export const isSameYear = (startDate, endDate) => moment(startDate).isSame(endDate, 'year');
-export const getTime = (dateTime) => dateTime.split('T')[1] || '';
+export const getTime = (dateTime) => (dateTime ? dateTime.split('T')[1] : '');
 export const hasValidDateFormat = (date) => moment(date, ['MM/DD/YYYY', 'YYYY-MM-DD'], true).isValid();
 export const hasValidTimeFormat = (time) => time && moment(time, validTimeFormats, true).isValid();
 export const startOfDayTime = (time) => time || moment().startOf('day').format('HH:mm');


### PR DESCRIPTION
Frontend was crashing on some edge cases of invalid blackout dates formats. This issue has been handled on frontend and screenshots are attached for both before and after condition, with same data returned from API.

Before Fix

<img width="1440" alt="Screenshot 2022-01-05 at 10 07 46 PM" src="https://user-images.githubusercontent.com/67791278/148259285-d43eef97-e0c0-407c-a7fb-b8f6404b1335.png">


After Fix Mocking same data returned in first case

<img width="1328" alt="Screenshot 2022-01-05 at 10 08 34 PM" src="https://user-images.githubusercontent.com/67791278/148259316-d99040a9-750e-4de3-bb6a-df5349a575d2.png">

TNL TICKET : [TNL-9404](https://openedx.atlassian.net/browse/TNL-9404)
