### PR TITLE
fix: header improvements

### DIFF
--- a/src/studio-header/Header.jsx
+++ b/src/studio-header/Header.jsx
@@ -35,53 +35,22 @@ function Header({
       submenuContent: (
         <>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.outline'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/course/${courseId}`}>{intl.formatMessage(messages['header.links.outline'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/course_info/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.updates'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/course_info/${courseId}`}>{intl.formatMessage(messages['header.links.updates'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/tabs/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.pages'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/tabs/${courseId}`}>{intl.formatMessage(messages['header.links.pages'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/assets/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.filesAndUploads'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/assets/${courseId}`}>{intl.formatMessage(messages['header.links.filesAndUploads'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/textbooks/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.textbooks'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/textbooks/${courseId}`}>{intl.formatMessage(messages['header.links.textbooks'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/videos/${courseId}`}
-            >{
-              intl.formatMessage(messages['header.links.videoUploads'])
-            }
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/videos/${courseId}`}>{intl.formatMessage(messages['header.links.videoUploads'])}</a>
           </div>
         </>
       ),
@@ -92,52 +61,22 @@ function Header({
       submenuContent: (
         <>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/settings/details/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.scheduleAndDetails'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/details/${courseId}`}>{intl.formatMessage(messages['header.links.scheduleAndDetails'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/settings/grading/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.grading'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/grading/${courseId}`}>{intl.formatMessage(messages['header.links.grading'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/course_team/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.courseTeam'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/course_team/${courseId}`}>{intl.formatMessage(messages['header.links.courseTeam'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/group_configurations/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.groupConfigurations'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/group_configurations/${courseId}`}>{intl.formatMessage(messages['header.links.groupConfigurations'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/settings/advanced/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.advancedSettings'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/advanced/${courseId}`}>{intl.formatMessage(messages['header.links.advancedSettings'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/certificates/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.certificates'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/certificates/${courseId}`}>{intl.formatMessage(messages['header.links.certificates'])}</a>
           </div>
         </>
       ),
@@ -148,28 +87,13 @@ function Header({
       submenuContent: (
         <>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/import/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.import'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/import/${courseId}`}>{intl.formatMessage(messages['header.links.import'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/export/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.export'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/export/${courseId}`}>{intl.formatMessage(messages['header.links.export'])}</a>
           </div>
           <div className="mb-1 small">
-            <a
-              rel="noopener"
-              href={`${config.STUDIO_BASE_URL}/checklists/${courseId}`}
-            >
-              {intl.formatMessage(messages['header.links.checklists'])}
-            </a>
+            <a rel="noopener" href={`${config.STUDIO_BASE_URL}/checklists/${courseId}`}>{intl.formatMessage(messages['header.links.checklists'])}</a>
           </div>
         </>
       ),
@@ -219,8 +143,8 @@ function Header({
       )}
     >
       <a
-        className="course-title-lockup"
-        style={{ lineHeight: 1, width: '25%' }}
+        className="course-title-lockup w-25"
+        style={{ lineHeight: 1 }}
         href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
         aria-label={intl.formatMessage(messages['header.label.courseOutline'])}
       >

--- a/src/studio-header/Header.jsx
+++ b/src/studio-header/Header.jsx
@@ -5,6 +5,7 @@ import React, { useContext } from 'react';
 import Responsive from 'react-responsive';
 import { AppContext } from '@edx/frontend-platform/react';
 import { ensureConfig } from '@edx/frontend-platform';
+import { OverlayTrigger, Tooltip } from '@edx/paragon';
 import {
   injectIntl,
   intlShape,
@@ -33,12 +34,55 @@ function Header({
       content: intl.formatMessage(messages['header.links.content']),
       submenuContent: (
         <>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/course/${courseId}`}>{intl.formatMessage(messages['header.links.outline'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/course_info/${courseId}`}>{intl.formatMessage(messages['header.links.updates'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/tabs/${courseId}`}>{intl.formatMessage(messages['header.links.pages'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/assets/${courseId}`}>{intl.formatMessage(messages['header.links.filesAndUploads'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/textbooks/${courseId}`}>{intl.formatMessage(messages['header.links.textbooks'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/videos/${courseId}`}>{intl.formatMessage(messages['header.links.videoUploads'])}</a></div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.outline'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/course_info/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.updates'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/tabs/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.pages'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/assets/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.filesAndUploads'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/textbooks/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.textbooks'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/videos/${courseId}`}
+            >{
+              intl.formatMessage(messages['header.links.videoUploads'])
+            }
+            </a>
+          </div>
         </>
       ),
     },
@@ -47,12 +91,54 @@ function Header({
       content: intl.formatMessage(messages['header.links.settings']),
       submenuContent: (
         <>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/details/${courseId}`}>{intl.formatMessage(messages['header.links.scheduleAndDetails'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/grading/${courseId}`}>{intl.formatMessage(messages['header.links.grading'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/course_team/${courseId}`}>{intl.formatMessage(messages['header.links.courseTeam'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/group_configurations/${courseId}`}>{intl.formatMessage(messages['header.links.groupConfigurations'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/settings/advanced/${courseId}`}>{intl.formatMessage(messages['header.links.advancedSettings'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/certificates/${courseId}`}>{intl.formatMessage(messages['header.links.certificates'])}</a></div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/settings/details/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.scheduleAndDetails'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/settings/grading/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.grading'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/course_team/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.courseTeam'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/group_configurations/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.groupConfigurations'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/settings/advanced/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.advancedSettings'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/certificates/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.certificates'])}
+            </a>
+          </div>
         </>
       ),
     },
@@ -61,9 +147,30 @@ function Header({
       content: intl.formatMessage(messages['header.links.tools']),
       submenuContent: (
         <>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/import/${courseId}`}>{intl.formatMessage(messages['header.links.import'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/export/${courseId}`}>{intl.formatMessage(messages['header.links.export'])}</a></div>
-          <div className="mb-1 small"><a rel="noopener" href={`${config.STUDIO_BASE_URL}/checklists/${courseId}`}>{intl.formatMessage(messages['header.links.checklists'])}</a></div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/import/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.import'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/export/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.export'])}
+            </a>
+          </div>
+          <div className="mb-1 small">
+            <a
+              rel="noopener"
+              href={`${config.STUDIO_BASE_URL}/checklists/${courseId}`}
+            >
+              {intl.formatMessage(messages['header.links.checklists'])}
+            </a>
+          </div>
         </>
       ),
     },
@@ -103,15 +210,24 @@ function Header({
   }
 
   const courseLockUp = (
-    <a
-      className="course-title-lockup"
-      style={{ lineHeight: 1 }}
-      href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
-      aria-label={intl.formatMessage(messages['header.label.courseOutline'])}
+    <OverlayTrigger
+      placement="bottom"
+      overlay={(
+        <Tooltip variant="light">
+          {courseTitle}
+        </Tooltip>
+      )}
     >
-      <span className="d-block small m-0" data-testid="course-org-number">{courseOrg} {courseNumber}</span>
-      <span className="d-block m-0 font-weight-bold" data-testid="course-title">{courseTitle}</span>
-    </a>
+      <a
+        className="course-title-lockup"
+        style={{ lineHeight: 1, width: '25%' }}
+        href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
+        aria-label={intl.formatMessage(messages['header.label.courseOutline'])}
+      >
+        <span className="d-block small m-0" data-testid="course-org-number">{courseOrg} {courseNumber}</span>
+        <span className="d-block m-0 font-weight-bold" data-testid="course-title">{courseTitle}</span>
+      </a>
+    </OverlayTrigger>
   );
 
   const props = {

--- a/src/studio-header/Header.test.jsx
+++ b/src/studio-header/Header.test.jsx
@@ -64,8 +64,7 @@ describe('<Header />', () => {
     ));
 
     render(component);
-    expect(screen.getAllByTestId('course-org-number')[0].textContent).toEqual(expect.stringContaining('edX DemoX'));
-    expect(screen.getAllByTestId('course-title')[0].textContent).toEqual(expect.stringContaining('Demonstration Course'));
+    expect(screen.getByTestId('edx-header-logo'));
   });
 
   it('renders desktop header correctly with bad API call', async () => {
@@ -93,7 +92,7 @@ describe('<Header />', () => {
     ));
 
     render(component);
-    expect(screen.getAllByTestId('course-title')[0].textContent).toEqual(expect.stringContaining('course-v1:edX+DemoX+Demo_Course'));
+    expect(screen.getByTestId('edx-header-logo'));
   });
 
   afterEach(() => {

--- a/src/studio-header/MobileHeader.jsx
+++ b/src/studio-header/MobileHeader.jsx
@@ -107,7 +107,7 @@ class MobileHeader extends React.Component {
             ) : null}
         </div>
         <div className="d-flex align-items-center mobile-lockup">
-          {logoDestination === null ? <Logo className="logo" src={logo} alt={logoAltText} /> : <LinkedLogo className="logo" {...logoProps} itemType="http://schema.org/Organization" />}
+          {logoDestination === null ? <Logo className="logo" src={logo} alt={logoAltText} /> : <LinkedLogo className="logo" {...logoProps} itemType="http://schema.org/Organization" data-testid="edx-header-logo" />}
         </div>
         <div className="w-100 d-flex justify-content-end align-items-center">
           <Menu tag="nav" aria-label="Secondary" className="position-static">

--- a/src/studio-header/MobileHeader.jsx
+++ b/src/studio-header/MobileHeader.jsx
@@ -106,9 +106,8 @@ class MobileHeader extends React.Component {
               </Menu>
             ) : null}
         </div>
-        <div className="w-100 d-flex align-items-center mobile-lockup">
+        <div className="d-flex align-items-center mobile-lockup">
           {logoDestination === null ? <Logo className="logo" src={logo} alt={logoAltText} /> : <LinkedLogo className="logo" {...logoProps} itemType="http://schema.org/Organization" />}
-          { this.props.courseLockUp }
         </div>
         <div className="w-100 d-flex justify-content-end align-items-center">
           <Menu tag="nav" aria-label="Secondary" className="position-static">


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-9461

Improvements made in the desktop header -- set width to 25% so course name exceeding beyond the limit can be contained inside provided space. and tooltip is added on hover to view the full course name.


<img width="1440" alt="Screenshot 2022-01-13 at 8 40 52 PM" src="https://user-images.githubusercontent.com/67791278/149363269-e1616ec6-754e-4a2d-97ff-81b326d10afc.png">

Course name removed from mobile header view to make it according to the Figma designs.

<img width="464" alt="Screenshot 2022-01-13 at 8 42 26 PM" src="https://user-images.githubusercontent.com/67791278/149363901-6916801e-6c5d-4714-ae0b-098667ee3b36.png">

