### PR TITLE
fix: team page crash issue fix

### DIFF
--- a/src/pages-and-resources/teams/GroupEditor.jsx
+++ b/src/pages-and-resources/teams/GroupEditor.jsx
@@ -73,7 +73,7 @@ function GroupEditor({
                   </div>
                 ) : (
                   <div className="d-flex flex-column flex-shrink-1 small mw-100">
-                    <div className="small text-gray-500">{intl.formatMessage(TeamTypeNameMessage[group.type].label)}</div>
+                    <div className="small text-gray-500">{intl.formatMessage(TeamTypeNameMessage[group.type ? group.type : GroupTypes.OPEN].label)} </div>
                     <div className="h4 text-truncate my-1 font-weight-normal">{group.name}</div>
                     <div className="small text-truncate text-muted text-gray-500">{group.description}</div>
                   </div>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-9463

Context: 
groups: teamsConfiguration?.teamSets || teamsConfiguration?.topics
 
groups can be team_sets or topics coming from already configured team sets from legacy UI. in case of topics the type field is missing in group data and types can be either `public` `private` or `open`
 
one such example of such course which is rendering error on MFE is https://course-authoring.edx.org/course/course-v1:edX+victor101+2017Run/pages-and-resources/teams/settings
 
all such topics having missing type fields in their data are rendered public for now to avoid UI crash.
 