### PR TITLE
fix: divide discussions by cohort toggle should not divide course-wid…

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
@@ -31,8 +31,9 @@ import { DivisionSchemes } from '../../../../../data/constants';
 const courseId = 'course-v1:edX+TestX+Test_Course';
 const defaultAppConfig = {
   id: 'legacy',
-  divideByCohorts: false,
-  divideCourseTopicsByCohorts: false,
+  divideByCohorts: true,
+  divideCourseTopicsByCohorts: true,
+  alwaysDivideInlineDiscussions: true,
   discussionTopics: [
     { name: 'Edx', id: '13f106c6-6735-4e84-b097-0456cff55960' },
     { name: 'General', id: 'course' },
@@ -45,6 +46,7 @@ const defaultAppConfig = {
   allowAnonymousPostsPeers: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
+  dividedInlineDiscussions: [],
 };
 describe('LegacyConfigForm', () => {
   let axiosMock;
@@ -156,11 +158,11 @@ describe('LegacyConfigForm', () => {
     ).toBeInTheDocument();
     expect(
       container.querySelector('#divideCourseTopicsByCohorts'),
-    ).not.toBeChecked();
+    ).toBeChecked();
 
     defaultAppConfig.divideDiscussionIds.forEach(id => expect(
       container.querySelector(`#checkbox-${id}`),
-    ).not.toBeInTheDocument());
+    ).toBeInTheDocument());
 
     // AnonymousPostingFields
     expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
@@ -29,25 +29,22 @@ import { selectApp } from '../../../data/slice';
 import { DivisionSchemes } from '../../../../../data/constants';
 
 const courseId = 'course-v1:edX+TestX+Test_Course';
-const defaultAppConfig = {
+const defaultAppConfig = (divideDiscussionIds = []) => ({
   id: 'legacy',
-  divideByCohorts: true,
-  divideCourseTopicsByCohorts: true,
-  alwaysDivideInlineDiscussions: true,
+  divideByCohorts: false,
+  divideCourseTopicsByCohorts: false,
+  alwaysDivideInlineDiscussions: false,
   discussionTopics: [
     { name: 'Edx', id: '13f106c6-6735-4e84-b097-0456cff55960' },
     { name: 'General', id: 'course' },
   ],
-  divideDiscussionIds: [
-    '13f106c6-6735-4e84-b097-0456cff55960',
-    'course',
-  ],
+  divideDiscussionIds,
+  dividedInlineDiscussions: [],
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
-  dividedInlineDiscussions: [],
-};
+});
 describe('LegacyConfigForm', () => {
   let axiosMock;
   let store;
@@ -113,8 +110,8 @@ describe('LegacyConfigForm', () => {
       // any of the form inputs, this exact object shape is returned back to us, so we're reusing
       // it here.  It's not supposed to be 'the same object', it just happens to be.
       {
-        ...defaultAppConfig,
-        divideByCohorts: true,
+        ...defaultAppConfig(),
+        divideByCohorts: false,
         divisionScheme: DivisionSchemes.COHORT,
       },
     );
@@ -123,12 +120,14 @@ describe('LegacyConfigForm', () => {
   test('default field states are correct, including removal of folded sub-fields', async () => {
     await mockStore({ ...legacyApiResponse, plugin_configuration: { divided_course_wide_discussions: [] } });
     createComponent();
+    const { divideDiscussionIds } = defaultAppConfig(['13f106c6-6735-4e84-b097-0456cff55960', 'course']);
+
     // DivisionByGroupFields
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
     expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
     expect(container.querySelector('#divideCourseTopicsByCohorts')).not.toBeInTheDocument();
 
-    defaultAppConfig.divideDiscussionIds.forEach(id => expect(
+    divideDiscussionIds.forEach(id => expect(
       container.querySelector(`#checkbox-${id}`),
     ).not.toBeInTheDocument());
 
@@ -146,9 +145,15 @@ describe('LegacyConfigForm', () => {
   test('folded sub-fields are in the DOM when parents are enabled', async () => {
     await mockStore({
       ...legacyApiResponse,
-      plugin_configuration: { ...legacyApiResponse.plugin_configuration, allow_anonymous: true },
+      plugin_configuration: {
+        ...legacyApiResponse.plugin_configuration,
+        allow_anonymous: true,
+        always_divide_inline_discussions: true,
+        divided_course_wide_discussions: [],
+      },
     });
     createComponent();
+    const { divideDiscussionIds } = defaultAppConfig(['13f106c6-6735-4e84-b097-0456cff55960', 'course']);
 
     // DivisionByGroupFields
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
@@ -158,11 +163,11 @@ describe('LegacyConfigForm', () => {
     ).toBeInTheDocument();
     expect(
       container.querySelector('#divideCourseTopicsByCohorts'),
-    ).toBeChecked();
+    ).not.toBeChecked();
 
-    defaultAppConfig.divideDiscussionIds.forEach(id => expect(
+    divideDiscussionIds.forEach(id => expect(
       container.querySelector(`#checkbox-${id}`),
-    ).toBeInTheDocument());
+    ).not.toBeInTheDocument());
 
     // AnonymousPostingFields
     expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
@@ -181,11 +186,13 @@ describe('LegacyConfigForm', () => {
         ...legacyApiResponse,
         plugin_configuration: {
           ...legacyApiResponse.plugin_configuration,
-          divided_course_wide_discussions: ['13f106c6-6735-4e84-b097-0456cff55960',
-            'course', 'test-topic'],
+          allow_anonymous: true,
+          always_divide_inline_discussions: true,
+          divided_course_wide_discussions: ['13f106c6-6735-4e84-b097-0456cff55960', 'course'],
         },
       });
       createComponent();
+      const { divideDiscussionIds } = defaultAppConfig(['13f106c6-6735-4e84-b097-0456cff55960', 'course']);
 
       // DivisionByGroupFields
       expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
@@ -193,7 +200,7 @@ describe('LegacyConfigForm', () => {
       expect(container.querySelector('#divideCourseTopicsByCohorts')).toBeInTheDocument();
       expect(container.querySelector('#divideCourseTopicsByCohorts')).toBeChecked();
 
-      defaultAppConfig.divideDiscussionIds.forEach(id => {
+      divideDiscussionIds.forEach(id => {
         expect(container.querySelector(`#checkbox-${id}`)).toBeInTheDocument();
         expect(container.querySelector(`#checkbox-${id}`)).toBeChecked();
       });

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
@@ -39,7 +39,6 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
     { name: 'General', id: 'course' },
   ],
   divideDiscussionIds,
-  dividedInlineDiscussions: [],
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   allowDivisionByUnit: false,

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -57,17 +57,17 @@ function normalizePluginConfig(data) {
   if (!data || Object.keys(data).length < 1) {
     return {};
   }
-  const discussionDividedTopicsCount = _.size(data.divided_course_wide_discussions);
-  const discussionTopicsCount = _.size(data.discussion_topics);
-  const enableDivideCourseTopicsByCohorts = Boolean(discussionDividedTopicsCount
-    && (discussionDividedTopicsCount !== discussionTopicsCount));
+  const enableDivideByCohorts = data.always_divide_inline_discussions && data.division_scheme === 'cohort';
+  const enableDivideCourseTopicsByCohorts = enableDivideByCohorts && data.divided_course_wide_discussions.length > 0;
   return {
     allowAnonymousPosts: data.allow_anonymous,
     allowAnonymousPostsPeers: data.allow_anonymous_to_peers,
     divisionScheme: data.division_scheme,
+    alwaysDivideInlineDiscussions: data.always_divide_inline_discussions,
+    dividedInlineDiscussions: data.divided_inline_discussions,
     blackoutDates: normalizeBlackoutDates(data.discussion_blackouts),
     allowDivisionByUnit: false,
-    divideByCohorts: discussionDividedTopicsCount > 0,
+    divideByCohorts: enableDivideByCohorts,
     divideCourseTopicsByCohorts: enableDivideCourseTopicsByCohorts,
   };
 }
@@ -180,6 +180,7 @@ function denormalizeData(courseId, appId, data) {
   }
   if ('divideByCohorts' in data) {
     pluginConfiguration.division_scheme = data.divideByCohorts ? DivisionSchemes.COHORT : DivisionSchemes.NONE;
+    pluginConfiguration.always_divide_inline_discussions = data.divideByCohorts;
   }
   if (data.blackoutDates?.length) {
     pluginConfiguration.discussion_blackouts = data.blackoutDates.map((blackoutDates) => (
@@ -195,8 +196,9 @@ function denormalizeData(courseId, appId, data) {
       return newTopics;
     }, {});
   }
-  if (data.divideDiscussionIds) {
-    pluginConfiguration.divided_course_wide_discussions = data.divideDiscussionIds;
+  if ('divideCourseTopicsByCohorts' in data) {
+    pluginConfiguration.divided_course_wide_discussions = data.divideCourseTopicsByCohorts
+      ? data.divideDiscussionIds : [];
   }
 
   const ltiConfiguration = {};

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -64,7 +64,6 @@ function normalizePluginConfig(data) {
     allowAnonymousPostsPeers: data.allow_anonymous_to_peers,
     divisionScheme: data.division_scheme,
     alwaysDivideInlineDiscussions: data.always_divide_inline_discussions,
-    dividedInlineDiscussions: data.divided_inline_discussions,
     blackoutDates: normalizeBlackoutDates(data.discussion_blackouts),
     allowDivisionByUnit: false,
     divideByCohorts: enableDivideByCohorts,

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -227,7 +227,7 @@ describe('Data layer integration tests', () => {
         saveStatus: SAVED,
         hasValidationError: false,
         discussionTopicIds,
-        divideDiscussionIds,
+        divideDiscussionIds: [],
       });
       expect(store.getState().models.apps.legacy).toEqual(legacyApp);
       expect(store.getState().models.apps.piazza).toEqual(piazzaApp);
@@ -240,11 +240,11 @@ describe('Data layer integration tests', () => {
         // TODO: Note!  As of this writing, all the data below this line is NOT returned in the API
         // but we add it in during normalization.
         divisionScheme: DivisionSchemes.COHORT,
-        divideByCohorts: true,
-        alwaysDivideInlineDiscussions: true,
+        divideByCohorts: false,
+        alwaysDivideInlineDiscussions: false,
         dividedInlineDiscussions: [],
         allowDivisionByUnit: false,
-        divideCourseTopicsByCohorts: true,
+        divideCourseTopicsByCohorts: false,
       });
     });
   });

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -241,8 +241,10 @@ describe('Data layer integration tests', () => {
         // but we add it in during normalization.
         divisionScheme: DivisionSchemes.COHORT,
         divideByCohorts: true,
+        alwaysDivideInlineDiscussions: true,
+        dividedInlineDiscussions: [],
         allowDivisionByUnit: false,
-        divideCourseTopicsByCohorts: false,
+        divideCourseTopicsByCohorts: true,
       });
     });
   });
@@ -388,8 +390,9 @@ describe('Data layer integration tests', () => {
         plugin_configuration: {
           allow_anonymous: true,
           allow_anonymous_to_peers: true,
+          always_divide_inline_discussions: true,
           discussion_blackouts: [],
-          division_scheme: DivisionSchemes.NONE,
+          division_scheme: DivisionSchemes.COHORT,
           discussion_topics: {
             Edx: { id: '13f106c6-6735-4e84-b097-0456cff55960' },
             General: { id: 'course' },
@@ -406,6 +409,7 @@ describe('Data layer integration tests', () => {
         plugin_configuration: {
           allow_anonymous: true,
           allow_anonymous_to_peers: true,
+          always_divide_inline_discussions: true,
           discussion_blackouts: [],
           division_scheme: DivisionSchemes.COHORT,
           discussion_topics: {
@@ -431,9 +435,10 @@ describe('Data layer integration tests', () => {
           blackoutDates: [],
           // TODO: Note!  As of this writing, all the data below this line is NOT returned in the API
           // but we technically send it to the thunk, so here it is.
-          divideByCohorts: false,
-          allowDivisionByUnit: true,
-          divideCourseTopicsByCohorts: false,
+          divideByCohorts: true,
+          allowDivisionsByUnit: true,
+          alwaysDivideInlineDiscussions: true,
+          divideCourseTopicsByCohorts: true,
           divideDiscussionIds,
           discussionTopics: [
             { name: 'Edx', id: '13f106c6-6735-4e84-b097-0456cff55960' },
@@ -462,13 +467,14 @@ describe('Data layer integration tests', () => {
         // These three fields should be updated.
         allowAnonymousPosts: true,
         allowAnonymousPostsPeers: true,
+        alwaysDivideInlineDiscussions: true,
         blackoutDates: [],
         // TODO: Note!  The values we tried to save were ignored, this test reflects what currently
         // happens, but NOT what we want to have happen!
         divideByCohorts: true,
         divisionScheme: DivisionSchemes.COHORT,
         allowDivisionByUnit: false,
-        divideCourseTopicsByCohorts: false,
+        divideCourseTopicsByCohorts: true,
       });
     });
   });

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -242,7 +242,6 @@ describe('Data layer integration tests', () => {
         divisionScheme: DivisionSchemes.COHORT,
         divideByCohorts: false,
         alwaysDivideInlineDiscussions: false,
-        dividedInlineDiscussions: [],
         allowDivisionByUnit: false,
         divideCourseTopicsByCohorts: false,
       });

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -93,7 +93,7 @@ export const generateLegacyApiResponse = () => ({
   plugin_configuration: {
     allow_anonymous: false,
     allow_anonymous_to_peers: false,
-    always_divide_inline_discussions: false,
+    always_divide_inline_discussions: true,
     available_division_schemes: ['enrollment_track'],
     discussion_topics: {
       Edx: { id: '13f106c6-6735-4e84-b097-0456cff55960' },

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -100,7 +100,6 @@ export const generateLegacyApiResponse = () => ({
       General: { id: 'course' },
     },
     divided_course_wide_discussions: [],
-    divided_inline_discussions: [],
     division_scheme: DivisionSchemes.COHORT,
     // Note, this gets stringified when normalized into the app, but the API returns it as an
     // actual array.  Argh.

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -93,16 +93,13 @@ export const generateLegacyApiResponse = () => ({
   plugin_configuration: {
     allow_anonymous: false,
     allow_anonymous_to_peers: false,
-    always_divide_inline_discussions: true,
+    always_divide_inline_discussions: false,
     available_division_schemes: ['enrollment_track'],
     discussion_topics: {
       Edx: { id: '13f106c6-6735-4e84-b097-0456cff55960' },
       General: { id: 'course' },
     },
-    divided_course_wide_discussions: [
-      '13f106c6-6735-4e84-b097-0456cff55960',
-      'course',
-    ],
+    divided_course_wide_discussions: [],
     divided_inline_discussions: [],
     division_scheme: DivisionSchemes.COHORT,
     // Note, this gets stringified when normalized into the app, but the API returns it as an


### PR DESCRIPTION
- Divide discussions by cohort toggle should not divide course-wide discussions.
- Divide discussions by cohorts toggle should only divide content-specific discussion topics by cohorts.
- When dividing course-wide discussion topics toggle enable, it should select all discussion topics for divide.
- User can select any topic for the course-wide discussion division
<img width="603" alt="Screenshot 2022-01-14 at 4 09 49 PM" src="https://user-images.githubusercontent.com/79941147/149506124-cb29609b-779b-4dae-9fb3-fe8c78caa980.png">
.