### PR TITLE
fix: header course name ui improvement

### DIFF
--- a/src/studio-header/Header.jsx
+++ b/src/studio-header/Header.jsx
@@ -137,14 +137,13 @@ function Header({
     <OverlayTrigger
       placement="bottom"
       overlay={(
-        <Tooltip variant="light">
+        <Tooltip>
           {courseTitle}
         </Tooltip>
       )}
     >
       <a
         className="course-title-lockup w-25"
-        style={{ lineHeight: 1 }}
         href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
         aria-label={intl.formatMessage(messages['header.label.courseOutline'])}
       >

--- a/src/studio-header/header.scss
+++ b/src/studio-header/header.scss
@@ -21,7 +21,11 @@ $white: #fff;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      line-height: 1rem;
     }
+  a {
+    line-height: 1rem;
+  }
 }
 
 .mobile-lockup {
@@ -89,7 +93,7 @@ $white: #fff;
   .main-nav {
     flex-wrap: nowrap;
     .nav-link {
-      padding: 1.125rem 1rem;
+      padding: 1rem;
       text-decoration: none;
       font-weight: 500;
       letter-spacing: .01em;


### PR DESCRIPTION
Tooltip color changed to dark and name line-height improvement.

<img width="1440" alt="Screenshot 2022-01-18 at 5 04 36 PM" src="https://user-images.githubusercontent.com/67791278/149934485-8176ad3f-9175-486f-82f4-42a8b2a7592a.png">
