### PR TITLE
fix: line height of header course title

### DIFF
--- a/src/studio-header/header.scss
+++ b/src/studio-header/header.scss
@@ -3,28 +3,25 @@ $spacer: 1rem;
 $blue: #007db8;
 $white: #fff;
 
-@import './Menu/menu.scss';
+@import "./Menu/menu.scss";
 
 .course-title-lockup {
-  @media only screen and (max-width : 768px) {
+  @media only screen and (max-width: 768px) {
     padding-left: 0.5rem;
     max-width: 70%;
   }
-  @media only screen and (min-width : 769px) {
+  @media only screen and (min-width: 769px) {
     padding: 0.5rem;
     padding-right: 1rem;
     border-right: 1px solid #e5e5e5;
   }
   overflow: hidden;
-    span {
-      color: #333;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: 1rem;
-    }
-  a {
-    line-height: 1rem;
+  span {
+    color: #333;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.375rem;
   }
 }
 
@@ -45,11 +42,12 @@ $white: #fff;
   border: none;
   height: 3rem;
   width: 3rem;
-  padding: .75rem;
+  padding: 0.75rem;
   justify-content: center;
-  align-items:center;
-  &:hover, &:focus {
-    background: rgba(0,0,0,.1);
+  align-items: center;
+  &:hover,
+  &:focus {
+    background: rgba(0, 0, 0, 0.1);
   }
 }
 
@@ -69,10 +67,9 @@ $white: #fff;
   }
 }
 
-
 .site-header-desktop {
   height: 3.75rem;
-  box-shadow: 0 1px 0 0 rgba(0,0,0,.1);
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.1);
   background: $white;
   .nav-link {
     text-decoration: none;
@@ -81,7 +78,7 @@ $white: #fff;
     display: block;
     box-sizing: content-box;
     position: relative;
-    top: -.05em;
+    top: -0.05em;
     height: 1.75rem;
     padding: 1rem 0;
     margin-right: 1rem;
@@ -96,7 +93,7 @@ $white: #fff;
       padding: 1rem;
       text-decoration: none;
       font-weight: 500;
-      letter-spacing: .01em;
+      letter-spacing: 0.01em;
     }
     .nav-link:hover,
     .nav-link:focus,
@@ -109,7 +106,7 @@ $white: #fff;
       position: relative;
       .menu-content {
         border-top: solid 2px $component-active-bg;
-        box-shadow: 0 1px 2px rgba(0,0,0,.25);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
         padding: 1rem;


### PR DESCRIPTION
- Add space between course outline and title lines in the header
-  Update span line-height: 1rem to line-height:1.375rem and remove the unnecessary a tag line-height.


Before fix
<img width="847" alt="Screenshot 2022-01-19 at 3 11 41 PM" src="https://user-images.githubusercontent.com/79941147/150109869-28a2a263-d2ed-4ba7-b79f-b672a8843d3e.png">

After fix
<img width="847" alt="Screenshot 2022-01-19 at 3 10 41 PM" src="https://user-images.githubusercontent.com/79941147/150109719-cccdec10-555e-4ce4-a38f-81c91ce210d3.png">

