### PR TITLE
fix: reset the proctoringProvider field value to be empty when disabling proctoring

### DIFF
--- a/src/pages-and-resources/proctoring/Settings.jsx
+++ b/src/pages-and-resources/proctoring/Settings.jsx
@@ -92,7 +92,7 @@ function ProctoringSettings({ intl, onClose }) {
   }
 
   function postSettingsBackToServer() {
-    const dataToPostBack = {
+    let dataToPostBack = {
       proctored_exam_settings: {
         enable_proctored_exams: formValues.enableProctoredExams,
         proctoring_provider: formValues.proctoringProvider,
@@ -101,6 +101,17 @@ function ProctoringSettings({ intl, onClose }) {
     };
     if (isEdxStaff) {
       dataToPostBack.proctored_exam_settings.allow_proctoring_opt_out = formValues.allowOptingOut;
+    }
+
+    if(!formValues.enableProctoredExams){
+      dataToPostBack = {
+        proctored_exam_settings: {
+          enable_proctored_exams: false,
+          proctoring_provider: null,
+          create_zendesk_tickets: false,
+          allow_proctoring_opt_out: false,
+        },
+      };
     }
 
     if (formValues.proctoringProvider === 'proctortrack') {

--- a/src/pages-and-resources/proctoring/Settings.test.jsx
+++ b/src/pages-and-resources/proctoring/Settings.test.jsx
@@ -166,6 +166,41 @@ describe('ProctoredExamSettings', () => {
       expect(screen.queryByTestId('createZendeskTicketsYes')).toBeNull();
       expect(screen.queryByTestId('createZendeskTicketsNo')).toBeNull();
     });
+
+    it('When enableProctoredExam is false, proctoredProvider and other attributes are saved as empty', async () => {
+      await waitFor(() => {
+        screen.getByText('Proctored exams');
+      });
+      expect(screen.queryByText('Allow opting out of proctored exams')).toBeDefined();
+      expect(screen.queryByDisplayValue('mockproc')).toBeDefined();
+  
+      let enabledProctoredExamCheck = screen.getAllByLabelText('Proctored exams', { exact: false })[0];
+      expect(enabledProctoredExamCheck.checked).toEqual(true);
+      await act(async () => {
+        fireEvent.click(enabledProctoredExamCheck, { target: { value: false } });
+      });
+      enabledProctoredExamCheck = screen.getByLabelText('Proctored exams');
+      expect(enabledProctoredExamCheck.checked).toEqual(false);
+  
+      axiosMock.onPost(
+        StudioApiService.getProctoredExamSettingsUrl(defaultProps.courseId),
+      ).reply(200, {});
+  
+      let submitButton = screen.getByTestId('submissionButton');
+      await act(() => {
+        fireEvent.click(submitButton);
+      });
+
+      expect(axiosMock.history.post.length).toBe(1);
+        expect(JSON.parse(axiosMock.history.post[0].data)).toEqual({
+          proctored_exam_settings: {
+            enable_proctored_exams: false,
+            allow_proctoring_opt_out: false,
+            proctoring_provider: null,
+            create_zendesk_tickets: false,
+          },
+        });
+    });
   });
 
   describe('Validation with invalid escalation email', () => {

--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -90,7 +90,7 @@ function ProctoredExamSettings({ courseId, intl }) {
   }
 
   function postSettingsBackToServer() {
-    const dataToPostBack = {
+    let dataToPostBack = {
       proctored_exam_settings: {
         enable_proctored_exams: enableProctoredExams,
         proctoring_provider: proctoringProvider,
@@ -99,6 +99,17 @@ function ProctoredExamSettings({ courseId, intl }) {
     };
     if (isEdxStaff) {
       dataToPostBack.proctored_exam_settings.allow_proctoring_opt_out = allowOptingOut;
+    }
+
+    if(!enableProctoredExams){
+      dataToPostBack = {
+        proctored_exam_settings: {
+          enable_proctored_exams: false,
+          proctoring_provider: '',
+          create_zendesk_tickets: false,
+          allow_proctoring_opt_out: false,
+        },
+      };
     }
 
     if (proctoringProvider === 'proctortrack') {
@@ -296,6 +307,7 @@ function ProctoredExamSettings({ courseId, intl }) {
             value={proctoringProvider}
             onChange={onProctoringProviderChange}
             aria-describedby="proctoringProviderHelpText"
+            data-testid="proctoringProvider"
           >
             {getProctoringProviderOptions(availableProctoringProviders)}
           </Form.Control>


### PR DESCRIPTION
Before this change, when user disables proctoring on the UI, we would still persist the ProctoringProvider selection and ProctortrackEscalationEmail.

After this change, when the user disables proctoring, we reset the ProctoringProvider value to '' (empty) and reset the value of ProctortrackEscalationEmail to '' (empty) as well. This way, we remove the effect of Proctoring configuration from course.

To me, this might be the easiest way to help a course to be importable into a different environment like edge.edx.org where proctoring is not configured.
The downside is, if the course team wants to enable proctoring again, they'd have to fill the ProctortrackEscalationEmail again.

@openedx/masters-devs-cosmonauts Please review