### PR TITLE
feat: hide PII sharing fields for LTI config

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -399,7 +399,7 @@ describe.each([
   });
 
   test(`successfully advances to settings step for lti when adminOnlyConfig=${isAdminOnlyConfig} and user ${isAdmin ? 'is' : 'is not'} admin`, async () => {
-    const showLTIConfig = isAdmin || !isAdminOnlyConfig;
+    const showLTIConfig = isAdmin;
     history.push(`/course/${courseId}/pages-and-resources/discussion`);
 
     // This is an important line that ensures the spinner has been removed - and thus our main
@@ -423,6 +423,8 @@ describe.each([
   { piiSharingAllowed: false },
   { piiSharingAllowed: true },
 ])('PII sharing fields test', ({ piiSharingAllowed }) => {
+  const enablePIISharing = false;
+
   beforeEach(() => {
     initializeMockApp({
       authenticatedUser: {
@@ -458,7 +460,7 @@ describe.each([
 
     userEvent.click(queryByLabelText(container, 'Select Piazza'));
     userEvent.click(queryByText(container, messages.nextButton.defaultMessage));
-    if (piiSharingAllowed) {
+    if (enablePIISharing) {
       expect(queryByTestId(container, 'piiSharingFields')).toBeInTheDocument();
     } else {
       expect(queryByTestId(container, 'piiSharingFields')).not.toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
@@ -2,14 +2,21 @@ import React, { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { StatefulButton } from '@edx/paragon';
 
 import messages from './messages';
 import { SAVING } from '../data/slice';
 import { AppConfigFormContext } from './AppConfigFormProvider';
+import { useModel } from '../../../generic/model-store';
 
 function AppConfigFormSaveButton({ intl, labelText }) {
   const saveStatus = useSelector(state => state.discussions.saveStatus);
+  const { selectedAppId } = useSelector((state) => state.discussions);
+
+  const app = useModel('apps', selectedAppId);
+  const canSubmit = getAuthenticatedUser().administrator || !app.adminOnlyConfig;
+
   const { formRef } = useContext(AppConfigFormContext);
 
   const submitButtonState = saveStatus === SAVING ? 'pending' : 'default';
@@ -20,16 +27,18 @@ function AppConfigFormSaveButton({ intl, labelText }) {
   }, [formRef]);
 
   return (
-    <StatefulButton
-      labels={{
-        default: labelText || intl.formatMessage(messages.saveButton),
-        pending: intl.formatMessage(messages.savingButton),
-        complete: intl.formatMessage(messages.savedButton),
-      }}
-      state={submitButtonState}
-      onClick={handleSave}
-      style={{ minWidth: '88px' }}
-    />
+    canSubmit && (
+      <StatefulButton
+        labels={{
+          default: labelText || intl.formatMessage(messages.saveButton),
+          pending: intl.formatMessage(messages.savingButton),
+          complete: intl.formatMessage(messages.savedButton),
+        }}
+        state={submitButtonState}
+        onClick={handleSave}
+        style={{ minWidth: '88px' }}
+      />
+    )
   );
 }
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -53,7 +53,7 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
   const isInvalidConsumerSecret = Boolean(touched.consumerSecret && errors.consumerSecret);
   const isInvalidLaunchUrl = Boolean(touched.launchUrl && errors.launchUrl);
   const supportEmail = getConfig().SUPPORT_EMAIL;
-  const showLTIConfig = user.administrator && app.adminOnlyConfig;
+  const showLTIConfig = user.administrator;
   const enablePIISharing = false;
 
   useEffect(() => {

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -53,7 +53,8 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
   const isInvalidConsumerSecret = Boolean(touched.consumerSecret && errors.consumerSecret);
   const isInvalidLaunchUrl = Boolean(touched.launchUrl && errors.launchUrl);
   const supportEmail = getConfig().SUPPORT_EMAIL;
-  const showLTIConfig = user.administrator || !app.adminOnlyConfig;
+  const showLTIConfig = user.administrator && app.adminOnlyConfig;
+  const enablePIISharing = false;
 
   useEffect(() => {
     dispatch(updateValidationStatus({ hasError: Object.keys(errors).length > 0 }));
@@ -63,26 +64,10 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
     <Card className="mb-5 p-5" data-testid="ltiConfigForm">
       <Form ref={formRef} onSubmit={handleSubmit}>
         <h3 className="mb-3">{providerName}</h3>
-        <p>
-          <FormattedMessage
-            {...messages.adminOnlyConfig}
-            values={{
-              providerName,
-              platformName: getConfig().SITE_NAME,
-              supportEmail: supportEmail ? (
-                <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
-              ) : (
-                'support'
-              ),
-            }}
-          />
-        </p>
-        <p>
-          {showLTIConfig && intl.formatMessage(messages.formInstructions)}
-        </p>
-        {app.ltiMessages && app.ltiMessages.map((msg) => <p key={msg}>{msg}</p>)}
-        {showLTIConfig && (
+        {showLTIConfig ? (
           <>
+            <p>{intl.formatMessage(messages.adminOnlyConfig, { providerName })}</p>
+            <p>{intl.formatMessage(messages.formInstructions)}</p>
             <Form.Group
               controlId="consumerKey"
               isInvalid={isInvalidConsumerKey}
@@ -132,8 +117,23 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
               )}
             </Form.Group>
           </>
+        ) : (
+          <p>
+            <FormattedMessage
+              {...messages.stuffOnlyConfig}
+              values={{
+                providerName,
+                platformName: getConfig().SITE_NAME,
+                supportEmail: supportEmail ? (
+                  <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
+                ) : (
+                  'support'
+                ),
+              }}
+            />
+          </p>
         )}
-        {piiConfig.piiSharing && (
+        {(enablePIISharing) && (
           <div data-testid="piiSharingFields">
             <Form.Text className="my-2">{intl.formatMessage(messages.piiSharing)}</Form.Text>
             <Form.Group controlId="piiSharing">

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -39,9 +39,13 @@ const messages = defineMessages({
     defaultMessage: 'Launch URL is a required field',
     description: 'Tells the user that the Launch URL field is required and must have a value.',
   },
+  stuffOnlyConfig: {
+    id: 'authoring.discussions.stuffConfig',
+    defaultMessage: '{providerName} can only be configured by {platformName} administrators. Please contact {supportEmail} to enable this feature. This will require sharing usernames and emails of learners and the course team with {providerName}',
+  },
   adminOnlyConfig: {
     id: 'authoring.discussions.adminOnlyConfig',
-    defaultMessage: '{providerName} can only be configured by {platformName} administrators. Please contact {supportEmail} to enable this feature.',
+    defaultMessage: 'This configuration will require sharing usernames and emails of learners and the course team with {providerName}',
   },
   piiSharing: {
     id: 'authoring.discussions.piiSharing',

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -74,8 +74,8 @@ function normalizePluginConfig(data) {
 function normalizePiiSharing(data) {
   return {
     piiSharing: data.pii_sharing_allowed,
-    piiShareUsername: data.pii_share_username,
-    piiShareEmail: data.pii_share_email,
+    piiShareUsername: data.pii_sharing_allowed,
+    piiShareEmail: data.pii_sharing_allowed,
   };
 }
 

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -38,6 +38,7 @@ export const generatePiazzaApiResponse = (piazzaAdminOnlyConfig = false, piiShar
         },
         messages: [],
         has_full_support: true,
+        admin_only_config: false,
       },
       piazza: {
         features: [
@@ -74,6 +75,7 @@ export const generatePiazzaApiResponse = (piazzaAdminOnlyConfig = false, piiShar
         },
         messages: [],
         has_full_support: false,
+        admin_only_config: false,
       },
     },
   },
@@ -123,6 +125,7 @@ export const generateLegacyApiResponse = () => ({
         },
         messages: [],
         has_full_support: true,
+        admin_only_config: false,
       },
       piazza: {
         features: [
@@ -141,6 +144,7 @@ export const generateLegacyApiResponse = () => ({
         },
         messages: [],
         has_full_support: false,
+        admin_only_config: false,
       },
     },
   },


### PR DESCRIPTION
[TNL-9511](https://openedx.atlassian.net/browse/TNL-9511)
- PII sharing fields are hidden for all LTI providers
- PII sharing option is not visible to any user (Global staff, educators)
- `enableEmailsharing` and `enableUsername` sharing depends on `allowPiiSharing flag`


**Global staff**
- LTI form fields are only visible to Global staff.
- LTI form message is updated to `This configuration will require sharing usernames and emails of learners and the course team with {providerName}`.
- LTI form instructions are visible.
- Save button is active for Global staff.
<img width="1440" alt="Screenshot 2022-01-31 at 6 26 19 PM" src="https://user-images.githubusercontent.com/79941147/151819597-6c846c97-025d-4876-bb34-4fdc61dbb373.png">
<img width="1440" alt="Screenshot 2022-01-31 at 6 43 09 PM" src="https://user-images.githubusercontent.com/79941147/151819613-12bb7d04-3fa5-40bf-a0c3-b23fcf06c654.png">
<img width="1440" alt="Screenshot 2022-01-31 at 6 43 31 PM" src="https://user-images.githubusercontent.com/79941147/151819615-3be69189-30d1-4ad2-8398-9ecfaf00f833.png">


**Educators**
- LTI form fields are not visible to Educators.
- LTI form message is updated to `{providerName} can only be configured by {platformName} administrators. Please contact {supportEmail} to enable this feature. This will require sharing usernames and emails of learners and the course team with {providerName}`.
- LTI form instructions are not visible.
- Save button is not visible for Educators
<img width="1440" alt="Screenshot 2022-01-31 at 6 23 26 PM" src="https://user-images.githubusercontent.com/79941147/151819741-a1f96333-3e81-43e6-aabd-3796490b1cb5.png">
<img width="1440" alt="Screenshot 2022-01-31 at 6 23 46 PM" src="https://user-images.githubusercontent.com/79941147/151819755-3848be2e-534a-4458-8ac9-dc60e1d4cebc.png">
<img width="1440" alt="Screenshot 2022-01-31 at 6 24 02 PM" src="https://user-images.githubusercontent.com/79941147/151819766-c4471828-2956-49b6-a8fc-4a9b2d11be88.png">


