### PR TITLE
fix: update f-l-c-c version for editor save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3714,9 +3714,9 @@
       }
     },
     "@edx/frontend-lib-content-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-1.1.0.tgz",
-      "integrity": "sha512-UV+zm8DNk4I1UNLxSgmGQMhiYxDMUTToDeJ/hVf9/l0NVo0LauJh0pdymXUb59sVYan9Q/wzT2jZz3asn05r6g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-1.1.1.tgz",
+      "integrity": "sha512-mWfWCKj+eKgWhjgoOIEye/0+kZwWRVxXhC4NwCtgW+NHfFI/rHVPOraE2NOoNH+ml4XDLmVEjz7s93OIyyV8Nw==",
       "requires": {
         "@tinymce/tinymce-react": "^3.13.0",
         "babel-polyfill": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
-    "@edx/frontend-lib-content-components": "^1.1.0",
+    "@edx/frontend-lib-content-components": "1.1.1",
     "@edx/frontend-platform": "1.14.0",
     "@edx/paragon": "16.17.0",
     "@fortawesome/fontawesome-svg-core": "1.2.28",


### PR DESCRIPTION
An error in the content components caused the new html editor not to save. This will make it so it won't encode the destination uri twice.