### PR TITLE
refactor: code for iconbutton usage

### DIFF
--- a/src/generic/CollapsableEditor.jsx
+++ b/src/generic/CollapsableEditor.jsx
@@ -28,18 +28,10 @@ const CollapsableEditor = ({
       className="collapsible-trigger d-flex border-0 align-items-center"
       style={{ justifyContent: 'unset' }}
     >
-      <div className="d-flex flex-grow-1 w-75">
-        {title}
-      </div>
+      <div className="d-flex flex-grow-1 w-75">{title}</div>
       <Collapsible.Visible whenClosed>
         <div className="align-self-start">
-          <IconButton
-            alt={expandAlt}
-            src={ExpandMore}
-            iconAs={Icon}
-            onClick={() => {}}
-            variant="dark"
-          />
+          <IconButton alt={expandAlt} src={ExpandMore} iconAs={Icon} variant="dark" />
         </div>
       </Collapsible.Visible>
       <Collapsible.Visible whenOpen>
@@ -58,19 +50,11 @@ const CollapsableEditor = ({
           </div>
         )}
         <div className="pl-4 d-flex">
-          <IconButton
-            alt={collapseAlt}
-            src={ExpandLess}
-            iconAs={Icon}
-            onClick={() => {}}
-            variant="dark"
-          />
+          <IconButton alt={collapseAlt} src={ExpandLess} iconAs={Icon} variant="dark" />
         </div>
       </Collapsible.Visible>
     </Collapsible.Trigger>
-    <Collapsible.Body className="collapsible-body rounded px-0">
-      {children}
-    </Collapsible.Body>
+    <Collapsible.Body className="collapsible-body rounded px-0">{children}</Collapsible.Body>
   </Collapsible.Advanced>
 );
 

--- a/src/pages-and-resources/pages/PageCard.jsx
+++ b/src/pages-and-resources/pages/PageCard.jsx
@@ -42,7 +42,6 @@ function PageCard({
             iconAs={Icon}
             size="inline"
             alt={intl.formatMessage(messages.settings)}
-            onClick={() => {}}
           />
         </Hyperlink>
       );


### PR DESCRIPTION
With the upgrade of the paragon, the version is bumped beyond https://github.com/edx/paragon/tree/v16.16.1 which added the default `onClick` param for `IconButton`. In this PR we are removing the unessassry `onClick` params. 

Quick Links:
https://github.com/openedx/paragon/pull/872
https://github.com/openedx/paragon/commit/2fef5ae49d2550389dee37f5c0ea92c597c5322c