### PR TITLE
fix: display same message for everyone during discussions provider configuration

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -64,9 +64,22 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
     <Card className="mb-5 p-5" data-testid="ltiConfigForm">
       <Form ref={formRef} onSubmit={handleSubmit}>
         <h3 className="mb-3">{providerName}</h3>
-        {showLTIConfig ? (
+        <p>
+          <FormattedMessage
+            {...messages.stuffOnlyConfig}
+            values={{
+              providerName,
+              platformName: getConfig().SITE_NAME,
+              supportEmail: supportEmail ? (
+                <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
+              ) : (
+                'support'
+              ),
+            }}
+          />
+        </p>
+        {showLTIConfig && (
           <>
-            <p>{intl.formatMessage(messages.adminOnlyConfig, { providerName })}</p>
             <p>{intl.formatMessage(messages.formInstructions)}</p>
             <Form.Group
               controlId="consumerKey"
@@ -117,21 +130,6 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
               )}
             </Form.Group>
           </>
-        ) : (
-          <p>
-            <FormattedMessage
-              {...messages.stuffOnlyConfig}
-              values={{
-                providerName,
-                platformName: getConfig().SITE_NAME,
-                supportEmail: supportEmail ? (
-                  <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
-                ) : (
-                  'support'
-                ),
-              }}
-            />
-          </p>
         )}
         {(enablePIISharing) && (
           <div data-testid="piiSharingFields">

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -43,10 +43,6 @@ const messages = defineMessages({
     id: 'authoring.discussions.stuffConfig',
     defaultMessage: '{providerName} can only be configured by {platformName} administrators. Please contact {supportEmail} to enable this feature. This will require sharing usernames and emails of learners and the course team with {providerName}',
   },
-  adminOnlyConfig: {
-    id: 'authoring.discussions.adminOnlyConfig',
-    defaultMessage: 'This configuration will require sharing usernames and emails of learners and the course team with {providerName}',
-  },
   piiSharing: {
     id: 'authoring.discussions.piiSharing',
     defaultMessage: 'Optionally share a user\'s username and/or email with the LTI provider:',


### PR DESCRIPTION
[TNL-9598](https://openedx.atlassian.net/browse/TNL-9598)

- Display the same message for everyone (educators, global staff) during discussions provider (LTI) configuration

<img width="885" alt="Screenshot 2022-02-22 at 12 54 14 PM" src="https://user-images.githubusercontent.com/79941147/155087925-6d3810e0-1295-45dc-b9c6-cc674cb0f8c5.png">
<img width="800" alt="Screenshot 2022-02-22 at 12 58 34 PM" src="https://user-images.githubusercontent.com/79941147/155087944-3ddbfcf0-46f2-48ef-b01f-54caebecbf74.png">
