### PR TITLE
fix: remove new and legacy from discussion app names [BD-38]

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -147,7 +147,7 @@ describe('DiscussionsSettings', () => {
       // content has been loaded - prior to proceeding with our expectations.
       await waitForElementToBeRemoved(screen.getByRole('status'));
 
-      userEvent.click(queryByLabelText(container, 'Select edX (Legacy)'));
+      userEvent.click(queryByLabelText(container, 'Select edX'));
       userEvent.click(queryByText(container, messages.nextButton.defaultMessage));
 
       await waitForElementToBeRemoved(screen.getByRole('status'));

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -82,12 +82,12 @@ const messages = defineMessages({
   },
   'appName-legacy': {
     id: 'authoring.discussions.appConfigForm.appName-legacy',
-    defaultMessage: 'edX (Legacy)',
+    defaultMessage: 'edX',
     description: 'The name of the Legacy edX Discussions app.',
   },
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',
-    defaultMessage: 'edX (NEW)',
+    defaultMessage: 'edX',
     description: 'The name of the new edX Discussions app.',
   },
   divisionByGroup: {

--- a/src/pages-and-resources/discussions/app-list/messages.js
+++ b/src/pages-and-resources/discussions/app-list/messages.js
@@ -48,7 +48,7 @@ const messages = defineMessages({
   // Legacy
   'appName-legacy': {
     id: 'authoring.discussions.appList.appName-legacy',
-    defaultMessage: 'edX (Legacy)',
+    defaultMessage: 'edX',
     description: 'The name of the Legacy edX Discussions app.',
   },
   'appDescription-legacy': {


### PR DESCRIPTION
Both providers should have the same name.