### PR TITLE
fix: modify message on discussion provider LTI configuration page

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { ensureConfig } from '@edx/frontend-platform';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Card, Form, MailtoLink } from '@edx/paragon';
@@ -50,9 +50,14 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
   const isInvalidConsumerKey = Boolean(touched.consumerKey && errors.consumerKey);
   const isInvalidConsumerSecret = Boolean(touched.consumerSecret && errors.consumerSecret);
   const isInvalidLaunchUrl = Boolean(touched.launchUrl && errors.launchUrl);
-  const supportEmail = getConfig().SUPPORT_EMAIL;
   const showLTIConfig = user.administrator;
   const enablePIISharing = false;
+  const supportEmails = {
+    Yellowdig: 'learnmore@yellowdig.com',
+    'Ed Discussion': 'team@edstem.org',
+    InScribe: 'hello@inscribeapp.com',
+    Piazza: 'team@piazza.com',
+  };
 
   useEffect(() => {
     dispatch(updateValidationStatus({ hasError: Object.keys(errors).length > 0 }));
@@ -67,9 +72,8 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
             {...messages.stuffOnlyConfig}
             values={{
               providerName,
-              platformName: getConfig().SITE_NAME,
-              supportEmail: supportEmail ? (
-                <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
+              supportEmail: supportEmails[providerName] ? (
+                <MailtoLink to={supportEmails[providerName]}>{supportEmails[providerName]}</MailtoLink>
               ) : (
                 'support'
               ),

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -41,7 +41,7 @@ const messages = defineMessages({
   },
   stuffOnlyConfig: {
     id: 'authoring.discussions.stuffConfig',
-    defaultMessage: '{providerName} can only be configured by {platformName} administrators. Please contact {supportEmail} to enable this feature. This will require sharing usernames and emails of learners and the course team with {providerName}',
+    defaultMessage: 'To get {providerName} for your course, please contact their support team at {supportEmail}. This will require sharing usernames and emails of learners and course team with the {providerName}. Please contact your edX project coordinator to get PII sharing enabled for this course.',
   },
   piiSharing: {
     id: 'authoring.discussions.piiSharing',

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -41,7 +41,7 @@ const messages = defineMessages({
   },
   stuffOnlyConfig: {
     id: 'authoring.discussions.stuffConfig',
-    defaultMessage: 'To get {providerName} for your course, please contact their support team at {supportEmail}. This will require sharing usernames and emails of learners and course team with the {providerName}. Please contact your edX project coordinator to get PII sharing enabled for this course.',
+    defaultMessage: 'To enable {providerName} for your course, please contact their support team at {supportEmail} to learn more about pricing and usage. To fully configure {providerName} will also require sharing usernames and emails for learners and course team. Please contact your edX project coordinator to enable PII sharing for this course.',
   },
   piiSharing: {
     id: 'authoring.discussions.piiSharing',


### PR DESCRIPTION
## Ticket: [TNL-9706](https://openedx.atlassian.net/browse/TNL-9706)

Updated message on discussion provider LTI configuration page.
<img width="735" alt="Screenshot 2022-03-18 at 6 49 11 PM" src="https://user-images.githubusercontent.com/51022010/159014877-32bef58d-c4b6-470b-b7f8-8620e73b9750.png">

