### PR TITLE
fix: split message on discussion provider LTI configuration page

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -69,7 +69,20 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
         <h3 className="mb-3">{providerName}</h3>
         <p>
           <FormattedMessage
-            {...messages.stuffOnlyConfig}
+            {...messages.stuffOnlyConfigInfo}
+            values={{
+              providerName,
+              supportEmail: supportEmails[providerName] ? (
+                <MailtoLink to={supportEmails[providerName]}>{supportEmails[providerName]}</MailtoLink>
+              ) : (
+                'support'
+              ),
+            }}
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            {...messages.stuffOnlyConfigGuide}
             values={{
               providerName,
               supportEmail: supportEmails[providerName] ? (

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -69,7 +69,7 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
         <h3 className="mb-3">{providerName}</h3>
         <p>
           <FormattedMessage
-            {...messages.stuffOnlyConfigInfo}
+            {...messages.staffOnlyConfigInfo}
             values={{
               providerName,
               supportEmail: supportEmails[providerName] ? (
@@ -82,7 +82,7 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
         </p>
         <p>
           <FormattedMessage
-            {...messages.stuffOnlyConfigGuide}
+            {...messages.staffOnlyConfigGuide}
             values={{
               providerName,
               supportEmail: supportEmails[providerName] ? (

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -39,9 +39,13 @@ const messages = defineMessages({
     defaultMessage: 'Launch URL is a required field',
     description: 'Tells the user that the Launch URL field is required and must have a value.',
   },
-  stuffOnlyConfig: {
-    id: 'authoring.discussions.stuffConfig',
-    defaultMessage: 'To enable {providerName} for your course, please contact their support team at {supportEmail} to learn more about pricing and usage. To fully configure {providerName} will also require sharing usernames and emails for learners and course team. Please contact your edX project coordinator to enable PII sharing for this course.',
+  stuffOnlyConfigInfo: {
+    id: 'authoring.discussions.stuffOnlyConfigInfo',
+    defaultMessage: 'To enable {providerName} for your course, please contact their support team at {supportEmail} to learn more about pricing and usage.',
+  },
+  stuffOnlyConfigGuide: {
+    id: 'authoring.discussions.stuffOnlyConfigGuide',
+    defaultMessage: 'To fully configure {providerName} will also require sharing usernames and emails for learners and course team. Please contact your edX project coordinator to enable PII sharing for this course.',
   },
   piiSharing: {
     id: 'authoring.discussions.piiSharing',

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/messages.js
@@ -39,11 +39,11 @@ const messages = defineMessages({
     defaultMessage: 'Launch URL is a required field',
     description: 'Tells the user that the Launch URL field is required and must have a value.',
   },
-  stuffOnlyConfigInfo: {
+  staffOnlyConfigInfo: {
     id: 'authoring.discussions.stuffOnlyConfigInfo',
     defaultMessage: 'To enable {providerName} for your course, please contact their support team at {supportEmail} to learn more about pricing and usage.',
   },
-  stuffOnlyConfigGuide: {
+  staffOnlyConfigGuide: {
     id: 'authoring.discussions.stuffOnlyConfigGuide',
     defaultMessage: 'To fully configure {providerName} will also require sharing usernames and emails for learners and course team. Please contact your edX project coordinator to enable PII sharing for this course.',
   },


### PR DESCRIPTION
## Ticket: [TNL-9706](https://openedx.atlassian.net/browse/TNL-9706)

Split message into separate paragraphs on discussion provider LTI configuration page.
<img width="684" alt="Screenshot 2022-03-21 at 1 25 27 PM" src="https://user-images.githubusercontent.com/51022010/159227467-22e86e3d-e3c8-4ce5-9d22-23c32725d728.png">

