### PR TITLE
Update: lti config fields will only be visible for all if the pii sharing is allowed 

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -93,7 +93,7 @@ describe('DiscussionsSettings', () => {
       axiosMock.onGet(getDiscussionsProvidersUrl(courseId))
         .reply(200, generateProvidersApiResponse(false));
       axiosMock.onGet(getDiscussionsSettingsUrl(courseId))
-        .reply(200, piazzaApiResponse);
+        .reply(200, generatePiazzaApiResponse(true));
       renderComponent();
     });
 
@@ -193,7 +193,7 @@ describe('DiscussionsSettings', () => {
     test('successfully submit the modal', async () => {
       history.push(`/course/${courseId}/pages-and-resources/discussion`);
 
-      axiosMock.onPost(getDiscussionsSettingsUrl(courseId)).reply(200, piazzaApiResponse);
+      axiosMock.onPost(getDiscussionsSettingsUrl(courseId)).reply(200, generatePiazzaApiResponse(true));
 
       // This is an important line that ensures the spinner has been removed - and thus our main
       // content has been loaded - prior to proceeding with our expectations.
@@ -414,11 +414,11 @@ describe.each([
     axiosMock.onGet(getDiscussionsProvidersUrl(courseId))
       .reply(200, generateProvidersApiResponse(isAdminOnlyConfig));
     axiosMock.onGet(getDiscussionsSettingsUrl(courseId))
-      .reply(200, generatePiazzaApiResponse());
+      .reply(200, generatePiazzaApiResponse(true));
     renderComponent();
   });
 
-  test(`successfully advances to settings step for lti when adminOnlyConfig=${isAdminOnlyConfig} and user ${isAdmin ? 'is' : 'is not'} admin`, async () => {
+  test(`successfully advances to settings step for lti when adminOnlyConfig=${isAdminOnlyConfig} and user ${isAdmin ? 'is' : 'is not'} admin `, async () => {
     const showLTIConfig = isAdmin;
     history.push(`/course/${courseId}/pages-and-resources/discussion`);
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -93,7 +93,7 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
             }}
           />
         </p>
-        {showLTIConfig && (
+        {(showLTIConfig && piiConfig.piiSharing) && (
           <>
             <p>{intl.formatMessage(messages.formInstructions)}</p>
             <Form.Group


### PR DESCRIPTION
[TNL-9738](https://openedx.atlassian.net/browse/TNL-9738)

- use case update ->  lti config fields will only be visible for all if the pii sharing is allowed 
- test case update according to the new use case. 

view when pii sharing is disabled.
<img width="608" alt="Screenshot 2022-03-30 at 6 02 38 PM" src="https://user-images.githubusercontent.com/67791278/160905663-53968842-4bee-4a5d-a101-ff0b089b2554.png">
