### PR TITLE
feat: add reported email notifications setting in legacy discussions

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -15,6 +15,7 @@ import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 import BlackoutDatesField from '../shared/BlackoutDatesField';
 import DiscussionTopics from '../shared/discussion-topics/DiscussionTopics';
 import DivisionByGroupFields from '../shared/DivisionByGroupFields';
+import ReportedContentEmailNotifications from '../shared/ReportedContentEmailNotifications';
 import InContextDiscussionFields from '../shared/InContextDiscussionFields';
 import OpenedXConfigFormProvider from './OpenedXConfigFormProvider';
 
@@ -36,6 +37,7 @@ function OpenedXConfigForm({
     unitLevelVisibility,
     allowAnonymousPosts: appConfigObj?.allowAnonymousPosts || false,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
+    reportedContentEmailNotifications: appConfigObj?.reportedContentEmailNotifications || false,
     blackoutDates: appConfigObj?.blackoutDates || [],
     discussionTopics: discussionTopicsModel || [],
     divideByCohorts: appConfigObj?.divideByCohorts || false,
@@ -135,6 +137,8 @@ function OpenedXConfigForm({
                 <DiscussionTopics />
                 <AppConfigFormDivider thick />
                 <DivisionByGroupFields />
+                <AppConfigFormDivider thick />
+                <ReportedContentEmailNotifications />
                 <AppConfigFormDivider thick />
                 <BlackoutDatesField />
               </Form>

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -38,6 +38,7 @@ function OpenedXConfigForm({
     allowAnonymousPosts: appConfigObj?.allowAnonymousPosts || false,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
     reportedContentEmailNotifications: appConfigObj?.reportedContentEmailNotifications || false,
+    enableReportedContentEmailNotifications: appConfigObj?.enableReportedContentEmailNotifications || false,
     blackoutDates: appConfigObj?.blackoutDates || [],
     discussionTopics: discussionTopicsModel || [],
     divideByCohorts: appConfigObj?.divideByCohorts || false,
@@ -139,7 +140,6 @@ function OpenedXConfigForm({
                 <DivisionByGroupFields />
                 <AppConfigFormDivider thick />
                 <ReportedContentEmailNotifications />
-                <AppConfigFormDivider thick />
                 <BlackoutDatesField />
               </Form>
             </Card>

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -46,6 +46,7 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
   unitLevelVisibility: undefined,
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
+  reportedContentEmailNotifications: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
 });
@@ -154,6 +155,10 @@ describe('OpenedXConfigForm', () => {
       container.querySelector('#allowAnonymousPostsPeers'),
     ).not.toBeInTheDocument();
 
+    // ReportedContentEmailNotifications
+    expect(container.querySelector('#reportedContentEmailNotifications')).toBeInTheDocument();
+    expect(container.querySelector('#reportedContentEmailNotifications')).not.toBeChecked();
+
     // BlackoutDatesField
     expect(queryByText(container, messages.blackoutDatesLabel.defaultMessage)).toBeInTheDocument();
   });
@@ -164,6 +169,7 @@ describe('OpenedXConfigForm', () => {
       plugin_configuration: {
         ...legacyApiResponse.plugin_configuration,
         allow_anonymous: true,
+        reported_content_email_notifications: true,
         always_divide_inline_discussions: true,
         divided_course_wide_discussions: [],
       },
@@ -194,6 +200,10 @@ describe('OpenedXConfigForm', () => {
     expect(
       container.querySelector('#allowAnonymousPostsPeers'),
     ).not.toBeChecked();
+
+    // ReportedContentEmailNotifications
+    expect(container.querySelector('#reportedContentEmailNotifications')).toBeInTheDocument();
+    expect(container.querySelector('#reportedContentEmailNotifications')).toBeChecked();
   });
 
   test('folded discussion topics are in the DOM when divideByCohorts and divideCourseWideTopics are enabled',
@@ -203,6 +213,7 @@ describe('OpenedXConfigForm', () => {
         plugin_configuration: {
           ...legacyApiResponse.plugin_configuration,
           allow_anonymous: true,
+          reported_content_email_notifications: true,
           always_divide_inline_discussions: true,
           divided_course_wide_discussions: ['13f106c6-6735-4e84-b097-0456cff55960', 'course'],
         },

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -47,6 +47,7 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   reportedContentEmailNotifications: false,
+  enableReportedContentEmailNotifications: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
 });
@@ -135,7 +136,14 @@ describe('OpenedXConfigForm', () => {
   });
 
   test('default field states are correct, including removal of folded sub-fields', async () => {
-    await mockStore({ ...legacyApiResponse, plugin_configuration: { divided_course_wide_discussions: [] } });
+    await mockStore({
+      ...legacyApiResponse,
+      plugin_configuration: {
+         ...legacyApiResponse.plugin_configuration,
+        reported_content_email_notifications_flag: true,
+        divided_course_wide_discussions: [],
+      },
+    });
     createComponent();
     const { divideDiscussionIds } = defaultAppConfig(['13f106c6-6735-4e84-b097-0456cff55960', 'course']);
 
@@ -170,6 +178,7 @@ describe('OpenedXConfigForm', () => {
         ...legacyApiResponse.plugin_configuration,
         allow_anonymous: true,
         reported_content_email_notifications: true,
+        reported_content_email_notifications_flag: true,
         always_divide_inline_discussions: true,
         divided_course_wide_discussions: [],
       },
@@ -214,6 +223,7 @@ describe('OpenedXConfigForm', () => {
           ...legacyApiResponse.plugin_configuration,
           allow_anonymous: true,
           reported_content_email_notifications: true,
+          reported_content_email_notifications_flag: true,
           always_divide_inline_discussions: true,
           divided_course_wide_discussions: ['13f106c6-6735-4e84-b097-0456cff55960', 'course'],
         },

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/ReportedContentEmailNotifications.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/ReportedContentEmailNotifications.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useFormikContext } from 'formik';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
+import AppConfigFormDivider from './AppConfigFormDivider';
 import messages from '../../messages';
 
 function ReportedContentEmailNotifications({ intl }) {
@@ -13,16 +14,21 @@ function ReportedContentEmailNotifications({ intl }) {
 
   return (
     <>
-      <h5 className="text-gray-500 mt-4 mb-2 ">{intl.formatMessage(messages.reportedContentEmailNotifications)}</h5>
-      <FormSwitchGroup
-        className="mb-4"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        id="reportedContentEmailNotifications"
-        checked={values.reportedContentEmailNotifications}
-        label={intl.formatMessage(messages.reportedContentEmailNotificationsLabel)}
-        helpText={intl.formatMessage(messages.reportedContentEmailNotificationsHelp)}
-      />
+      {values.enableReportedContentEmailNotifications && (
+        <div>
+          <h5 className="text-gray-500 mt-4 mb-2 ">{intl.formatMessage(messages.reportedContentEmailNotifications)}</h5>
+          <FormSwitchGroup
+            className="mb-4"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            id="reportedContentEmailNotifications"
+            checked={values.reportedContentEmailNotifications}
+            label={intl.formatMessage(messages.reportedContentEmailNotificationsLabel)}
+            helpText={intl.formatMessage(messages.reportedContentEmailNotificationsHelp)}
+          />
+          <AppConfigFormDivider thick />
+        </div>
+      )}
     </>
   );
 }

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/ReportedContentEmailNotifications.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/ReportedContentEmailNotifications.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
+import messages from '../../messages';
+
+function ReportedContentEmailNotifications({ intl }) {
+  const {
+    handleChange,
+    handleBlur,
+    values,
+  } = useFormikContext();
+
+  return (
+    <>
+      <h5 className="text-gray-500 mt-4 mb-2 ">{intl.formatMessage(messages.reportedContentEmailNotifications)}</h5>
+      <FormSwitchGroup
+        className="mb-4"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        id="reportedContentEmailNotifications"
+        checked={values.reportedContentEmailNotifications}
+        label={intl.formatMessage(messages.reportedContentEmailNotificationsLabel)}
+        helpText={intl.formatMessage(messages.reportedContentEmailNotificationsHelp)}
+      />
+    </>
+  );
+}
+
+ReportedContentEmailNotifications.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(ReportedContentEmailNotifications);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.test.jsx
@@ -33,6 +33,7 @@ const appConfig = {
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   reportedContentEmailNotifications: false,
+  enableReportedContentEmailNotifications: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
 };

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.test.jsx
@@ -32,6 +32,7 @@ const appConfig = {
   divideDiscussionIds: [],
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
+  reportedContentEmailNotifications: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
 };

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -185,6 +185,20 @@ const messages = defineMessages({
     defaultMessage: 'Learners will be able to post anonymously to other peers but all posts will be visible to course staff.',
   },
 
+  // Reported Email Notifications
+  reportedContentEmailNotifications: {
+    id: 'authoring.discussions.builtIn.reportedContentEmailNotifications',
+    defaultMessage: 'Notifications',
+  },
+  reportedContentEmailNotificationsLabel: {
+    id: 'authoring.discussions.builtIn.reportedContentEmailNotifications.label',
+    defaultMessage: 'Email notifications for reported content',
+  },
+  reportedContentEmailNotificationsHelp: {
+    id: 'authoring.discussions.builtIn.reportedContentEmailNotifications.help',
+    defaultMessage: 'Discussion Admins, Moderators, Community TAs and Group Community TAs (only for their own cohort) will receive an email notification when content is reported.',
+  },
+
   // Discussion Topics
   discussionTopics: {
     id: 'authoring.discussions.discussionTopics',

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -61,6 +61,7 @@ function normalizePluginConfig(data) {
   return {
     allowAnonymousPosts: data.allow_anonymous,
     allowAnonymousPostsPeers: data.allow_anonymous_to_peers,
+    reportedContentEmailNotifications: data.reported_content_email_notifications,
     divisionScheme: data.division_scheme,
     alwaysDivideInlineDiscussions: data.always_divide_inline_discussions,
     blackoutDates: normalizeBlackoutDates(data.discussion_blackouts),
@@ -171,6 +172,9 @@ function denormalizeData(courseId, appId, data) {
   }
   if ('allowAnonymousPostsPeers' in data) {
     pluginConfiguration.allow_anonymous_to_peers = data.allowAnonymousPostsPeers;
+  }
+  if ('reportedContentEmailNotifications' in data) {
+    pluginConfiguration.reported_content_email_notifications = data.reportedContentEmailNotifications;
   }
   if ('divideByCohorts' in data) {
     pluginConfiguration.division_scheme = data.divideByCohorts ? DivisionSchemes.COHORT : DivisionSchemes.NONE;

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -62,6 +62,7 @@ function normalizePluginConfig(data) {
     allowAnonymousPosts: data.allow_anonymous,
     allowAnonymousPostsPeers: data.allow_anonymous_to_peers,
     reportedContentEmailNotifications: data.reported_content_email_notifications,
+    enableReportedContentEmailNotifications: data.reported_content_email_notifications_flag,
     divisionScheme: data.division_scheme,
     alwaysDivideInlineDiscussions: data.always_divide_inline_discussions,
     blackoutDates: normalizeBlackoutDates(data.discussion_blackouts),

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -242,6 +242,7 @@ describe('Data layer integration tests', () => {
         id: 'legacy',
         allowAnonymousPosts: false,
         allowAnonymousPostsPeers: false,
+        reportedContentEmailNotifications: false,
         blackoutDates: [],
         // TODO: Note!  As of this writing, all the data below this line is NOT returned in the API
         // but we add it in during normalization.
@@ -400,6 +401,7 @@ describe('Data layer integration tests', () => {
         plugin_configuration: {
           allow_anonymous: true,
           allow_anonymous_to_peers: true,
+          reported_content_email_notifications: true,
           always_divide_inline_discussions: true,
           discussion_blackouts: [],
           division_scheme: DivisionSchemes.COHORT,
@@ -419,6 +421,7 @@ describe('Data layer integration tests', () => {
         plugin_configuration: {
           allow_anonymous: true,
           allow_anonymous_to_peers: true,
+          reported_content_email_notifications: true,
           always_divide_inline_discussions: true,
           discussion_blackouts: [],
           division_scheme: DivisionSchemes.COHORT,
@@ -443,6 +446,7 @@ describe('Data layer integration tests', () => {
         {
           allowAnonymousPosts: true,
           allowAnonymousPostsPeers: true,
+          reportedContentEmailNotifications: true,
           blackoutDates: [],
           // TODO: Note!  As of this writing, all the data below this line is NOT returned in the API
           // but we technically send it to the thunk, so here it is.
@@ -478,6 +482,7 @@ describe('Data layer integration tests', () => {
         // These three fields should be updated.
         allowAnonymousPosts: true,
         allowAnonymousPostsPeers: true,
+        reportedContentEmailNotifications: true,
         alwaysDivideInlineDiscussions: true,
         blackoutDates: [],
         // TODO: Note!  The values we tried to save were ignored, this test reflects what currently

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -243,6 +243,7 @@ describe('Data layer integration tests', () => {
         allowAnonymousPosts: false,
         allowAnonymousPostsPeers: false,
         reportedContentEmailNotifications: false,
+        enableReportedContentEmailNotifications: false,
         blackoutDates: [],
         // TODO: Note!  As of this writing, all the data below this line is NOT returned in the API
         // but we add it in during normalization.

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -90,6 +90,7 @@ export const generateLegacyApiResponse = () => ({
   plugin_configuration: {
     allow_anonymous: false,
     allow_anonymous_to_peers: false,
+    reported_content_email_notifications: false,
     always_divide_inline_discussions: false,
     available_division_schemes: ['enrollment_track'],
     discussion_topics: {

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -91,6 +91,7 @@ export const generateLegacyApiResponse = () => ({
     allow_anonymous: false,
     allow_anonymous_to_peers: false,
     reported_content_email_notifications: false,
+    reported_content_email_notifications_flag: false,
     always_divide_inline_discussions: false,
     available_division_schemes: ['enrollment_track'],
     discussion_topics: {


### PR DESCRIPTION
[TNL-9797](https://openedx.atlassian.net/browse/TNL-9797)

- Add reported email notifications toggle in legacy discussions
- It would be false by default
- Toggle value depends on `reported_email_notifications`
- `reported_email_notifications` is integrated with reported email notification toggle
- Update relevant Test case.

<img width="787" alt="Screenshot 2022-04-05 at 5 25 32 PM" src="https://user-images.githubusercontent.com/79941147/161754885-589cbd18-7c46-4c3b-8e5e-a0834df48a05.png">
<img width="802" alt="Screenshot 2022-04-05 at 5 25 38 PM" src="https://user-images.githubusercontent.com/79941147/161754906-c2dca95e-b69a-46c5-8eeb-f54d6afd13da.png">
