### PR TITLE
feat: removed the support of allow anonymous to all from discussion configs

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -35,7 +35,6 @@ function OpenedXConfigForm({
     enableInContext,
     enableGradedUnits,
     unitLevelVisibility,
-    allowAnonymousPosts: appConfigObj?.allowAnonymousPosts || false,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
     reportedContentEmailNotifications: appConfigObj?.reportedContentEmailNotifications || false,
     enableReportedContentEmailNotifications: appConfigObj?.enableReportedContentEmailNotifications || false,

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -157,11 +157,10 @@ describe('OpenedXConfigForm', () => {
     ).not.toBeInTheDocument());
 
     // AnonymousPostingFields
-    expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
-    expect(container.querySelector('#allowAnonymousPosts')).not.toBeChecked();
     expect(
       container.querySelector('#allowAnonymousPostsPeers'),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
+    expect(container.querySelector('#allowAnonymousPostsPeers')).not.toBeChecked();
 
     // ReportedContentEmailNotifications
     expect(container.querySelector('#reportedContentEmailNotifications')).toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -200,8 +200,6 @@ describe('OpenedXConfigForm', () => {
     ).not.toBeInTheDocument());
 
     // AnonymousPostingFields
-    expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
-    expect(container.querySelector('#allowAnonymousPosts')).toBeChecked();
     expect(
       container.querySelector('#allowAnonymousPostsPeers'),
     ).toBeInTheDocument();

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { TransitionReplace } from '@edx/paragon';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from '../../messages';
 import AppConfigFormDivider from './AppConfigFormDivider';
@@ -15,30 +14,15 @@ function AnonymousPostingFields({
   return (
     <>
       <h5 className="mt-4 text-gray-500">{intl.formatMessage(messages.anonymousPosting)}</h5>
+      <AppConfigFormDivider />
       <FormSwitchGroup
         onChange={onChange}
         onBlur={onBlur}
-        id="allowAnonymousPosts"
-        checked={values.allowAnonymousPosts}
-        label={intl.formatMessage(messages.allowAnonymousPostsLabel)}
-        helpText={intl.formatMessage(messages.allowAnonymousPostsHelp)}
+        id="allowAnonymousPostsPeers"
+        checked={values.allowAnonymousPostsPeers}
+        label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
+        helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
       />
-      <TransitionReplace>
-        {values.allowAnonymousPosts ? (
-          <React.Fragment key="open">
-            <AppConfigFormDivider />
-            <FormSwitchGroup
-              onChange={onChange}
-              onBlur={onBlur}
-              className="ml-4"
-              id="allowAnonymousPostsPeers"
-              checked={values.allowAnonymousPostsPeers}
-              label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
-              helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
-            />
-          </React.Fragment>
-        ) : <React.Fragment key="closed" />}
-      </TransitionReplace>
     </>
   );
 }
@@ -48,7 +32,6 @@ AnonymousPostingFields.propTypes = {
   onChange: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   values: PropTypes.shape({
-    allowAnonymousPosts: PropTypes.bool,
     allowAnonymousPostsPeers: PropTypes.bool,
   }).isRequired,
 };


### PR DESCRIPTION
TNL TIcket : [9469](https://openedx.atlassian.net/browse/TNL-9469)

This PR is a part of the change mentioned in the above ticket, more related PRs in different repos are linked.

Discussion MFE PR: https://github.com/openedx/frontend-app-discussions/pull/118
https://github.com/openedx/edx-platform/pull/30189

updated screen after removing allow anonymous post for all.
<img width="708" alt="Screenshot 2022-04-06 at 1 06 12 AM" src="https://user-images.githubusercontent.com/67791278/161840091-066672ae-0f11-4062-af48-c7395b70273f.png">

## Testing instructions

checkout in all the three mentioned branches in different repos

- configure discussion provider will no longer show toggle-switch to post anonymously
- add post both using new MFE and legacy experience post anonymously options is removed
- for courses already configured to allow post anonymous feature still won't show the option to post anonymously

