### PR TITLE
fix: update the PII sharing message for live configuration

### DIFF
--- a/src/pages-and-resources/live/Settings.jsx
+++ b/src/pages-and-resources/live/Settings.jsx
@@ -74,7 +74,9 @@ function LiveSettings({
                 </SelectableBox>
               ))}
             </SelectableBox.Set>
-            <p data-testid="helper-text">{intl.formatMessage(messages.providerHelperText, { providerName: 'Zoom' })}</p>
+            <p data-testid="helper-text">
+              {intl.formatMessage(messages.providerHelperText, { providerName: values.provider })}
+            </p>
             {values.piiSharingEnable ? (
               <>
                 <p className="pb-2">{intl.formatMessage(messages.formInstructions)}</p>
@@ -107,7 +109,9 @@ function LiveSettings({
                 />
               </>
             ) : (
-              <p data-testid="request-pii-sharing">{intl.formatMessage(messages.requestPiiSharingEnable)}</p>
+              <p data-testid="request-pii-sharing">
+                {intl.formatMessage(messages.requestPiiSharingEnable, { provider: values.provider })}
+              </p>
             )}
           </>
         )

--- a/src/pages-and-resources/live/Settings.test.jsx
+++ b/src/pages-and-resources/live/Settings.test.jsx
@@ -89,7 +89,7 @@ describe('LiveSettings', () => {
     expect(label).toHaveTextContent(messages.enableLiveLabel.defaultMessage);
     expect(label.firstChild).toHaveTextContent('Enabled');
     expect(helperText).toHaveTextContent(
-      messages.providerHelperText.defaultMessage.replace('{providerName}', 'Zoom'),
+      messages.providerHelperText.defaultMessage.replace('{providerName}', 'zoom'),
     );
   });
 
@@ -108,7 +108,7 @@ describe('LiveSettings', () => {
     expect(label).toHaveTextContent('Live');
     expect(label.firstChild).not.toHaveTextContent('Enabled');
     expect(helperText).toHaveTextContent(
-      messages.providerHelperText.defaultMessage.replace('{providerName}', 'Zoom'),
+      messages.providerHelperText.defaultMessage.replace('{providerName}', 'zoom'),
     );
   });
 
@@ -127,7 +127,7 @@ describe('LiveSettings', () => {
     expect(providers.childElementCount).toBe(1);
     expect(providers).toHaveTextContent('Zoom');
     expect(helperText).toHaveTextContent(
-      messages.providerHelperText.defaultMessage.replace('{providerName}', 'Zoom'),
+      messages.providerHelperText.defaultMessage.replace('{providerName}', 'zoom'),
     );
   });
 
@@ -170,7 +170,9 @@ describe('LiveSettings', () => {
     const launchUrl = container.querySelector('input[name="launchUrl"]');
     const launchEmail = container.querySelector('input[name="launchEmail"]');
 
-    expect(requestPiiText).toHaveTextContent(messages.requestPiiSharingEnable.defaultMessage);
+    expect(requestPiiText).toHaveTextContent(
+      messages.requestPiiSharingEnable.defaultMessage.replaceAll('{provider}', 'zoom'),
+    );
     expect(consumerKey).not.toBeInTheDocument();
     expect(consumerSecret).not.toBeInTheDocument();
     expect(launchUrl).not.toBeInTheDocument();

--- a/src/pages-and-resources/live/messages.js
+++ b/src/pages-and-resources/live/messages.js
@@ -93,8 +93,8 @@ const messages = defineMessages({
   },
   requestPiiSharingEnable: {
     id: 'authoring.live.requestPiiSharingEnable',
-    defaultMessage: 'Request your edX support team to enable the PII sharing for this course, in order to access the LTI configurations for a provider',
-    description: 'Tells the user that request edx support team to enable the PII sharing to access the LTO configuration for a provider.',
+    defaultMessage: 'This configuration will require sharing usernames and emails of learners and the course team with {provider}. To access the LTI configuration for {provider}, please request your edX project coordinator to get PII sharing enabled for this course.',
+    description: 'Tells the user that request edx project coordinator to enable the PII sharing to access the LTI configuration for a provider.',
   },
   general: {
     id: 'authoring.live.appDocInstructions.documentationLink',


### PR DESCRIPTION
[INF-145](https://openedx.atlassian.net/browse/INF-145)

- Update the PII sharing message to `This configuration will require sharing usernames and emails of learners and the course team with {provider}. To access the LTI configuration for {provider}, please request your edX project coordinator to get PII sharing enabled for this course.`

<img width="851" alt="Screenshot 2022-04-19 at 1 58 53 AM" src="https://user-images.githubusercontent.com/79941147/163890159-697b1513-daab-400b-b804-385fdc33b352.png">
<img width="857" alt="Screenshot 2022-04-19 at 1 59 18 AM" src="https://user-images.githubusercontent.com/79941147/163890167-1c738a80-67e2-4ddb-bc78-1c08a6d4edca.png">
