### PR TITLE
fix: remove PII sharing flag from live configuration

### DIFF
--- a/src/pages-and-resources/live/Settings.jsx
+++ b/src/pages-and-resources/live/Settings.jsx
@@ -74,45 +74,39 @@ function LiveSettings({
                 </SelectableBox>
               ))}
             </SelectableBox.Set>
-            {values.piiSharingEnable ? (
-              <>
-                <p data-testid="helper-text">
-                  {intl.formatMessage(messages.providerHelperText, { providerName: values.provider })}
-                </p>
-                <p className="pb-2">{intl.formatMessage(messages.formInstructions)}</p>
-                <FormikControl
-                  name="consumerKey"
-                  value={values.consumerKey}
-                  floatingLabel={intl.formatMessage(messages.consumerKey)}
-                  className="pb-1"
-                  type="input"
-                />
-                <FormikControl
-                  name="consumerSecret"
-                  value={values.consumerSecret}
-                  floatingLabel={intl.formatMessage(messages.consumerSecret)}
-                  className="pb-1"
-                  type="input"
-                />
-                <FormikControl
-                  name="launchUrl"
-                  value={values.launchUrl}
-                  floatingLabel={intl.formatMessage(messages.launchUrl)}
-                  className="pb-1"
-                  type="input"
-                />
-                <FormikControl
-                  name="launchEmail"
-                  value={values.launchEmail}
-                  floatingLabel={intl.formatMessage(messages.launchEmail)}
-                  type="input"
-                />
-              </>
-            ) : (
-              <p data-testid="request-pii-sharing">
-                {intl.formatMessage(messages.requestPiiSharingEnable, { provider: values.provider })}
+            <>
+              <p data-testid="helper-text">
+                {intl.formatMessage(messages.providerHelperText, { providerName: values.provider })}
               </p>
-            )}
+              <p className="pb-2">{intl.formatMessage(messages.formInstructions)}</p>
+              <FormikControl
+                name="consumerKey"
+                value={values.consumerKey}
+                floatingLabel={intl.formatMessage(messages.consumerKey)}
+                className="pb-1"
+                type="input"
+              />
+              <FormikControl
+                name="consumerSecret"
+                value={values.consumerSecret}
+                floatingLabel={intl.formatMessage(messages.consumerSecret)}
+                className="pb-1"
+                type="input"
+              />
+              <FormikControl
+                name="launchUrl"
+                value={values.launchUrl}
+                floatingLabel={intl.formatMessage(messages.launchUrl)}
+                className="pb-1"
+                type="input"
+              />
+              <FormikControl
+                name="launchEmail"
+                value={values.launchEmail}
+                floatingLabel={intl.formatMessage(messages.launchEmail)}
+                type="input"
+              />
+            </>
           </>
         )
       }

--- a/src/pages-and-resources/live/Settings.test.jsx
+++ b/src/pages-and-resources/live/Settings.test.jsx
@@ -97,7 +97,7 @@ describe('LiveSettings', () => {
     const fetchProviderConfigUrl = `${providerConfigurationApiUrl}/${courseId}/`;
     axiosMock.onGet(fetchProviderConfigUrl).reply(
       200,
-      generateLiveConfigurationApiResponse(false, false),
+      generateLiveConfigurationApiResponse(false),
     );
     await executeThunk(fetchLiveConfiguration(courseId), store.dispatch);
     renderComponent();
@@ -114,7 +114,7 @@ describe('LiveSettings', () => {
     const fetchProviderConfigUrl = `${providerConfigurationApiUrl}/${courseId}/`;
     axiosMock.onGet(fetchProviderConfigUrl).reply(
       200,
-      generateLiveConfigurationApiResponse(false, true),
+      generateLiveConfigurationApiResponse(false),
     );
     await executeThunk(fetchLiveConfiguration(courseId), store.dispatch);
     renderComponent();
@@ -129,7 +129,7 @@ describe('LiveSettings', () => {
     );
   });
 
-  test('Only helper text and lti fields are visible when pii sharing is enabled', async () => {
+  test('Displays helper text and lti fields for selected provider', async () => {
     const fetchProviderConfigUrl = `${providerConfigurationApiUrl}/${courseId}/`;
     axiosMock.onGet(fetchProviderConfigUrl).reply(
       200,
@@ -151,30 +151,6 @@ describe('LiveSettings', () => {
     expect(launchUrl.lastChild).toHaveTextContent(messages.launchUrl.defaultMessage);
     expect(launchEmail.firstChild).toBeVisible();
     expect(launchEmail.lastChild).toHaveTextContent(messages.launchEmail.defaultMessage);
-  });
-
-  test('Only connect to support is visible when pii sharing is disabled', async () => {
-    const fetchProviderConfigUrl = `${providerConfigurationApiUrl}/${courseId}/`;
-    axiosMock.onGet(fetchProviderConfigUrl).reply(
-      200,
-      generateLiveConfigurationApiResponse(false, false),
-    );
-    await executeThunk(fetchLiveConfiguration(courseId), store.dispatch);
-    renderComponent();
-
-    const requestPiiText = queryByTestId(container, 'request-pii-sharing');
-    const consumerKey = container.querySelector('input[name="consumerKey"]');
-    const consumerSecret = container.querySelector('input[name="consumerSecret"]');
-    const launchUrl = container.querySelector('input[name="launchUrl"]');
-    const launchEmail = container.querySelector('input[name="launchEmail"]');
-
-    expect(requestPiiText).toHaveTextContent(
-      messages.requestPiiSharingEnable.defaultMessage.replaceAll('{provider}', 'zoom'),
-    );
-    expect(consumerKey).not.toBeInTheDocument();
-    expect(consumerSecret).not.toBeInTheDocument();
-    expect(launchUrl).not.toBeInTheDocument();
-    expect(launchEmail).not.toBeInTheDocument();
   });
 
   test('Form should be submitted and closed when valid data is provided', async () => {

--- a/src/pages-and-resources/live/data/thunks.js
+++ b/src/pages-and-resources/live/data/thunks.js
@@ -15,7 +15,6 @@ function normalizeLiveConfig(config) {
   configuration.launchUrl = config?.ltiConfiguration?.lti1P1LaunchUrl || '';
   configuration.launchEmail = config?.ltiConfiguration?.ltiConfig?.additionalParameters?.customInstructorEmail || '';
   configuration.provider = config?.providerType || 'zoom';
-  configuration.piiSharingEnable = config?.piiSharingAllowed || false;
   return configuration;
 }
 
@@ -35,7 +34,6 @@ function deNormalizeLiveConfig(config) {
       },
     },
   };
-  configuration.pii_sharing_allowed = config?.piiSharingEnable || false;
   return configuration;
 }
 

--- a/src/pages-and-resources/live/factories/mockApiResponses.jsx
+++ b/src/pages-and-resources/live/factories/mockApiResponses.jsx
@@ -56,7 +56,6 @@ export const initialState = {
       launchUrl: '',
       launchEmail: '',
       provider: 'zoom',
-      piiSharingEnable: true,
     },
     saveStatus: 'successful',
     configuredProvider: 'zoom',
@@ -65,7 +64,6 @@ export const initialState = {
 
 export const generateLiveConfigurationApiResponse = (
   enabled = true,
-  piiSharingAllowed = true,
 ) => ({
   course_key: courseId,
   provider_type: 'zoom',
@@ -81,5 +79,4 @@ export const generateLiveConfigurationApiResponse = (
       },
     },
   },
-  pii_sharing_allowed: piiSharingAllowed,
 });

--- a/src/pages-and-resources/live/messages.js
+++ b/src/pages-and-resources/live/messages.js
@@ -91,11 +91,6 @@ const messages = defineMessages({
     defaultMessage: 'This configuration will require sharing username and emails of learners and the course team with {providerName}.',
     description: 'Tells the user that sharing username and email is required for configuration',
   },
-  requestPiiSharingEnable: {
-    id: 'authoring.live.requestPiiSharingEnable',
-    defaultMessage: 'This configuration will require sharing usernames and emails of learners and the course team with {provider}. To access the LTI configuration for {provider}, please request your edX project coordinator to get PII sharing enabled for this course.',
-    description: 'Tells the user that request edx project coordinator to enable the PII sharing to access the LTI configuration for a provider.',
-  },
   general: {
     id: 'authoring.live.appDocInstructions.documentationLink',
     defaultMessage: 'General documentation',


### PR DESCRIPTION
### [INF-150](https://openedx.atlassian.net/browse/INF-150)

- Remove PII sharing enable message from live configuration
- Remove the respective test case 
- Live provider configuration field will be visible for the selected provider without enabling the PII sharing flag

<img width="915" alt="Screenshot 2022-04-25 at 11 45 07 PM" src="https://user-images.githubusercontent.com/79941147/165154497-5443eea6-a6db-4773-9a3c-c9cd7cee0d84.png">
