### PR TITLE
fix: requestSubmit() is not a function in safari

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
@@ -15,7 +15,7 @@ function AppConfigFormSaveButton({ intl, labelText }) {
   const { selectedAppId } = useSelector((state) => state.discussions);
 
   const app = useModel('apps', selectedAppId);
-  const canSubmit = getAuthenticatedUser().administrator || !app.adminOnlyConfig;
+  const canSubmit = getAuthenticatedUser().administrator || !app?.adminOnlyConfig;
 
   const { formRef } = useContext(AppConfigFormContext);
 
@@ -23,7 +23,12 @@ function AppConfigFormSaveButton({ intl, labelText }) {
 
   // This causes the form to be submitted from a button outside the form.
   const handleSave = useCallback(() => {
-    formRef.current.requestSubmit();
+    // https://developer.mozilla.org/en-US/docs/Web/API/Event/Event
+    // cancelable: (optional) a Boolean indicating whether the event can be canceled. The default is false.
+    // cancelable: true cancels the untrusted event and safari, chrome cancel the untrusted event by default
+    formRef.current.dispatchEvent(new Event('submit', {
+      cancelable: true,
+    }));
   }, [formRef]);
 
   return (


### PR DESCRIPTION
### [INF-187](https://2u-internal.atlassian.net/browse/INF-187)
- requestSubmit() is not supported in safari. requestSubmit() alternative is form.submit(). submit() does not dispatch submit event and run the validation as compare to requestSubmit(). To resolve this issue, I dispatch the submit event manually.

- [requestSubmit offers a way to validate a form before submit](https://www.stefanjudis.com/today-i-learned/requestsubmit-offers-a-way-to-validate-a-form-before-submitting-it/) 
- [submit() on form element doesn't trigger onSubmit · Issue #6796 · facebook/react](https://github.com/facebook/react/issues/6796) 
- [FIrefox doesn't preventing dispatched submit event](https://stackoverflow.com/questions/49587933/firefox-doesnt-preventing-dispatched-submit-event)

### Safari
<img width="1440" alt="Screenshot 2022-05-12 at 10 35 56 PM" src="https://user-images.githubusercontent.com/79941147/168135814-cbc776c0-4c57-41a0-9f17-9ef084900ca7.png">

### Firefox
<img width="1440" alt="Screenshot 2022-05-12 at 10 36 12 PM" src="https://user-images.githubusercontent.com/79941147/168135922-571d3aca-e94e-4fb9-abff-8ae67f0511ae.png">

### Chrome
<img width="1439" alt="Screenshot 2022-05-12 at 10 36 27 PM" src="https://user-images.githubusercontent.com/79941147/168136107-91f1a963-81fe-4df3-b72f-a5c6b73bf66d.png">
