### PR TITLE
Simplify in-context discussion toggles [BD-38]

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -25,14 +25,14 @@ function OpenedXConfigForm({
   onSubmit, formRef, intl, legacy,
 }) {
   const {
-    selectedAppId, enableInContext, enableGradedUnits, discussionTopicIds, divideDiscussionIds,
+    selectedAppId, enableGradedUnits, discussionTopicIds, divideDiscussionIds,
   } = useSelector(state => state.discussions);
   const appConfigObj = useModel('appConfigs', selectedAppId);
   const discussionTopicsModel = useModels('discussionTopics', discussionTopicIds);
   const legacyAppConfig = {
     ...(appConfigObj || {}),
     divideDiscussionIds,
-    enableInContext,
+    enableInContext: true,
     enableGradedUnits,
     unitLevelVisibility: true,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
@@ -48,7 +48,6 @@ function OpenedXConfigForm({
   const [validDiscussionTopics, setValidDiscussionTopics] = useState(discussionTopicsModel);
   // These fields are only used for the new provider and aren't supported for legacy.
   const additionalFields = legacy ? {} : {
-    enableInContext: Yup.bool().default(true),
     enabledGradedUnits: Yup.bool().default(false),
     groupAtSubsection: Yup.bool().default(false),
   };

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -25,7 +25,7 @@ function OpenedXConfigForm({
   onSubmit, formRef, intl, legacy,
 }) {
   const {
-    selectedAppId, enableInContext, enableGradedUnits, unitLevelVisibility, discussionTopicIds, divideDiscussionIds,
+    selectedAppId, enableInContext, enableGradedUnits, discussionTopicIds, divideDiscussionIds,
   } = useSelector(state => state.discussions);
   const appConfigObj = useModel('appConfigs', selectedAppId);
   const discussionTopicsModel = useModels('discussionTopics', discussionTopicIds);
@@ -34,7 +34,7 @@ function OpenedXConfigForm({
     divideDiscussionIds,
     enableInContext,
     enableGradedUnits,
-    unitLevelVisibility,
+    unitLevelVisibility: true,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
     reportedContentEmailNotifications: appConfigObj?.reportedContentEmailNotifications || false,
     enableReportedContentEmailNotifications: appConfigObj?.enableReportedContentEmailNotifications || false,
@@ -51,7 +51,6 @@ function OpenedXConfigForm({
     enableInContext: Yup.bool().default(true),
     enabledGradedUnits: Yup.bool().default(false),
     groupAtSubsection: Yup.bool().default(false),
-    unitLevelVisibility: Yup.bool().default(false),
   };
   const validationSchema = Yup.object().shape({
     blackoutDates: Yup.array(

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -41,7 +41,7 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
   ],
   divideDiscussionIds,
   enableGradedUnits: undefined,
-  enableInContext: undefined,
+  enableInContext: true,
   groupAtSubsection: false,
   unitLevelVisibility: true,
   allowAnonymousPosts: false,

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -43,7 +43,7 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
   enableGradedUnits: undefined,
   enableInContext: undefined,
   groupAtSubsection: false,
-  unitLevelVisibility: undefined,
+  unitLevelVisibility: true,
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   reportedContentEmailNotifications: false,
@@ -109,7 +109,6 @@ describe('OpenedXConfigForm', () => {
     expect(queryByText(container, messages.visibilityInContext.defaultMessage)).toBeInTheDocument();
     expect(queryByText(container, messages.gradedUnitPagesLabel.defaultMessage)).toBeInTheDocument();
     expect(queryByText(container, messages.groupInContextSubsectionLabel.defaultMessage)).toBeInTheDocument();
-    expect(queryByText(container, messages.allowUnitLevelVisibilityLabel.defaultMessage)).toBeInTheDocument();
   });
 
   test('calls onSubmit when the formRef is submitted', async () => {
@@ -139,7 +138,7 @@ describe('OpenedXConfigForm', () => {
     await mockStore({
       ...legacyApiResponse,
       plugin_configuration: {
-         ...legacyApiResponse.plugin_configuration,
+        ...legacyApiResponse.plugin_configuration,
         reported_content_email_notifications_flag: true,
         divided_course_wide_discussions: [],
       },

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
@@ -46,16 +46,6 @@ function InContextDiscussionFields({
               label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
               helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
             />
-            <AppConfigFormDivider />
-            <FormSwitchGroup
-              onChange={onChange}
-              onBlur={onBlur}
-              className="ml-4"
-              id="unitLevelVisibility"
-              checked={values.unitLevelVisibility}
-              label={intl.formatMessage(messages.allowUnitLevelVisibilityLabel)}
-              helpText={intl.formatMessage(messages.allowUnitLevelVisibilityHelp)}
-            />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
 
@@ -72,7 +62,6 @@ InContextDiscussionFields.propTypes = {
     enableInContext: PropTypes.bool,
     enableGradedUnits: PropTypes.bool,
     groupAtSubsection: PropTypes.bool,
-    unitLevelVisibility: PropTypes.bool,
   }).isRequired,
 };
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { TransitionReplace } from '@edx/paragon';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from '../../messages';
 import AppConfigFormDivider from './AppConfigFormDivider';
@@ -18,38 +17,20 @@ function InContextDiscussionFields({
       <FormSwitchGroup
         onChange={onChange}
         onBlur={onBlur}
-        id="enableInContext"
-        checked={values.enableInContext}
-        label={intl.formatMessage(messages.inContextDiscussionLabel)}
-        helpText={intl.formatMessage(messages.inContextDiscussionHelp)}
+        id="enableGradedUnits"
+        checked={values.enableGradedUnits}
+        label={intl.formatMessage(messages.gradedUnitPagesLabel)}
+        helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
       />
-      <TransitionReplace>
-        {values.enableInContext ? (
-          <React.Fragment key="open">
-            <AppConfigFormDivider />
-            <FormSwitchGroup
-              onChange={onChange}
-              onBlur={onBlur}
-              className="ml-4"
-              id="enableGradedUnits"
-              checked={values.enableGradedUnits}
-              label={intl.formatMessage(messages.gradedUnitPagesLabel)}
-              helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
-            />
-            <AppConfigFormDivider />
-            <FormSwitchGroup
-              onChange={onChange}
-              onBlur={onBlur}
-              className="ml-4"
-              id="groupAtSubsection"
-              checked={values.groupAtSubsection}
-              label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
-              helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
-            />
-          </React.Fragment>
-        ) : <React.Fragment key="closed" />}
-
-      </TransitionReplace>
+      <AppConfigFormDivider />
+      <FormSwitchGroup
+        onChange={onChange}
+        onBlur={onBlur}
+        id="groupAtSubsection"
+        checked={values.groupAtSubsection}
+        label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
+        helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
+      />
     </>
   );
 }
@@ -59,7 +40,6 @@ InContextDiscussionFields.propTypes = {
   onChange: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   values: PropTypes.shape({
-    enableInContext: PropTypes.bool,
     enableGradedUnits: PropTypes.bool,
     groupAtSubsection: PropTypes.bool,
   }).isRequired,

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -154,14 +154,6 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.groupInContextSubsection.help',
     defaultMessage: 'Learners will be able to view any post in the sub-section no matter which unit page they are viewing. While this is not recommended, if your course has short learning sequences or low enrollment grouping may increase engagement.',
   },
-  allowUnitLevelVisibilityLabel: {
-    id: 'authoring.discussions.builtIn.allowUnitLevelVisibility.label',
-    defaultMessage: 'Allow visibility configuration for each course unit',
-  },
-  allowUnitLevelVisibilityHelp: {
-    id: 'authoring.discussions.builtIn.allowUnitLevelVisibility.help',
-    defaultMessage: 'With this advanced setting enabled you will be able to override the global visibility setting and turn discussions on or off for each unit from the course outline view..',
-  },
 
   // Anonymous posting fields
   anonymousPosting: {

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -132,7 +132,7 @@ const messages = defineMessages({
   },
   gradedUnitPagesLabel: {
     id: 'authoring.discussions.builtIn.gradedUnitPages.label',
-    defaultMessage: 'Graded unit pages',
+    defaultMessage: 'Enable discussions on units in graded subsections',
   },
   gradedUnitPagesHelp: {
     id: 'authoring.discussions.builtIn.gradedUnitPages.help',

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -130,14 +130,6 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.visibilityInContext',
     defaultMessage: 'Visibility of in-context discussions',
   },
-  inContextDiscussionLabel: {
-    id: 'authoring.discussions.builtIn.inContextDiscussion.label',
-    defaultMessage: 'In-context discussion',
-  },
-  inContextDiscussionHelp: {
-    id: 'authoring.discussions.builtIn.inContextDiscussion.help',
-    defaultMessage: 'Learners will be able to view or hide a discussion side panel to engage with discussion on the course unit page.',
-  },
   gradedUnitPagesLabel: {
     id: 'authoring.discussions.builtIn.gradedUnitPages.label',
     defaultMessage: 'Graded unit pages',


### PR DESCRIPTION
## Description

Implements the following changes:

1. Following toggles will be removed:
    * Allow visibility configuration for each course unit
    * In-context discussion
2. Following toggles will be renamed:
    * "Graded unit pages" will be renamed to "Enable discussions on units in graded subsection"

## Testing instructions

1. The test setup uses the demo course setup in devstack and the app running in `localhost:2001`
2. Change the Discussion `provider` value to `openedx` in http://localhost:18000/admin/discussions/discussionsconfiguration/ for the demo course
3. Go to http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources/discussion/configure/openedx
4. Check the changes are implemented as expected.


