### PR TITLE
fix: changed client secret input type to password

### DIFF
--- a/src/pages-and-resources/live/LiveCommonFields.jsx
+++ b/src/pages-and-resources/live/LiveCommonFields.jsx
@@ -23,7 +23,7 @@ function LiveCommonFields({
         value={values.consumerSecret}
         floatingLabel={intl.formatMessage(messages.consumerSecret)}
         className="pb-1"
-        type="input"
+        type="password"
       />
       <FormikControl
         name="launchUrl"

--- a/src/pages-and-resources/live/Settings.jsx
+++ b/src/pages-and-resources/live/Settings.jsx
@@ -51,7 +51,7 @@ function LiveSettings({
     }),
     consumerSecret: Yup.string().when(['provider', 'tierType'], {
       is: (provider, tier) => provider === 'zoom' || (provider === 'big_blue_button' && tier === bbbPlanTypes.commercial),
-      then: Yup.string().required(intl.formatMessage(messages.consumerSecretRequired)),
+      then: Yup.string().notRequired(intl.formatMessage(messages.consumerSecretRequired)),
     }),
     launchUrl: Yup.string().when(['provider', 'tierType'], {
       is: (provider, tier) => provider === 'zoom' || (provider === 'big_blue_button' && tier === bbbPlanTypes.commercial),


### PR DESCRIPTION
## Description 
course live API was returning the password in plain text, now as requirements change it is modified to return `****` instead of a password. `****` is returned with the same length as the original password so the user can have some idea while copy-pasting.

## Ticket
https://2u-internal.atlassian.net/browse/INF-527

## Testing instructions
In course authoring app go to live settings and observe that password is not visible and API is not returning plain text client secret.