### PR TITLE
fix: handle null blackout dates

### DIFF
--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -32,7 +32,7 @@ function normalizeLtiConfig(data) {
 }
 
 export function normalizeBlackoutDates(data) {
-  if (!data.length) {
+  if (!data || Object.keys(data).length < 1) {
     return [];
   }
 


### PR DESCRIPTION
### [INF-555](https://2u-internal.atlassian.net/browse/INF-555)


### Description

We had a course report that the Discussion Provider selection page was failing to load with `Technical Error` banner. It was because the backend API was returning `null` in blackout dates. 
This PR address this issue.