### PR TITLE
Fix [RTL]: mirror legacy page card arrow

### DIFF
--- a/src/pages-and-resources/pages/PageCard.scss
+++ b/src/pages-and-resources/pages/PageCard.scss
@@ -12,3 +12,11 @@
   -webkit-box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3) !important;
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.3) !important;
 }
+
+[dir=rtl] {
+  .desktop-card, .mobile-card {
+    .pgn__card-header-actions .pgn__hyperlink .btn-icon {
+      transform: scaleX(-1)
+    }
+  }
+}


### PR DESCRIPTION
**TL;DR -** fixes a forward arrow in **pages & resources > page card** that wasn't mirrored for RTL.

**Details**
- the mirroring is done within the PageCard.scss file where a `transform: scaleX(-1)` CSS property is used on an RTL selector. It's much cleaner and lighter than editing JS code.

**Screenshots**
The forward arrow button should follow text direction

| LTR for reference | RTL before fix | RTL after fix |
| ---- | ---- | ---- |
| ![image](https://user-images.githubusercontent.com/10594967/194274080-34b0555c-e35d-4f77-a94b-f5dd181cb39d.png) | ![Screenshot from 2022-10-06 10-10-58](https://user-images.githubusercontent.com/10594967/194274171-50138bca-ea3e-4497-b6ed-63f3bd91f0b8.png) | ![Screenshot from 2022-10-06 10-10-23](https://user-images.githubusercontent.com/10594967/194275383-8a66aac2-ec8d-4820-bb8b-e12c708195ee.png) |
