### PR TITLE
fix: update helper text for bigBlueButton free plan

### DIFF
--- a/src/pages-and-resources/live/BBBSettings.jsx
+++ b/src/pages-and-resources/live/BBBSettings.jsx
@@ -88,11 +88,19 @@ function BbbSettings({
         ) : (
           <>
             {bbbPlan === bbbPlanTypes.commercial && <LiveCommonFields values={values} />}
-            {bbbPlan === bbbPlanTypes.free
-              && (
-              <p data-testid="free-plan-message">
+            {bbbPlan === bbbPlanTypes.free && (
+              <span data-testid="free-plan-message">
                 {intl.formatMessage(messages.freePlanMessage)}
-              </p>
+                <Hyperlink
+                  destination="https://bigbluebutton.org/privacy-policy/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  showLaunchIcon
+                  className="text-gray-700 ml-1"
+                >
+                  {intl.formatMessage(messages.privacyPolicy)}
+                </Hyperlink>
+              </span>
             )}
           </>
         )}

--- a/src/pages-and-resources/live/messages.js
+++ b/src/pages-and-resources/live/messages.js
@@ -165,7 +165,7 @@ const messages = defineMessages({
   },
   privacyPolicy: {
     id: 'authoring.live.privacyPolicy',
-    defaultMessage: 'Privacy Policy',
+    defaultMessage: 'Privacy Policy.',
     description: 'The text of privacy policy hyperlink for free plan',
   },
 });

--- a/src/pages-and-resources/live/messages.js
+++ b/src/pages-and-resources/live/messages.js
@@ -160,8 +160,13 @@ const messages = defineMessages({
 
   freePlanMessage: {
     id: 'authoring.live.freePlanMessage',
-    defaultMessage: 'The free plan is pre-configured, and no additional configurations are required.',
+    defaultMessage: 'The free plan is pre-configured, and no additional configurations are required. By selecting the free plan, you are agreeing to Blindside Networks',
     description: 'Tells user that free plans requires no additional configurations',
+  },
+  privacyPolicy: {
+    id: 'authoring.live.privacyPolicy',
+    defaultMessage: 'Privacy Policy',
+    description: 'The text of privacy policy hyperlink for free plan',
   },
 });
 


### PR DESCRIPTION
### [INF-593](https://2u-internal.atlassian.net/browse/INF-593)

- Update the helper text for the big blue button free plan to
`The free plan is pre-configured, and no additional configurations are required. By selecting the free plan, you are agreeing to Blindside Networks` [privacy policy](https://bigbluebutton.org/privacy-policy/).

### Before fix
<img width="858" alt="Screenshot 2022-10-26 at 8 33 04 PM" src="https://user-images.githubusercontent.com/79941147/198071538-7ec727ae-7119-42aa-a182-ce25144ef4d0.png">

### After fix
<img width="857" alt="Screenshot 2022-10-26 at 8 39 45 PM" src="https://user-images.githubusercontent.com/79941147/198071761-1d17dc2f-1118-4c05-a3e1-a8839b32d1e7.png">
