### PR TITLE
Style: Toggle remains Disabled and Link to instructor dashboard show on Disabled Cohorts

### DIFF
--- a/src/generic/FormSwitchGroup.jsx
+++ b/src/generic/FormSwitchGroup.jsx
@@ -13,6 +13,7 @@ export default function FormSwitchGroup({
   onChange,
   onBlur,
   checked,
+  disabled,
 }) {
   const helpTextId = `${id}HelpText`;
 
@@ -36,6 +37,7 @@ export default function FormSwitchGroup({
             onChange={onChange}
             onBlur={onBlur}
             checked={checked}
+            disabled={disabled}
           />
         </div>
         <Form.Text
@@ -57,6 +59,7 @@ FormSwitchGroup.propTypes = {
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func,
   checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 FormSwitchGroup.defaultProps = {
   className: null,

--- a/src/generic/FormSwitchGroup.jsx
+++ b/src/generic/FormSwitchGroup.jsx
@@ -59,10 +59,11 @@ FormSwitchGroup.propTypes = {
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func,
   checked: PropTypes.bool.isRequired,
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
 };
 FormSwitchGroup.defaultProps = {
   className: null,
   onBlur: null,
   name: null,
+  disabled: false,
 };

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
@@ -92,7 +92,6 @@ function AppConfigForm({
       <OpenedXConfigForm
         formRef={formRef}
         onSubmit={handleSubmit}
-        courseId={courseId}
         legacy
       />
     );

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
@@ -92,6 +92,7 @@ function AppConfigForm({
       <OpenedXConfigForm
         formRef={formRef}
         onSubmit={handleSubmit}
+        courseId={courseId}
         legacy
       />
     );

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -22,7 +22,7 @@ import OpenedXConfigFormProvider from './OpenedXConfigFormProvider';
 setupYupExtensions();
 
 function OpenedXConfigForm({
-  onSubmit, formRef, intl, legacy,
+  onSubmit, formRef, courseId, intl, legacy,
 }) {
   const {
     selectedAppId, enableGradedUnits, discussionTopicIds, divideDiscussionIds,
@@ -134,7 +134,7 @@ function OpenedXConfigForm({
                 <AppConfigFormDivider thick />
                 <DiscussionTopics />
                 <AppConfigFormDivider thick />
-                <DivisionByGroupFields />
+                <DivisionByGroupFields courseId={courseId} />
                 <AppConfigFormDivider thick />
                 <ReportedContentEmailNotifications />
                 <BlackoutDatesField />
@@ -150,6 +150,7 @@ function OpenedXConfigForm({
 OpenedXConfigForm.propTypes = {
   legacy: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  courseId: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   formRef: PropTypes.object.isRequired,
   intl: intlShape.isRequired,

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.jsx
@@ -22,7 +22,7 @@ import OpenedXConfigFormProvider from './OpenedXConfigFormProvider';
 setupYupExtensions();
 
 function OpenedXConfigForm({
-  onSubmit, formRef, courseId, intl, legacy,
+  onSubmit, formRef, intl, legacy,
 }) {
   const {
     selectedAppId, enableGradedUnits, discussionTopicIds, divideDiscussionIds,
@@ -37,7 +37,7 @@ function OpenedXConfigForm({
     unitLevelVisibility: true,
     allowAnonymousPostsPeers: appConfigObj?.allowAnonymousPostsPeers || false,
     reportedContentEmailNotifications: appConfigObj?.reportedContentEmailNotifications || false,
-    enableReportedContentEmailNotifications: appConfigObj?.enableReportedContentEmailNotifications || false,
+    enableReportedContentEmailNotifications: Boolean(appConfigObj?.enableReportedContentEmailNotifications) || false,
     blackoutDates: appConfigObj?.blackoutDates || [],
     discussionTopics: discussionTopicsModel || [],
     divideByCohorts: appConfigObj?.divideByCohorts || false,
@@ -134,7 +134,7 @@ function OpenedXConfigForm({
                 <AppConfigFormDivider thick />
                 <DiscussionTopics />
                 <AppConfigFormDivider thick />
-                <DivisionByGroupFields courseId={courseId} />
+                <DivisionByGroupFields />
                 <AppConfigFormDivider thick />
                 <ReportedContentEmailNotifications />
                 <BlackoutDatesField />
@@ -150,7 +150,6 @@ function OpenedXConfigForm({
 OpenedXConfigForm.propTypes = {
   legacy: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  courseId: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   formRef: PropTypes.object.isRequired,
   intl: intlShape.isRequired,

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -82,7 +82,6 @@ describe('OpenedXConfigForm', () => {
             onSubmit={onSubmit}
             formRef={formRef}
             legacy={legacy}
-            courseId={courseId}
           />
         </IntlProvider>
       </AppProvider>,
@@ -143,14 +142,17 @@ describe('OpenedXConfigForm', () => {
         ...legacyApiResponse.plugin_configuration,
         reported_content_email_notifications_flag: true,
         divided_course_wide_discussions: [],
+         available_division_schemes: [],
       },
     });
     createComponent();
     const { divideDiscussionIds } = defaultAppConfig(['13f106c6-6735-4e84-b097-0456cff55960', 'course']);
 
     // DivisionByGroupFields
+
+    expect(container.querySelector('#alert')).toBeInTheDocument();
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
-    expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
+    expect(container.querySelector('#divideByCohorts')).toBeDisabled();
     expect(container.querySelector('#divideCourseTopicsByCohorts')).not.toBeInTheDocument();
 
     divideDiscussionIds.forEach(id => expect(
@@ -181,7 +183,7 @@ describe('OpenedXConfigForm', () => {
         reported_content_email_notifications_flag: true,
         always_divide_inline_discussions: true,
         divided_course_wide_discussions: [],
-        available_division_schemes: [],
+        available_division_schemes: ['cohorts'],
       },
     });
     createComponent();

--- a/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/openedx/OpenedXConfigForm.test.jsx
@@ -50,6 +50,7 @@ const defaultAppConfig = (divideDiscussionIds = []) => ({
   enableReportedContentEmailNotifications: false,
   allowDivisionByUnit: false,
   blackoutDates: [],
+  cohortsEnabled: false,
 });
 describe('OpenedXConfigForm', () => {
   let axiosMock;
@@ -81,6 +82,7 @@ describe('OpenedXConfigForm', () => {
             onSubmit={onSubmit}
             formRef={formRef}
             legacy={legacy}
+            courseId={courseId}
           />
         </IntlProvider>
       </AppProvider>,
@@ -179,6 +181,7 @@ describe('OpenedXConfigForm', () => {
         reported_content_email_notifications_flag: true,
         always_divide_inline_discussions: true,
         divided_course_wide_discussions: [],
+        available_division_schemes: [],
       },
     });
     createComponent();
@@ -186,14 +189,10 @@ describe('OpenedXConfigForm', () => {
 
     // DivisionByGroupFields
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
-    expect(container.querySelector('#divideByCohorts')).toBeChecked();
+    expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
     expect(
       container.querySelector('#divideCourseTopicsByCohorts'),
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('#divideCourseTopicsByCohorts'),
-    ).not.toBeChecked();
-
+    ).not.toBeInTheDocument();
     divideDiscussionIds.forEach(id => expect(
       container.querySelector(`#checkbox-${id}`),
     ).not.toBeInTheDocument());
@@ -229,13 +228,10 @@ describe('OpenedXConfigForm', () => {
 
       // DivisionByGroupFields
       expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
-      expect(container.querySelector('#divideByCohorts')).toBeChecked();
-      expect(container.querySelector('#divideCourseTopicsByCohorts')).toBeInTheDocument();
-      expect(container.querySelector('#divideCourseTopicsByCohorts')).toBeChecked();
-
+      expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
+      expect(container.querySelector('#divideCourseTopicsByCohorts')).not.toBeInTheDocument();
       divideDiscussionIds.forEach(id => {
-        expect(container.querySelector(`#checkbox-${id}`)).toBeInTheDocument();
-        expect(container.querySelector(`#checkbox-${id}`)).toBeChecked();
+        expect(container.querySelector(`#checkbox-${id}`)).not.toBeInTheDocument();
       });
     });
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useContext } from 'react';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Form, TransitionReplace } from '@edx/paragon';
+import PropTypes from 'prop-types';
+import {
+ Form, TransitionReplace, Hyperlink, Alert,
+} from '@edx/paragon';
+import { AppContext } from '@edx/frontend-platform/react';
 import { FieldArray, useFormikContext } from 'formik';
 import _ from 'lodash';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
@@ -8,7 +12,7 @@ import messages from '../../messages';
 import AppConfigFormDivider from './AppConfigFormDivider';
 import { OpenedXConfigFormContext } from '../openedx/OpenedXConfigFormProvider';
 
-const DivisionByGroupFields = ({ intl }) => {
+const DivisionByGroupFields = ({ courseId, intl }) => {
   const { validDiscussionTopics } = useContext(OpenedXConfigFormContext);
   const {
     handleChange,
@@ -21,7 +25,12 @@ const DivisionByGroupFields = ({ intl }) => {
     discussionTopics,
     divideByCohorts,
     divideCourseTopicsByCohorts,
+    cohortsEnabled,
+
   } = appConfig;
+
+  const { config } = useContext(AppContext);
+  const learningCourseURL = `${config.LMS_BASE_URL}/courses/${courseId}/instructor`;
 
   useEffect(() => {
     if (divideByCohorts) {
@@ -56,20 +65,30 @@ const DivisionByGroupFields = ({ intl }) => {
 
   return (
     <>
-      <h5 className="text-gray-500 mb-2 mt-4">
+      <h5 className="text-gray-500 mb-4 mt-4">
         {intl.formatMessage(messages.divisionByGroup)}
       </h5>
+      {!cohortsEnabled
+      && (
+      <Alert className="bg-light-200 font-weight-normal h5">
+        {intl.formatMessage(messages.cohortsEnabled)}
+        <Hyperlink destination={learningCourseURL} target="_blank">
+          {intl.formatMessage(messages.instructorDashboard)}
+        </Hyperlink>
+      </Alert>
+      )}
       <FormSwitchGroup
         onChange={handleChange}
         className="mt-2"
         onBlur={handleBlur}
         id="divideByCohorts"
-        checked={divideByCohorts}
+        checked={cohortsEnabled === false ? cohortsEnabled : divideByCohorts}
         label={intl.formatMessage(messages.divideByCohortsLabel)}
         helpText={intl.formatMessage(messages.divideByCohortsHelp)}
+        disabled={!cohortsEnabled}
       />
       <TransitionReplace>
-        {divideByCohorts ? (
+        {(divideByCohorts && cohortsEnabled) ? (
           <React.Fragment key="open">
             <AppConfigFormDivider />
             <FormSwitchGroup
@@ -124,6 +143,7 @@ const DivisionByGroupFields = ({ intl }) => {
 };
 
 DivisionByGroupFields.propTypes = {
+  courseId: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
 };
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
@@ -1,18 +1,18 @@
 import React, { useEffect, useContext } from 'react';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import PropTypes from 'prop-types';
 import {
  Form, TransitionReplace, Hyperlink, Alert,
 } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { FieldArray, useFormikContext } from 'formik';
 import _ from 'lodash';
+import { useParams } from 'react-router-dom';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from '../../messages';
 import AppConfigFormDivider from './AppConfigFormDivider';
 import { OpenedXConfigFormContext } from '../openedx/OpenedXConfigFormProvider';
 
-const DivisionByGroupFields = ({ courseId, intl }) => {
+const DivisionByGroupFields = ({ intl }) => {
   const { validDiscussionTopics } = useContext(OpenedXConfigFormContext);
   const {
     handleChange,
@@ -26,9 +26,9 @@ const DivisionByGroupFields = ({ courseId, intl }) => {
     divideByCohorts,
     divideCourseTopicsByCohorts,
     cohortsEnabled,
-
   } = appConfig;
 
+  const { courseId } = useParams();
   const { config } = useContext(AppContext);
   const learningCourseURL = `${config.LMS_BASE_URL}/courses/${courseId}/instructor`;
 
@@ -70,7 +70,7 @@ const DivisionByGroupFields = ({ courseId, intl }) => {
       </h5>
       {!cohortsEnabled
       && (
-      <Alert className="bg-light-200 font-weight-normal h5">
+      <Alert className="bg-light-200 font-weight-normal h5" id="alert">
         {intl.formatMessage(messages.cohortsEnabled)}
         <Hyperlink destination={learningCourseURL} target="_blank">
           {intl.formatMessage(messages.instructorDashboard)}
@@ -143,7 +143,6 @@ const DivisionByGroupFields = ({ courseId, intl }) => {
 };
 
 DivisionByGroupFields.propTypes = {
-  courseId: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
 };
 

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -124,7 +124,16 @@ const messages = defineMessages({
     defaultMessage: 'Questions for the TAs',
     description: 'Label for a checkbox allowing a user to divide the Questions for the TAs (TA stands for "teaching assistant") course wide topic by cohorts.',
   },
-
+    cohortsEnabled: {
+    id: 'authoring.discussions.builtIn.cohortsEnabled.label',
+    defaultMessage: 'To adjust these settings, enable cohorts on the ',
+    description: 'Label text informing the user to enable cohort',
+  },
+  instructorDashboard: {
+    id: 'authoring.discussions.builtIn.instructorDashboard.label',
+    defaultMessage: 'instructor dashboard',
+    description: 'Label text for instructor dashboard',
+  },
   // In-context discussion fields
   visibilityInContext: {
     id: 'authoring.discussions.builtIn.visibilityInContext',

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -56,6 +56,7 @@ function normalizePluginConfig(data) {
   if (!data || Object.keys(data).length < 1) {
     return {};
   }
+
   const enableDivideByCohorts = data.always_divide_inline_discussions && data.division_scheme === 'cohort';
   const enableDivideCourseTopicsByCohorts = enableDivideByCohorts && data.divided_course_wide_discussions.length > 0;
   return {
@@ -69,6 +70,7 @@ function normalizePluginConfig(data) {
     allowDivisionByUnit: false,
     divideByCohorts: enableDivideByCohorts,
     divideCourseTopicsByCohorts: enableDivideCourseTopicsByCohorts,
+    cohortsEnabled: data.available_division_schemes.includes('cohort'),
   };
 }
 

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -70,7 +70,7 @@ function normalizePluginConfig(data) {
     allowDivisionByUnit: false,
     divideByCohorts: enableDivideByCohorts,
     divideCourseTopicsByCohorts: enableDivideCourseTopicsByCohorts,
-    cohortsEnabled: data.available_division_schemes.includes('cohort'),
+    cohortsEnabled: data.available_division_schemes?.includes('cohort') || false,
   };
 }
 

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -252,6 +252,7 @@ describe('Data layer integration tests', () => {
         alwaysDivideInlineDiscussions: false,
         allowDivisionByUnit: false,
         divideCourseTopicsByCohorts: false,
+        cohortsEnabled: false,
       });
     });
   });
@@ -455,6 +456,7 @@ describe('Data layer integration tests', () => {
           allowDivisionsByUnit: true,
           alwaysDivideInlineDiscussions: true,
           divideCourseTopicsByCohorts: true,
+          divisionScheme: DivisionSchemes.COHORT,
           divideDiscussionIds,
           discussionTopics: [
             { name: 'Edx', id: '13f106c6-6735-4e84-b097-0456cff55960' },
@@ -463,7 +465,6 @@ describe('Data layer integration tests', () => {
         },
         pagesAndResourcesPath,
       ), store.dispatch);
-
       expect(window.location.pathname).toEqual(pagesAndResourcesPath);
       expect(store.getState().discussions).toEqual(
         expect.objectContaining({
@@ -490,6 +491,7 @@ describe('Data layer integration tests', () => {
         // happens, but NOT what we want to have happen!
         divideByCohorts: true,
         divisionScheme: DivisionSchemes.COHORT,
+        cohortsEnabled: false,
         allowDivisionByUnit: false,
         divideCourseTopicsByCohorts: true,
       });


### PR DESCRIPTION
### [INF-522](https://2u-internal.atlassian.net/browse/INF-522)

Cohorts section works differently based on whether or not cohorts are enabled for the course.

**When Enable Cohorts is unchecked in Instructor Dashboard:**
> Divide discussions by cohorts toggle remains disabled AND set to OFF.
> A link to instructor dashboard is visible

**When Eanble Cohorts is checked:**

> Divide discussions by cohorts remains enabled
> State of Divide discussions by cohorts toggle, the nested Divide course-wide discussions topics toggle and checkboxes for topics should RESTORE to previous state.

**Before Fix:**


![Unknown-3](https://user-images.githubusercontent.com/73840786/198982059-de56c9df-5067-45ac-9cee-62648c349f8c.png)
![Unknown](https://user-images.githubusercontent.com/73840786/198982070-048b7e73-45b1-49af-b9e5-d2505347c847.png)



**After Fix:**



https://user-images.githubusercontent.com/73840786/198981766-e9c28969-6227-41cd-b989-a0328e6e22b9.mp4



