### PR TITLE
fix: show Zoom settings when pii sharing is enabled and make launch email optional

### DIFF
--- a/src/pages-and-resources/live/Settings.jsx
+++ b/src/pages-and-resources/live/Settings.jsx
@@ -57,10 +57,7 @@ function LiveSettings({
       is: (provider, tier) => provider === 'zoom' || (provider === 'big_blue_button' && tier === bbbPlanTypes.commercial),
       then: Yup.string().required(intl.formatMessage(messages.launchUrlRequired)),
     }),
-    launchEmail: Yup.string().when('provider', {
-      is: 'zoom',
-      then: Yup.string().required(intl.formatMessage(messages.launchEmailRequired)),
-    }),
+    launchEmail: Yup.string(),
   };
 
   const handleProviderChange = (providerId, setFieldValue, values) => {

--- a/src/pages-and-resources/live/ZoomSettings.jsx
+++ b/src/pages-and-resources/live/ZoomSettings.jsx
@@ -6,13 +6,13 @@ import { providerNames } from './constants';
 import LiveCommonFields from './LiveCommonFields';
 import FormikControl from '../../generic/FormikControl';
 
-function ZoomsSettings({
+function ZoomSettings({
  intl,
  values,
 }) {
   return (
     <>
-      {(!values.piiSharingEnable && (values.piiSharingEmail || values.piiSharingUsername)) ? (
+      {!values.piiSharingEnable ? (
         <p data-testid="request-pii-sharing">
           {intl.formatMessage(messages.requestPiiSharingEnable, { provider: providerNames[values.provider] })}
         </p>
@@ -37,7 +37,7 @@ function ZoomsSettings({
   );
 }
 
-ZoomsSettings.propTypes = {
+ZoomSettings.propTypes = {
   intl: intlShape.isRequired,
   values: PropTypes.shape({
     consumerKey: PropTypes.string,
@@ -51,4 +51,4 @@ ZoomsSettings.propTypes = {
   }).isRequired,
 };
 
-export default injectIntl(ZoomsSettings);
+export default injectIntl(ZoomSettings);

--- a/src/pages-and-resources/live/ZoomSettings.test.jsx
+++ b/src/pages-and-resources/live/ZoomSettings.test.jsx
@@ -80,8 +80,8 @@ describe('Zoom Settings', () => {
     history.push(liveSettingsUrl);
   });
 
-  test('LTI fields are visible when pii sharing is enabled and email or username sharing required', async () => {
-    await mockStore({ emailSharing: true });
+  test('LTI fields are visible when pii sharing is enabled', async () => {
+    await mockStore({ piiSharingAllowed: true });
     renderComponent();
 
     const spinner = getByRole(container, 'status');
@@ -103,9 +103,9 @@ describe('Zoom Settings', () => {
   });
 
   test(
-    'Only connect to support message is visible when pii sharing is disabled and email or username sharing is required',
+    'Only connect to support message is visible when pii sharing is disabled',
     async () => {
-      await mockStore({ emailSharing: true, piiSharingAllowed: false });
+      await mockStore({ piiSharingAllowed: false });
       renderComponent();
 
       const spinner = getByRole(container, 'status');
@@ -129,7 +129,7 @@ describe('Zoom Settings', () => {
 
   test('Provider Configuration should be displayed correctly', async () => {
     const apiDefaultResponse = generateLiveConfigurationApiResponse(true, true);
-    await mockStore({ emailSharing: false, piiSharingAllowed: false });
+    await mockStore({ piiSharingAllowed: true });
     renderComponent();
 
     const spinner = getByRole(container, 'status');


### PR DESCRIPTION
### [INF-640](https://2u-internal.atlassian.net/browse/INF-640)

### Description

Zoom Live Settings are now moved behind `pii_sharing`. If `pii_sharing` is enabled, only then the Zoom Settings will be available.
`launchEmail` field is also now an optional field for Zoom Live.