### PR TITLE
style: confirmation modal added for in-context discussion toggle

### DIFF
--- a/src/generic/ConfirmationPopup.jsx
+++ b/src/generic/ConfirmationPopup.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card } from '@edx/paragon';
 
-const DeletePopup = ({
+const ConfirmationPopup = ({
   label,
   bodyText,
-  onDelete,
-  deleteLabel,
+  onConfirm,
+  confirmLabel,
   onCancel,
   cancelLabel,
 }) => (
@@ -22,21 +22,21 @@ const DeletePopup = ({
         <Button variant="tertiary" onClick={onCancel}>
           {cancelLabel}
         </Button>
-        <Button variant="outline-brand" className="ml-2" onClick={onDelete}>
-          {deleteLabel}
+        <Button variant="outline-brand" className="ml-2" onClick={onConfirm}>
+          {confirmLabel}
         </Button>
       </Card.Footer>
     </Card.Body>
   </Card>
 );
 
-DeletePopup.propTypes = {
+ConfirmationPopup.propTypes = {
   label: PropTypes.string.isRequired,
   bodyText: PropTypes.string.isRequired,
-  onDelete: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  deleteLabel: PropTypes.string.isRequired,
+  confirmLabel: PropTypes.string.isRequired,
   cancelLabel: PropTypes.string.isRequired,
 };
 
-export default DeletePopup;
+export default ConfirmationPopup;

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
@@ -17,21 +17,17 @@ function InContextDiscussionFields({
     setFieldValue,
   } = useFormikContext();
 
-  const [showDeletePopup, setShowDeletePopup] = useState(false);
+  const [showPopup, setShowPopup] = useState(false);
 
   const handleConfirmation = () => {
     setFieldValue('enableGradedUnits', !values.enableGradedUnits);
-    setShowDeletePopup(false);
-  };
-
-  const handleChange = () => {
-        setShowDeletePopup(true);
+    setShowPopup(false);
   };
 
   return (
     <>
       <h5 className="text-gray-500 mt-4">{intl.formatMessage(messages.visibilityInContext)}</h5>
-      {showDeletePopup
+      {showPopup
         ? (
           <ConfirmationPopup
             label={values.enableGradedUnits
@@ -42,13 +38,13 @@ function InContextDiscussionFields({
               : intl.formatMessage(messages.confirmEnableDiscussions)}
             onConfirm={handleConfirmation}
             confirmLabel={intl.formatMessage(messages.confirm)}
-            onCancel={() => setShowDeletePopup(false)}
+            onCancel={() => setShowPopup(false)}
             cancelLabel={intl.formatMessage(messages.cancelButton)}
           />
           )
         : (
           <FormSwitchGroup
-            onChange={handleChange}
+            onChange={() => setShowPopup(true)}
             onBlur={onBlur}
             id="enableGradedUnits"
             checked={values.enableGradedUnits}

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useFormikContext } from 'formik';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from '../../messages';
 import AppConfigFormDivider from './AppConfigFormDivider';
+import ConfirmationPopup from '../../../../../generic/ConfirmationPopup';
 
 function InContextDiscussionFields({
   onBlur,
@@ -11,17 +13,49 @@ function InContextDiscussionFields({
   intl,
   values,
 }) {
+  const {
+    setFieldValue,
+  } = useFormikContext();
+
+  const [showDeletePopup, setShowDeletePopup] = useState(false);
+
+  const handleConfirmation = () => {
+    setFieldValue('enableGradedUnits', !values.enableGradedUnits);
+    setShowDeletePopup(false);
+  };
+
+  const handleChange = () => {
+        setShowDeletePopup(true);
+  };
+
   return (
     <>
       <h5 className="text-gray-500 mt-4">{intl.formatMessage(messages.visibilityInContext)}</h5>
-      <FormSwitchGroup
-        onChange={onChange}
-        onBlur={onBlur}
-        id="enableGradedUnits"
-        checked={values.enableGradedUnits}
-        label={intl.formatMessage(messages.gradedUnitPagesLabel)}
-        helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
-      />
+      {showDeletePopup
+        ? (
+          <ConfirmationPopup
+            label={values.enableGradedUnits
+              ? intl.formatMessage(messages.cancelEnableDiscussionsLabel)
+              : intl.formatMessage(messages.confirmEnableDiscussionsLabel)}
+            bodyText={values.enableGradedUnits
+              ? intl.formatMessage(messages.cancelEnableDiscussions)
+              : intl.formatMessage(messages.confirmEnableDiscussions)}
+            onConfirm={handleConfirmation}
+            confirmLabel={intl.formatMessage(messages.confirm)}
+            onCancel={() => setShowDeletePopup(false)}
+            cancelLabel={intl.formatMessage(messages.cancelButton)}
+          />
+          )
+        : (
+          <FormSwitchGroup
+            onChange={handleChange}
+            onBlur={onBlur}
+            id="enableGradedUnits"
+            checked={values.enableGradedUnits}
+            label={intl.formatMessage(messages.gradedUnitPagesLabel)}
+            helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
+          />
+          )}
       <AppConfigFormDivider />
       <FormSwitchGroup
         onChange={onChange}

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/blackout-dates/BlackoutDatesItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/blackout-dates/BlackoutDatesItem.jsx
@@ -14,7 +14,7 @@ import {
   badgeVariant,
 } from '../../../../data/constants';
 import CollapsableEditor from '../../../../../../generic/CollapsableEditor';
-import DeletePopup from '../../../../../../generic/DeletePopup';
+import ConfirmationPopup from '../../../../../../generic/ConfirmationPopup';
 import CollapseCardHeading from './CollapseCardHeading';
 
 const BlackoutDatesItem = ({
@@ -51,13 +51,13 @@ const BlackoutDatesItem = ({
 
   if (showDeletePopup) {
     return (
-      <DeletePopup
+      <ConfirmationPopup
         label={blackoutDate.status === constants.ACTIVE
           ? intl.formatMessage(messages.activeBlackoutDatesDeletionLabel)
           : intl.formatMessage(messages.blackoutDatesDeletionLabel)}
         bodyText={intl.formatMessage(deleteHelperText[blackoutDate.status])}
-        onDelete={onDelete}
-        deleteLabel={intl.formatMessage(messages.deleteButton)}
+        onConfirm={onDelete}
+        confirmLabel={intl.formatMessage(messages.deleteButton)}
         onCancel={() => setShowDeletePopup(false)}
         cancelLabel={intl.formatMessage(messages.cancelButton)}
       />

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -28,10 +28,35 @@ const messages = defineMessages({
     defaultMessage: 'Cancel',
     description: 'Button allowing the user to return to discussion provider configurations.',
   },
+  confirm: {
+    id: 'authoring.discussions.confirm',
+    defaultMessage: 'Confirm',
+    description: 'Button allowing the user to confirm Confirmation.',
+  },
   confirmConfigurationChange: {
     id: 'authoring.discussions.confirmConfigurationChange',
     defaultMessage: 'Are you sure you want to change the discussion settings?',
     description: 'Asks the user whether he/she really wants to change settings.',
+  },
+  confirmEnableDiscussionsLabel: {
+    id: 'authoring.discussions.confirmEnableDiscussionsLabel',
+    defaultMessage: 'Enable discussions on units in graded subsections?',
+    description: 'Asks the user whether he/she really wants to enable discussions on units in graded subsections.',
+  },
+  cancelEnableDiscussionsLabel: {
+    id: 'authoring.discussions.confirmEnableDiscussionsLabel',
+    defaultMessage: 'Disable discussions on units in graded subsections?',
+    description: 'Asks the user whether he/she really wants to disable discussions on units in graded subsections.',
+  },
+  confirmEnableDiscussions: {
+    id: 'authoring.discussions.confirmEnableDiscussions',
+    defaultMessage: 'Enabling this toggle will automatically enable discussion on all units in graded subsections, that are not timed exams.',
+    description: 'Asks the user whether he/she really wants to enable discussions on units in graded subsections.',
+  },
+  cancelEnableDiscussions: {
+    id: 'authoring.discussions.confirmEnableDiscussions',
+    defaultMessage: 'Disabling this toggle will automatically disable discussion on all units in graded subsections. Discussion topics containing at least 1 thread will be listed and accessible under “Archived” in Topics tab on the Discussions page.',
+    description: 'Asks the user whether he/she really wants to disable discussions on units in graded subsections.',
   },
   backButton: {
     id: 'authoring.discussions.backButton',

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -44,7 +44,7 @@ const messages = defineMessages({
     description: 'Asks the user whether he/she really wants to enable discussions on units in graded subsections.',
   },
   cancelEnableDiscussionsLabel: {
-    id: 'authoring.discussions.confirmEnableDiscussionsLabel',
+    id: 'authoring.discussions.cancelEnableDiscussionsLabel',
     defaultMessage: 'Disable discussions on units in graded subsections?',
     description: 'Asks the user whether he/she really wants to disable discussions on units in graded subsections.',
   },
@@ -54,7 +54,7 @@ const messages = defineMessages({
     description: 'Asks the user whether he/she really wants to enable discussions on units in graded subsections.',
   },
   cancelEnableDiscussions: {
-    id: 'authoring.discussions.confirmEnableDiscussions',
+    id: 'authoring.discussions.cancelEnableDiscussions',
     defaultMessage: 'Disabling this toggle will automatically disable discussion on all units in graded subsections. Discussion topics containing at least 1 thread will be listed and accessible under “Archived” in Topics tab on the Discussions page.',
     description: 'Asks the user whether he/she really wants to disable discussions on units in graded subsections.',
   },


### PR DESCRIPTION
[INF-671](https://2u-internal.atlassian.net/browse/INF-671)

**Confirmation model for the toggle named Enable discussions on units in graded subsections added.**

- When enabling the toggle, the confirmation modal will say: “Enabling this toggle will automatically enable discussion on all units in graded subsections, that are not timed exams.”

- When disabling the toggle, the confirmation modal will say: “Disabling this toggle will automatically disable discussion on all units in graded subsections. Discussion topics containing at least 1 thread will be listed and accessible under “Archived” in Topics tab on the Discussions page.”

- Confirmation modal has 2 buttons: Cancel and Confirm with their respective functions.

**After adding Modal** 

[22b6e69f-74eb-45fc-95da-d693804e9dec.webm](https://user-images.githubusercontent.com/73840786/205903590-9291c929-c259-4a8b-99c4-c0caa48f5d1e.webm)

