### PR TITLE
docs: improve readme to use devstack, not npm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,17 +154,13 @@ Developing
 Installation and Startup
 ========================
 
-1. Clone the repo:
+1. Clone the repo as a sibling of your devstack folder.:
 
   ``git clone https://github.com/openedx/frontend-app-course-authoring.git``
 
-2. Install npm dependencies:
+2. Start the dev server, from your devstack directory:
 
-  ``cd frontend-app-course-authoring && npm install``
-
-3. Start the dev server:
-
-  ``npm start``
+  ``make dev.up.frontend-app-course-authoring``
 
 The dev server is running at `http://localhost:2001 <http://localhost:2001>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -161,8 +161,8 @@ Installation and Startup
 2. Start the dev server, from your devstack directory:
 
   ``make dev.up.frontend-app-course-authoring``
-
-The dev server is running at `http://localhost:2001 <http://localhost:2001>`_.
+  
+3. Wait a moment for it to build. The dev server will be running at `http://localhost:2001 <http://localhost:2001>`_.
 
 If your devstack includes the default Demo course, you can visit the following URLs to see content:
 


### PR DESCRIPTION
As the working and accepted way to spin up and down this MFE is with devstack's make dev.up command, we can use this instead of running npm install, build and start.