### PR TITLE
fix: Editors should support runtime configuration (Olive backport)

### DIFF
--- a/src/editors/EditorContainer.jsx
+++ b/src/editors/EditorContainer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router';
 import { EditorPage } from '@edx/frontend-lib-content-components';
+import { getConfig } from '@edx/frontend-platform';
 
 const EditorContainer = ({
   courseId,
@@ -13,8 +14,8 @@ const EditorContainer = ({
         courseId={courseId}
         blockType={blockType}
         blockId={blockId}
-        studioEndpointUrl={process.env.STUDIO_BASE_URL}
-        lmsEndpointUrl={process.env.LMS_BASE_URL}
+        studioEndpointUrl={getConfig().STUDIO_BASE_URL}
+        lmsEndpointUrl={getConfig().LMS_BASE_URL}
       />
     </div>
   );


### PR DESCRIPTION
(This is a backport to olive.master of https://github.com/openedx/frontend-app-course-authoring/pull/412.)

Fetching settings directly via `process.env` circumvents the runtime configuration mechanism.  Change the editor page to use `getConfig()` instead.

### To test

This is a NOOP for any deployment that does not make use of runtime configuration, so a simple test consists of trying to edit a text block using the new HTML editor.  If it works, this is good.

The actual feature can be similarly tested with Tutor.  Enable the `new_core_editors.use_new_text_editor` waffle flag, and try creating/editing a text block.  If the editor pops up correctly, this is working.