### PR TITLE
fix: LTI providers should not be shown unless enabled

### DIFF
--- a/src/pages-and-resources/proctoring/Settings.jsx
+++ b/src/pages-and-resources/proctoring/Settings.jsx
@@ -493,14 +493,17 @@ function ProctoringSettings({ intl, onClose }) {
             // This option is not directly selectable.
             const proctoringProvidersStudio = settingsResponse.data.available_proctoring_providers;
             const proctoringProvidersLti = ltiProvidersResponse?.data || [];
-            setAllowLtiProviders(proctoringProvidersStudio.includes('lti_external'));
+            const enableLtiProviders = proctoringProvidersStudio.includes('lti_external');
+            setAllowLtiProviders(enableLtiProviders);
             setLtiProctoringProviders(proctoringProvidersLti);
             // flatten provider objects and coalesce values to just the provider key
-            setAvailableProctoringProviders(
-              proctoringProvidersLti.reduce((result, provider) => [...result, provider.name], []).concat(
-                proctoringProvidersStudio.filter(value => value !== 'lti_external'),
-              ),
-            );
+            let availableProviders = proctoringProvidersStudio.filter(value => value !== 'lti_external');
+            if (enableLtiProviders) {
+              availableProviders = proctoringProvidersLti.reduce(
+                (result, provider) => [...result, provider.name], availableProviders,
+              );
+            }
+            setAvailableProctoringProviders(availableProviders);
 
             let selectedProvider;
             if (proctoredExamSettings.proctoring_provider === 'lti_external') {

--- a/src/pages-and-resources/proctoring/Settings.test.jsx
+++ b/src/pages-and-resources/proctoring/Settings.test.jsx
@@ -486,6 +486,19 @@ describe('ProctoredExamSettings', () => {
       expect(providerOption.hasAttribute('disabled')).toEqual(false);
     });
 
+    it('Does not include lti provider options when lti_external is not available in studio', async () => {
+      const isAdmin = true;
+      setupApp(isAdmin);
+      mockCourseData(mockGetFutureCourseData);
+      await act(async () => render(intlWrapper(<IntlProctoredExamSettings {...defaultProps} />)));
+      await waitFor(() => {
+        screen.getByDisplayValue('mockproc');
+      });
+
+      const providerOption = screen.queryByTestId('test_lti');
+      expect(providerOption).not.toBeInTheDocument();
+    });
+
     it('Does not request lti provider options if there is no exam service url configuration', async () => {
       mergeConfig({
         EXAMS_BASE_URL: null,
@@ -583,7 +596,7 @@ describe('ProctoredExamSettings', () => {
     });
   });
 
-  describe.only('Save settings', () => {
+  describe('Save settings', () => {
     beforeEach(async () => {
       axiosMock.onPost(
         StudioApiService.getProctoredExamSettingsUrl(defaultProps.courseId),

--- a/src/pages-and-resources/proctoring/Settings.test.jsx
+++ b/src/pages-and-resources/proctoring/Settings.test.jsx
@@ -463,8 +463,10 @@ describe('ProctoredExamSettings', () => {
     });
 
    it('Does not include lti_external as a selectable option', async () => {
-      const courseData = mockGetFutureCourseData;
-      courseData.available_proctoring_providers = ['lti_external', 'proctortrack', 'mockproc'];
+      const courseData = {
+        ...mockGetFutureCourseData,
+        available_proctoring_providers: ['lti_external', 'proctortrack', 'mockproc'],
+      };
       mockCourseData(courseData);
       await act(async () => render(intlWrapper(<IntlProctoredExamSettings {...defaultProps} />)));
       await waitFor(() => {
@@ -474,8 +476,10 @@ describe('ProctoredExamSettings', () => {
     });
 
     it('Includes lti proctoring provider options when lti_external is allowed by studio', async () => {
-      const courseData = mockGetFutureCourseData;
-      courseData.available_proctoring_providers = ['lti_external', 'proctortrack', 'mockproc'];
+      const courseData = {
+        ...mockGetFutureCourseData,
+        available_proctoring_providers: ['lti_external', 'proctortrack', 'mockproc'],
+      };
       mockCourseData(courseData);
       await act(async () => render(intlWrapper(<IntlProctoredExamSettings {...defaultProps} />)));
       await waitFor(() => {

--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -519,14 +519,18 @@ function ProctoredExamSettings({ courseId, intl }) {
             // This option is not directly selectable.
             const proctoringProvidersStudio = settingsResponse.data.available_proctoring_providers;
             const proctoringProvidersLti = ltiProvidersResponse?.data || [];
-            setAllowLtiProviders(proctoringProvidersStudio.includes('lti_external'));
+            const enableLtiProviders = proctoringProvidersStudio.includes('lti_external');
+            setAllowLtiProviders(enableLtiProviders);
             setLtiProctoringProviders(proctoringProvidersLti);
             // flatten provider objects and coalesce values to just the provider key
-            setAvailableProctoringProviders(
-              proctoringProvidersLti.reduce((result, provider) => [...result, provider.name], []).concat(
-                proctoringProvidersStudio.filter(value => value !== 'lti_external'),
-              ),
-            );
+            let availableProviders = proctoringProvidersStudio.filter(value => value !== 'lti_external');
+            if (enableLtiProviders) {
+              availableProviders = proctoringProvidersLti.reduce(
+                (result, provider) => [...result, provider.name], availableProviders,
+              );
+            }
+            setAvailableProctoringProviders(availableProviders);
+
             if (proctoredExamSettings.proctoring_provider === 'lti_external') {
               setProctoringProvider(examConfigResponse.data.provider);
             } else {


### PR DESCRIPTION
### [MST-1713](https://2u-internal.atlassian.net/browse/MST-1713?atlOrigin=eyJpIjoiZjQ3Y2E0MDlmNTQwNDU5NDhiOTZhMWRmMjdiMzBmNzQiLCJwIjoiaiJ9)

Two places because of the old view that should be deprecated in https://2u-internal.atlassian.net/browse/MST-1677