### PR TITLE
fix: group at subsection field added in redux state

### DIFF
--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -71,6 +71,7 @@ function normalizePluginConfig(data) {
     divideByCohorts: enableDivideByCohorts,
     divideCourseTopicsByCohorts: enableDivideCourseTopicsByCohorts,
     cohortsEnabled: data.available_division_schemes?.includes('cohort') || false,
+    groupAtSubsection: data.group_at_subsection,
   };
 }
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/INF-691

the group at the subsection toggle field was not reflecting the actual value returned by the backend this was due to the fact that the key was missing during the normalization process of data and hence it always picked the default value of false. it has now been fixed in this PR and the screenshot is attached reflecting the fix. 

<img width="1334" alt="Screen Shot 2023-01-04 at 6 17 03 PM" src="https://user-images.githubusercontent.com/67791278/210564046-a068fbf9-67dc-44b2-8451-65cf39f5d364.png">
