### PR TITLE
fix: updated openedx discussion provider help text

### DIFF
--- a/src/pages-and-resources/discussions/app-list/messages.js
+++ b/src/pages-and-resources/discussions/app-list/messages.js
@@ -64,7 +64,7 @@ const messages = defineMessages({
   },
   'appDescription-openedx': {
     id: 'authoring.discussions.appList.appDescription-openedx',
-    defaultMessage: 'Start conversations with other learners, ask questions, and interact with other learners in the course.',
+    defaultMessage: 'Enable participation in discussion topics alongside course content.',
     description: 'A description of the new edX Discussions app.',
   },
   // Piazza


### PR DESCRIPTION
Updated help text for discussion provider "openedx"

Ticket:
[INF-730](https://2u-internal.atlassian.net/browse/INF-730)

After change:
![Screenshot from 2023-01-20 16-21-59](https://user-images.githubusercontent.com/77053848/213684069-1be98b8d-42fe-494e-8a33-4fe449dfceb3.png)

