### PR TITLE
Fixed broken "Pages and Resources" page

### DIFF
--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -14,20 +14,34 @@ import { getCourseAppsApiStatus, getLoadingStatus } from './pages-and-resources/
 import { RequestStatus } from './data/constants';
 import Loading from './generic/Loading';
 
-const AppHeader = (courseNumber, courseOrg, courseTitle, courseId) => (
+const AppHeader = ({
+  courseNumber, courseOrg, courseTitle, courseId,
+}) => (
   <Header
     courseNumber={courseNumber}
     courseOrg={courseOrg}
     courseTitle={courseTitle}
     courseId={courseId}
   />
-  );
+);
 
-  const AppFooter = () => (
-    <div className="mt-6">
-      <Footer />
-    </div>
-  );
+AppHeader.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  courseNumber: PropTypes.string,
+  courseOrg: PropTypes.string,
+  courseTitle: PropTypes.string.isRequired,
+};
+
+AppHeader.defaultProps = {
+  courseNumber: null,
+  courseOrg: null,
+};
+
+const AppFooter = () => (
+  <div className="mt-6">
+    <Footer />
+  </div>
+);
 
 const CourseAuthoringPage = ({ courseId, children }) => {
   const dispatch = useDispatch();
@@ -57,7 +71,14 @@ const CourseAuthoringPage = ({ courseId, children }) => {
       we shouldn't have the header and footer on these pages.
       This functionality will be removed in TNL-9591 */}
       {inProgress ? !pathname.includes('/editor/') && <Loading />
-        : AppHeader(courseNumber, courseOrg, courseTitle, courseId)}
+        : (
+          <AppHeader
+            courseNumber={courseNumber}
+            courseOrg={courseOrg}
+            courseTitle={courseTitle}
+            courseId={courseId}
+          />
+    )}
       {children}
       {!inProgress && <AppFooter />}
     </div>

--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -57,7 +57,7 @@ const CourseAuthoringPage = ({ courseId, children }) => {
       we shouldn't have the header and footer on these pages.
       This functionality will be removed in TNL-9591 */}
       {inProgress ? !pathname.includes('/editor/') && <Loading />
-        : <AppHeader courseNumber={courseNumber} courseOrg={courseOrg} courseTitle={courseTitle} courseId={courseId} />}
+        : AppHeader(courseNumber, courseOrg, courseTitle, courseId)}
       {children}
       {!inProgress && <AppFooter />}
     </div>


### PR DESCRIPTION
# What has changed
Fixed broken "Pages and Resources" page, as a result of changes made in [322](https://github.com/openedx/frontend-app-course-authoring/pull/322). Updated the AppHeader call in course authoring page.

<img width="1436" alt="Screenshot 2023-02-08 at 6 19 33 PM" src="https://user-images.githubusercontent.com/59555732/217546868-1489610d-3f49-4900-889c-1d9d74da6773.png">

