### PR TITLE
fix: changed title of openedx

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -112,7 +112,7 @@ const messages = defineMessages({
   },
   'appName-openedx': {
     id: 'authoring.discussions.appConfigForm.appName-openedx',
-    defaultMessage: 'edX',
+    defaultMessage: 'edX (new)',
     description: 'The name of the new edX Discussions app.',
   },
   divisionByGroup: {


### PR DESCRIPTION
[INF-843](https://2u-internal.atlassian.net/browse/INF-843)

Description
Changed the name of the "openedx" provider from "edx" to "edx (new)"

|Before|
<img width="1626" alt="Screenshot 2023-04-11 at 4 04 03 PM" src="https://user-images.githubusercontent.com/72802712/231167138-7adb7b0c-e377-482a-80fb-1a5954e3057b.png">

|After|
<img width="1626" alt="Screenshot 2023-04-11 at 4 04 42 PM" src="https://user-images.githubusercontent.com/72802712/231167189-234ddaed-a8f7-4a6d-9528-6547c79cf0cc.png">

Merge Checklist

- [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
- [ ]  Is there adequate test coverage for your changes?

Post-merge Checklist

- [ ]  Deploy the changes to prod after verifying on stage or ask https://github.com/orgs/openedx/teams/edx-infinity to do it.
- [ ]  🎉 🙌 Celebrate! Thanks for your contribution.