### PR TITLE
feat: include paragon in atlas pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,11 @@ pull_translations:
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
 	   && atlas pull --filter=$(transifex_langs) \
+	            translations/paragon/src/i18n/messages:paragon \
 	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	            translations/frontend-app-course-authoring/src/i18n/messages:frontend-app-course-authoring
 
-	$(intl_imports) frontend-component-footer frontend-app-course-authoring
+	$(intl_imports) paragon frontend-component-footer frontend-app-course-authoring
 endif
 
 # This target is used by Travis.


### PR DESCRIPTION
This is a follow up to #530 because it should have included the changes but apparently OEP-58 needs more publicity.

Testing
--------

I've ran the following:

```
$ OPENEDX_ATLAS_PULL=yes make pull_translations
$ cat src/i18n/index.js
```

Generates the following code, which seems to be good:

```js
// This file is generated by the openedx/frontend-platform's "intl-import.js" script.
//
// Refer to the i18n documents in https://docs.openedx.org/en/latest/developers/references/i18n.html to update
// the file and use the Micro-frontend i18n pattern in new repositories.
//

import messagesFromParagon from './messages/paragon';
import messagesFromFrontendComponentFooter from './messages/frontend-component-footer';
import messagesFromFrontendAppCourseAuthoring from './messages/frontend-app-course-authoring';

export default [
  messagesFromParagon,
  messagesFromFrontendComponentFooter,
  messagesFromFrontendAppCourseAuthoring,
];
```

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time
