### PR TITLE
feat: load up-to-date config on studio fetch

### DIFF
--- a/src/data/services/StudioApiService.js
+++ b/src/data/services/StudioApiService.js
@@ -5,11 +5,11 @@ ensureConfig([
   'STUDIO_BASE_URL',
 ], 'Studio API service');
 
-const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+const getStudioBaseUrl = () => getConfig().STUDIO_BASE_URL;
 
 class StudioApiService {
   static getProctoredExamSettingsUrl(courseID) {
-    return `${studioBaseUrl}/api/contentstore/v1/proctored_exam_settings/${courseID}`;
+    return `${getStudioBaseUrl()}/api/contentstore/v1/proctored_exam_settings/${courseID}`;
   }
 
   static getProctoredExamSettingsData(courseID) {
@@ -25,7 +25,7 @@ class StudioApiService {
   }
 
   static getStudioCourseRunUrl(courseID) {
-    return `${studioBaseUrl}/course/${courseID}`;
+    return `${getStudioBaseUrl()}/course/${courseID}`;
   }
 }
 


### PR DESCRIPTION
If a runtime configuration (https://github.com/openedx/frontend-platform/pull/335) is used this config will likely load and be stored in memory before the runtime overrides are merged in since that relies on a network request. This impacts anyone using Tutor locally because the wrong domain (localhost) will be used for studio requests.