### PR TITLE
feat: add xpert summaries configuration by default for units

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -13,3 +13,4 @@
 @import "grading-settings/scss/GradingSettings";
 @import "generic/styles";
 @import "schedule-and-details/ScheduleAndDetails";
+@import "pages-and-resources/PagesAndResources";

--- a/src/pages-and-resources/PagesAndResources.scss
+++ b/src/pages-and-resources/PagesAndResources.scss
@@ -1,0 +1,1 @@
+@import "./xpert-unit-summary/settings-modal/SettingsModal";

--- a/src/pages-and-resources/data/selectors.js
+++ b/src/pages-and-resources/data/selectors.js
@@ -6,3 +6,4 @@ export const getCourseAppsApiStatus = (state) => state.pagesAndResources.courseA
 export const getCourseAppSettingValue = (setting) => (state) => (
   state.pagesAndResources.courseAppSettings[setting]?.value
 );
+export const getResetStatus = (state) => state.pagesAndResources.resetStatus;

--- a/src/pages-and-resources/data/slice.js
+++ b/src/pages-and-resources/data/slice.js
@@ -9,6 +9,7 @@ const slice = createSlice({
     courseAppIds: [],
     loadingStatus: RequestStatus.IN_PROGRESS,
     savingStatus: '',
+    resetStatus: '',
     courseAppsApiStatus: {},
     courseAppSettings: {},
   },
@@ -21,6 +22,9 @@ const slice = createSlice({
     },
     updateSavingStatus: (state, { payload }) => {
       state.savingStatus = payload.status;
+    },
+    updateResetStatus: (state, { payload }) => {
+      state.resetStatus = payload.status;
     },
     updateCourseAppsApiStatus: (state, { payload }) => {
       state.courseAppsApiStatus = payload.status;
@@ -38,6 +42,7 @@ export const {
   fetchCourseAppsSuccess,
   updateLoadingStatus,
   updateSavingStatus,
+  updateResetStatus,
   updateCourseAppsApiStatus,
   fetchCourseAppsSettingsSuccess,
   updateCourseAppsSettingsSuccess,

--- a/src/pages-and-resources/xpert-unit-summary/XpertUnitSummarySettings.jsx
+++ b/src/pages-and-resources/xpert-unit-summary/XpertUnitSummarySettings.jsx
@@ -44,6 +44,8 @@ const XpertUnitSummarySettings = ({ intl }) => {
       }
       enableAppLabel={intl.formatMessage(messages.enableXpertUnitSummaryLabel)}
       learnMoreText={intl.formatMessage(messages.enableXpertUnitSummaryLink)}
+      allUnitsEnabledText={intl.formatMessage(messages.allUnitsEnabledByDefault)}
+      noUnitsEnabledText={intl.formatMessage(messages.noUnitsEnabledByDefault)}
       onClose={handleClose}
     />
   );

--- a/src/pages-and-resources/xpert-unit-summary/data/api.js
+++ b/src/pages-and-resources/xpert-unit-summary/data/api.js
@@ -20,6 +20,7 @@ export async function postXpertSettings(courseId, state) {
   const { data } = await getAuthenticatedHttpClient()
     .post(getXpertSettingsUrl(courseId), {
       enabled: state.enabled,
+      reset: state.reset,
     });
 
   return data;
@@ -28,6 +29,13 @@ export async function postXpertSettings(courseId, state) {
 export async function getXpertPluginConfigurable(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(getXpertConfigurationStatusUrl(courseId));
+
+  return data;
+}
+
+export async function deleteXpertSettings(courseId) {
+  const { data } = await getAuthenticatedHttpClient()
+    .delete(getXpertSettingsUrl(courseId));
 
   return data;
 }

--- a/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.jsx
+++ b/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.jsx
@@ -4,12 +4,17 @@ import {
   Alert,
   Badge,
   Form,
+  Icon,
   ModalDialog,
+  OverlayTrigger,
   StatefulButton,
+  Tooltip,
   TransitionReplace,
   Hyperlink,
 } from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+import {
+  Info, CheckCircleOutline, RotateLeft, SpinnerSimple,
+} from '@edx/paragon/icons';
 
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
@@ -26,9 +31,9 @@ import Loading from '../../../generic/Loading';
 import { useModel } from '../../../generic/model-store';
 import PermissionDeniedAlert from '../../../generic/PermissionDeniedAlert';
 import { useIsMobile } from '../../../utils';
-import { getLoadingStatus, getSavingStatus } from '../../data/selectors';
-import { updateSavingStatus } from '../../data/slice';
-import { updateXpertSettings } from '../data/thunks';
+import { getLoadingStatus, getSavingStatus, getResetStatus } from '../../data/selectors';
+import { updateSavingStatus, updateResetStatus } from '../../data/slice';
+import { updateXpertSettings, resetXpertSettings, removeXpertSettings } from '../data/thunks';
 import AppConfigFormDivider from '../../discussions/app-config-form/apps/shared/AppConfigFormDivider';
 import { PagesAndResourcesContext } from '../../PagesAndResourcesProvider';
 import messages from './messages';
@@ -105,6 +110,82 @@ SettingsModalBase.defaultProps = {
   footer: null,
 };
 
+const ResetUnitsButton = ({
+  intl,
+  courseId,
+  checked,
+  visible,
+}) => {
+  const resetStatusRequestStatus = useSelector(getResetStatus);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (resetStatusRequestStatus === RequestStatus.SUCCESSFUL) {
+      setTimeout(() => {
+        dispatch(updateResetStatus({ status: '' }));
+      }, 2000);
+    }
+  }, [resetStatusRequestStatus]);
+
+  const handleResetUnits = () => {
+    dispatch(resetXpertSettings(courseId, { enabled: checked === 'true', reset: true }));
+  };
+
+  const getResetButtonState = () => {
+    switch (resetStatusRequestStatus) {
+    case RequestStatus.PENDING:
+      return 'pending';
+    case RequestStatus.SUCCESSFUL:
+      return 'finish';
+    default:
+      return 'default';
+    }
+  };
+
+  if (!visible) { return null; }
+
+  return (
+    <OverlayTrigger
+      placement="right"
+      overlay={(
+        <Tooltip id={`tooltip-reset-${checked}`}>
+          {intl.formatMessage(messages.resetAllUnitsTooltip, { state: checked === 'true' ? 'checked' : 'unchecked' })}
+        </Tooltip>
+      )}
+    >
+      <StatefulButton
+        className="reset-units-button"
+        labels={{
+          default: intl.formatMessage(messages.resetAllUnits),
+          pending: '',
+          finish: intl.formatMessage(messages.reset),
+        }}
+        icons={{
+          default: <Icon src={RotateLeft} />,
+          pending: <Icon src={SpinnerSimple} className="icon-spin" />,
+          finish: <Icon src={CheckCircleOutline} />,
+        }}
+        state={getResetButtonState()}
+        onClick={handleResetUnits}
+        disabledStates={['pending', 'finish']}
+        variant="outline"
+        data-testid="reset-units"
+      />
+    </OverlayTrigger>
+  );
+};
+
+ResetUnitsButton.propTypes = {
+  intl: intlShape.isRequired,
+  courseId: PropTypes.string.isRequired,
+  checked: PropTypes.oneOf(['true', 'false']).isRequired,
+  visible: PropTypes.bool,
+};
+
+ResetUnitsButton.defaultProps = {
+  visible: false,
+};
+
 const SettingsModal = ({
   intl,
   appId,
@@ -119,6 +200,8 @@ const SettingsModal = ({
   enableAppHelp,
   learnMoreText,
   enableReinitialize,
+  allUnitsEnabledText,
+  noUnitsEnabledText,
 }) => {
   const { courseId } = useContext(PagesAndResourcesContext);
   const loadingStatus = useSelector(getLoadingStatus);
@@ -139,9 +222,15 @@ const SettingsModal = ({
     }
   }, [updateSettingsRequestStatus]);
 
-  const handleFormSubmit = async (values) => {
-    let success = true;
-    success = await dispatch(updateXpertSettings(courseId, values));
+  const handleFormSubmit = async ({ enabled, checked, ...rest }) => {
+    let success;
+    const values = { ...rest, enabled: enabled ? checked === 'true' : undefined };
+
+    if (enabled) {
+      success = await dispatch(updateXpertSettings(courseId, values));
+    } else {
+      success = await dispatch(removeXpertSettings(courseId));
+    }
 
     if (onSettingsSave) {
       success = success && await onSettingsSave(values);
@@ -174,13 +263,15 @@ const SettingsModal = ({
     return (
       <Formik
         initialValues={{
-          enabled: !!xpertSettings?.enabled,
+          enabled: xpertSettings?.enabled !== undefined,
+          checked: xpertSettings?.enabled?.toString() || 'true',
           ...initialValues,
         }}
         validationSchema={
           Yup.object()
             .shape({
               enabled: Yup.boolean(),
+              checked: Yup.string().oneOf(['true', 'false']),
               ...validationSchema,
             })
         }
@@ -206,6 +297,7 @@ const SettingsModal = ({
                   }}
                   state={submitButtonState}
                   onClick={handleFormikSubmit(formikProps)}
+                  disabled={!formikProps.dirty}
                 />
               )}
             >
@@ -220,7 +312,7 @@ const SettingsModal = ({
               <FormSwitchGroup
                 id={`enable-${appId}-toggle`}
                 name="enabled"
-                onChange={(event) => formikProps.handleChange(event)}
+                onChange={formikProps.handleChange}
                 onBlur={formikProps.handleBlur}
                 checked={formikProps.values.enabled}
                 label={(
@@ -240,6 +332,41 @@ const SettingsModal = ({
                   </div>
                 )}
               />
+              {(formikProps.values.enabled || configureBeforeEnable) && (
+                <Form.RadioSet
+                  name="checked"
+                  onChange={formikProps.handleChange}
+                  onBlur={formikProps.handleBlur}
+                  value={formikProps.values.checked}
+                >
+                  <Form.Radio
+                    className="summary-radio m-2 px-3"
+                    data-testid="enable-radio"
+                    value="true"
+                  >
+                    {allUnitsEnabledText}
+                    <ResetUnitsButton
+                      intl={intl}
+                      courseId={courseId}
+                      checked={formikProps.values.checked}
+                      visible={formikProps.values.checked === 'true'}
+                    />
+                  </Form.Radio>
+                  <Form.Radio
+                    className="summary-radio m-2 px-3"
+                    data-testid="disable-radio"
+                    value="false"
+                  >
+                    {noUnitsEnabledText}
+                    <ResetUnitsButton
+                      intl={intl}
+                      courseId={courseId}
+                      checked={formikProps.values.checked}
+                      visible={formikProps.values.checked === 'false'}
+                    />
+                  </Form.Radio>
+                </Form.RadioSet>
+              )}
               {(formikProps.values.enabled || configureBeforeEnable) && children
                 && <AppConfigFormDivider marginAdj={{ default: 0, sm: 0 }} />}
               <AppSettingsForm formikProps={formikProps} showForm={formikProps.values.enabled || configureBeforeEnable}>
@@ -281,6 +408,8 @@ SettingsModal.propTypes = {
   enableAppLabel: PropTypes.string.isRequired,
   enableAppHelp: PropTypes.string.isRequired,
   learnMoreText: PropTypes.string.isRequired,
+  allUnitsEnabledText: PropTypes.string.isRequired,
+  noUnitsEnabledText: PropTypes.string.isRequired,
   configureBeforeEnable: PropTypes.bool,
   enableReinitialize: PropTypes.bool,
 };

--- a/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.jsx
+++ b/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.jsx
@@ -144,12 +144,14 @@ const ResetUnitsButton = ({
 
   if (!visible) { return null; }
 
+  const messageKey = checked === 'true' ? 'resetAllUnitsTooltipChecked' : 'resetAllUnitsTooltipUnchecked';
+
   return (
     <OverlayTrigger
       placement="right"
       overlay={(
         <Tooltip id={`tooltip-reset-${checked}`}>
-          {intl.formatMessage(messages.resetAllUnitsTooltip, { state: checked === 'true' ? 'checked' : 'unchecked' })}
+          {intl.formatMessage(messages[messageKey])}
         </Tooltip>
       )}
     >

--- a/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.scss
+++ b/src/pages-and-resources/xpert-unit-summary/settings-modal/SettingsModal.scss
@@ -1,0 +1,31 @@
+.summary-radio {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-width: $border-width;
+  border-color: $border-color;
+  border-radius: $border-radius;
+  border-style: solid;
+
+  &:has(input:checked) {
+    border-width: 3px;
+    border-color: theme-color("primary");
+  }
+
+  > div {
+    flex: 1;
+
+    > label {
+      height: 80px;
+    }
+  }
+}
+
+.reset-units-button {
+  color: $link-color;
+  border-width: $border-width;
+  border-color: $border-color;
+  border-radius: $border-radius;
+  border-style: solid;
+  margin-left: auto;
+}

--- a/src/pages-and-resources/xpert-unit-summary/settings-modal/messages.js
+++ b/src/pages-and-resources/xpert-unit-summary/settings-modal/messages.js
@@ -33,9 +33,13 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units',
     defaultMessage: 'Reset all units',
   },
-  resetAllUnitsTooltip: {
-    id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip',
-    defaultMessage: 'Immediately reset any unit-level changes and {state} "Enable summaries" on all units.',
+  resetAllUnitsTooltipChecked: {
+    id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip.checked',
+    defaultMessage: 'Immediately reset any unit-level changes and checked "Enable summaries" on all units.',
+  },
+  resetAllUnitsTooltipUnchecked: {
+    id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip.unchecked',
+    defaultMessage: 'Immediately reset any unit-level changes and unchecked "Enable summaries" on all units.',
   },
   reset: {
     id: 'course-authoring.pages-resources.app-settings-modal.reset',

--- a/src/pages-and-resources/xpert-unit-summary/settings-modal/messages.js
+++ b/src/pages-and-resources/xpert-unit-summary/settings-modal/messages.js
@@ -29,6 +29,18 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.app-settings-modal.badge.disabled',
     defaultMessage: 'Disabled',
   },
+  resetAllUnits: {
+    id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units',
+    defaultMessage: 'Reset all units',
+  },
+  resetAllUnitsTooltip: {
+    id: 'course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip',
+    defaultMessage: 'Immediately reset any unit-level changes and {state} "Enable summaries" on all units.',
+  },
+  reset: {
+    id: 'course-authoring.pages-resources.app-settings-modal.reset',
+    defaultMessage: 'Reset',
+  },
   errorSavingTitle: {
     id: 'course-authoring.pages-resources.app-settings-modal.save-error.title',
     defaultMessage: 'We couldn\'t apply your changes.',


### PR DESCRIPTION
* Update modals to support reset and delete course xpert summary settings when is disabled
* Add radio buttons to specify the default value for the xpert course summary settings