### PR TITLE
fix: file info bugs

### DIFF
--- a/src/files-and-uploads/FileInfo.jsx
+++ b/src/files-and-uploads/FileInfo.jsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
-
+import {
+  injectIntl,
+  FormattedMessage,
+  FormattedDate,
+  intlShape,
+} from '@edx/frontend-platform/i18n';
 import {
   ModalDialog,
   Stack,
@@ -13,6 +17,7 @@ import {
   CheckboxControl,
 } from '@edx/paragon';
 import { ContentCopy, InfoOutline } from '@edx/paragon/icons';
+import { getUtcDateTime } from './data/utils';
 import AssetThumbnail from './FileThumbnail';
 
 import messages from './messages';
@@ -31,6 +36,7 @@ const FileInfo = ({
     setLockedState(locked);
     handleLockedAsset(asset.id, locked);
   };
+  const dateAdded = getUtcDateTime(asset.dateAdded);
 
   return (
     <ModalDialog
@@ -48,7 +54,7 @@ const FileInfo = ({
       <ModalDialog.Body className="pt-0 x-small">
         <hr />
         <div className="row flex-nowrap m-0 mt-4">
-          <div className="col-7 mr-3">
+          <div className="col-8 mr-3">
             <AssetThumbnail
               thumbnail={asset.thumbnail}
               externalUrl={asset.externalUrl}
@@ -60,7 +66,14 @@ const FileInfo = ({
             <div className="font-weight-bold">
               <FormattedMessage {...messages.dateAddedTitle} />
             </div>
-            {asset.dateAdded}
+            <FormattedDate
+              value={dateAdded}
+              year="numeric"
+              month="short"
+              day="2-digit"
+              hour="numeric"
+              minute="numeric"
+            />
             <div className="font-weight-bold mt-3">
               <FormattedMessage {...messages.fileSizeTitle} />
             </div>

--- a/src/files-and-uploads/FileThumbnail.jsx
+++ b/src/files-and-uploads/FileThumbnail.jsx
@@ -19,11 +19,19 @@ const AssetThumbnail = ({
   });
 
   return (
-    <div className="row justify-content-center">
+    <div className="row justify-content-center align-itmes-center">
       {thumbnail ? (
-        <Image fluid thumbnail src={src} alt={`Thumbnail of ${displayName}`} />
+        <Image
+          style={{ width: '503px', height: '281px' }}
+          className="border rounded p-1"
+          src={src}
+          alt={`Thumbnail of ${displayName}`}
+        />
       ) : (
-        <div className="border rounded p-1">
+        <div
+          className="row border justify-content-center align-items-center rounded m-0"
+          style={{ width: '503px', height: '281px' }}
+        >
           <Icon src={src} style={{ height: '48px', width: '48px' }} />
         </div>
       )}

--- a/src/files-and-uploads/data/utils.js
+++ b/src/files-and-uploads/data/utils.js
@@ -39,3 +39,9 @@ export const getSrc = ({ thumbnail, wrapperType, externalUrl }) => {
     return InsertDriveFile;
   }
 };
+
+export const getUtcDateTime = (date) => {
+  const utcDateString = date.replace(/\bat\b/g, '');
+  const utcDateTime = new Date(utcDateString);
+  return utcDateTime;
+};


### PR DESCRIPTION
JIRA Ticket: [TNL-10953](https://2u-internal.atlassian.net/browse/TNL-10953)

This PR makes addresses the following ui bugs in the file info modal:

1. Makes the file preview a fixed height and width
2. Adjusts the date added to use the localized version of the time instead of utc

<img width="1545" alt="Screenshot 2023-08-17 at 2 10 46 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/42981026/43385d1c-0049-451f-91ab-a8eaaa85abf6">
<img width="1545" alt="Screenshot 2023-08-17 at 2 10 36 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/42981026/4375390d-ace6-4a27-889b-a51723eee939">
