### PR TITLE
fix: add word break style for long words

### DIFF
--- a/src/files-and-uploads/FileInfo.jsx
+++ b/src/files-and-uploads/FileInfo.jsx
@@ -42,7 +42,11 @@ const FileInfo = ({
     >
       <ModalDialog.Header>
         <ModalDialog.Title>
-          {asset.displayName}
+          <div style={{ wordBreak: 'break-word' }}>
+            <Truncate lines={2} className="font-weight-bold small mt-3">
+              {asset.displayName}
+            </Truncate>
+          </div>
         </ModalDialog.Title>
       </ModalDialog.Header>
       <ModalDialog.Body className="pt-0 x-small">
@@ -70,9 +74,11 @@ const FileInfo = ({
               <FormattedMessage {...messages.studioUrlTitle} />
             </div>
             <ActionRow>
-              <Truncate lines={1}>
-                {asset.portableUrl}
-              </Truncate>
+              <div style={{ wordBreak: 'break-word' }}>
+                <Truncate lines={1}>
+                  {asset.portableUrl}
+                </Truncate>
+              </div>
               <ActionRow.Spacer />
               <IconButton
                 src={ContentCopy}
@@ -85,9 +91,11 @@ const FileInfo = ({
               <FormattedMessage {...messages.webUrlTitle} />
             </div>
             <ActionRow>
-              <Truncate lines={1}>
-                {asset.externalUrl}
-              </Truncate>
+              <div style={{ wordBreak: 'break-word' }}>
+                <Truncate lines={1}>
+                  {asset.externalUrl}
+                </Truncate>
+              </div>
               <ActionRow.Spacer />
               <IconButton
                 src={ContentCopy}

--- a/src/files-and-uploads/FilesAndUploads.jsx
+++ b/src/files-and-uploads/FilesAndUploads.jsx
@@ -236,7 +236,7 @@ const FilesAndUploads = ({
               }}
             />
           ) : (
-            <div data-testid="files-data-table">
+            <div data-testid="files-data-table" className="mr-4 ml-3">
               <DataTable.TableControlBar />
               { currentView === 'card' && <CardView CardComponent={fileCard} columnSizes={columnSizes} selectionPlacement="left" skeletonCardCount={6} /> }
               { currentView === 'list' && <CardView CardComponent={fileCard} columnSizes={{ xs: 12 }} selectionPlacement="left" skeletonCardCount={4} /> }

--- a/src/files-and-uploads/table-components/GalleryCard.jsx
+++ b/src/files-and-uploads/table-components/GalleryCard.jsx
@@ -64,9 +64,11 @@ const GalleryCard = ({
               </div>
             )}
           </div>
-          <Truncate lines={1} className="font-weight-bold small mt-3">
-            {original.displayName}
-          </Truncate>
+          <div style={{ wordBreak: 'break-word' }}>
+            <Truncate lines={1} className="font-weight-bold small mt-3">
+              {original.displayName}
+            </Truncate>
+          </div>
         </Card.Section>
         <Card.Footer>
           <Chip>

--- a/src/files-and-uploads/table-components/ListCard.jsx
+++ b/src/files-and-uploads/table-components/ListCard.jsx
@@ -53,9 +53,11 @@ const ListCard = ({
         </div>
         <Card.Body>
           <Card.Section>
-            <Truncate lines={1} className="font-weight-bold small mt-3">
-              {original.displayName}
-            </Truncate>
+            <div style={{ wordBreak: 'break-word' }}>
+              <Truncate lines={1} className="font-weight-bold small mt-3">
+                {original.displayName}
+              </Truncate>
+            </div>
             <Chip className="mt-3">
               {original.wrapperType}
             </Chip>


### PR DESCRIPTION
JIRA Ticket: [TNL-10959](https://2u-internal.atlassian.net/browse/TNL-10959)

A temporary fix while Paragon resolves the bug in the component.

Testing
1. Navigate to the assets page
2. All cards should have the same length
3. Open the file info
4. There should be no horizontal scrolling
