### PR TITLE
fix: Pass correct prop to TinyMceWidget and update FLCC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-component-footer": "12.0.0",
         "@edx/frontend-enterprise-hotjar": "^1.2.1",
-        "@edx/frontend-lib-content-components": "^1.169.0",
+        "@edx/frontend-lib-content-components": "^1.169.3",
         "@edx/frontend-platform": "4.2.0",
         "@edx/paragon": "^20.45.4",
         "@fortawesome/fontawesome-svg-core": "1.2.28",
@@ -2298,9 +2298,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "1.169.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-1.169.0.tgz",
-      "integrity": "sha512-PNs7KntOdF/oyL82dG/GprdKwE6kfO5UnNPJVK2Dh4WBO/rUWuQUfTewxVI61Qyegg+SJKseBHYfxyp9COCN4Q==",
+      "version": "1.169.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-1.169.3.tgz",
+      "integrity": "sha512-CgqMs9vEkx9rw6DBlLThKB/omJzMD+mntZGRevF547G/Gl8dt/KSquNZrOiNph1PImXTD1eb2DtSyN7VbYNBaA==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "12.0.0",
     "@edx/frontend-enterprise-hotjar": "^1.2.1",
-    "@edx/frontend-lib-content-components": "^1.169.0",
+    "@edx/frontend-lib-content-components": "^1.169.3",
     "@edx/frontend-platform": "4.2.0",
     "@edx/paragon": "^20.45.4",
     "@fortawesome/fontawesome-svg-core": "1.2.28",

--- a/src/generic/WysiwygEditor.jsx
+++ b/src/generic/WysiwygEditor.jsx
@@ -73,7 +73,7 @@ export const WysiwygEditor = ({
         minHeight={minHeight}
         editorContentHtml={initialValue}
         setEditorRef={setEditorRef}
-        updateContent={handleUpdate}
+        onChange={handleUpdate}
         initializeEditor={() => ({})}
       />
     </Provider>


### PR DESCRIPTION
This should be merged after https://github.com/openedx/frontend-lib-content-components/pull/379. It will need to update FLCC to the newer version, then.