### PR TITLE
fix: await async saveSetting func to remove unwanted err msg

### DIFF
--- a/src/pages-and-resources/progress/Settings.jsx
+++ b/src/pages-and-resources/progress/Settings.jsx
@@ -12,8 +12,8 @@ const ProgressSettings = ({ intl, onClose }) => {
   const [disableProgressGraph, saveSetting] = useAppSetting('disableProgressGraph');
   const showProgressGraphSetting = getConfig().ENABLE_PROGRESS_GRAPH_SETTINGS.toString().toLowerCase() === 'true';
 
-  const handleSettingsSave = (values) => {
-    if (showProgressGraphSetting) { saveSetting(!values.enableProgressGraph); }
+  const handleSettingsSave = async (values) => {
+    if (showProgressGraphSetting) { await saveSetting(!values.enableProgressGraph); }
   };
 
   return (


### PR DESCRIPTION
Without this change, an error msg is displayed till the request runs, i.e. it is not waiting for the request to complete.

![image](https://github.com/openedx/frontend-app-course-authoring/assets/10894099/24a1648d-8518-4af8-b810-ee4a39803bb4)

This issue was discovered while testing/reviewing https://github.com/openedx/frontend-app-learning/pull/1194