### PR TITLE
fix: export download link prefix

### DIFF
--- a/src/export-page/CourseExportPage.test.jsx
+++ b/src/export-page/CourseExportPage.test.jsx
@@ -111,7 +111,7 @@ describe('<CourseExportPage />', () => {
     const { getByText } = render(<RootWrapper />);
     expect(getByText(stepperMessages.stepperPreparingDescription.defaultMessage)).toBeInTheDocument();
   });
-  it('should show download path', async () => {
+  it('should show download path for relative path', async () => {
     axiosMock
       .onGet(getExportStatusApiUrl(courseId))
       .reply(200, { exportStatus: EXPORT_STAGES.SUCCESS, exportOutput: '/test-download-path.test' });
@@ -123,5 +123,18 @@ describe('<CourseExportPage />', () => {
     const downloadButton = getByText(stepperMessages.downloadCourseButtonTitle.defaultMessage);
     expect(downloadButton).toBeInTheDocument();
     expect(downloadButton.getAttribute('href')).toEqual(`${getConfig().STUDIO_BASE_URL}/test-download-path.test`);
+  });
+  it('should show download path for absolute path', async () => {
+    axiosMock
+      .onGet(getExportStatusApiUrl(courseId))
+      .reply(200, { exportStatus: EXPORT_STAGES.SUCCESS, exportOutput: 'http://test-download-path.test' });
+    const { getByText, container } = render(<RootWrapper />);
+    const startExportButton = container.querySelector('.btn-primary');
+    fireEvent.click(startExportButton);
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 3500));
+    const downloadButton = getByText(stepperMessages.downloadCourseButtonTitle.defaultMessage);
+    expect(downloadButton).toBeInTheDocument();
+    expect(downloadButton.getAttribute('href')).toEqual('http://test-download-path.test');
   });
 });

--- a/src/export-page/data/thunks.js
+++ b/src/export-page/data/thunks.js
@@ -1,5 +1,6 @@
 import Cookies from 'universal-cookie';
 import moment from 'moment';
+import { getConfig } from '@edx/frontend-platform';
 
 import { RequestStatus } from '../../data/constants';
 import { setExportCookie } from '../utils';
@@ -48,7 +49,11 @@ export function fetchExportStatus(courseId) {
       dispatch(updateCurrentStage(Math.abs(exportStatus)));
 
       if (exportOutput) {
-        dispatch(updateDownloadPath(exportOutput));
+        if (exportOutput.startsWith('/')) {
+          dispatch(updateDownloadPath(`${getConfig().STUDIO_BASE_URL}${exportOutput}`));
+        } else {
+          dispatch(updateDownloadPath(exportOutput));
+        }
         dispatch(updateSuccessDate(moment().valueOf()));
       }
 

--- a/src/export-page/export-stepper/ExportStepper.jsx
+++ b/src/export-page/export-stepper/ExportStepper.jsx
@@ -6,7 +6,6 @@ import {
 } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { getConfig } from '@edx/frontend-platform';
 import { Button } from '@edx/paragon';
 
 import CourseStepper from '../../generic/course-stepper';
@@ -91,7 +90,7 @@ const ExportStepper = ({ intl, courseId }) => {
         errorMessage={errorMessage}
         hasError={!!errorMessage}
       />
-      {downloadPath && currentStage === EXPORT_STAGES.SUCCESS && <Button className="ml-5.5 mt-n2.5" href={`${getConfig().STUDIO_BASE_URL}${downloadPath}`}>{intl.formatMessage(messages.downloadCourseButtonTitle)}</Button>}
+      {downloadPath && currentStage === EXPORT_STAGES.SUCCESS && <Button className="ml-5.5 mt-n2.5" href={downloadPath} download>{intl.formatMessage(messages.downloadCourseButtonTitle)}</Button>}
     </div>
   );
 };


### PR DESCRIPTION
This PR fixes the export link differences between relative export paths and absolute export paths. Currently all export path received from the api are treated as relative paths so the port for the page is prepended to the relative path. However, not all the export paths from the api are guaranteed to be relative paths. In the case that export path is an absolute path, the file will fail to download because the absolute path was prepended with unnecessary port.  This PR a checks if the export path is relative or absolute and prepends the port accordingly.

Testing
1. Navigate to the export mfe page
2. Export a course
3. Click the download button
4. File downloads as expected