### PR TITLE
feat: update list view to be table

### DIFF
--- a/src/files-and-uploads/FilesAndUploads.test.jsx
+++ b/src/files-and-uploads/FilesAndUploads.test.jsx
@@ -168,7 +168,7 @@ describe('FilesAndUploads', () => {
 
         expect(screen.getByTestId('grid-card-mOckID1')).toBeVisible();
 
-        expect(screen.queryByTestId('list-card-mOckID1')).toBeNull();
+        expect(screen.queryByRole('table')).toBeNull();
 
         const listButton = screen.getByLabelText('List');
         await act(async () => {
@@ -176,7 +176,7 @@ describe('FilesAndUploads', () => {
         });
         expect(screen.queryByTestId('grid-card-mOckID1')).toBeNull();
 
-        expect(screen.getByTestId('list-card-mOckID1')).toBeVisible();
+        expect(screen.getByRole('table')).toBeVisible();
       });
     });
 

--- a/src/files-and-uploads/table-components/table-custom-columns/AccessColumn.jsx
+++ b/src/files-and-uploads/table-components/table-custom-columns/AccessColumn.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Icon, OverlayTrigger, Tooltip } from '@edx/paragon';
+import { Locked, LockOpen } from '@edx/paragon/icons';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import messages from '../../messages';
+
+const AccessColumn = ({
+  row,
+  // injected
+  intl,
+}) => {
+  const { locked } = row.original;
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={(
+        <Tooltip id="access-tooltip-description">
+          {intl.formatMessage(messages.lockFileTooltipContent)}
+        </Tooltip>
+      )}
+    >
+      {locked ? (
+        <Icon src={Locked} size="sm" />
+      ) : (
+        <Icon src={LockOpen} size="sm" />
+      )}
+    </OverlayTrigger>
+  );
+};
+
+AccessColumn.propTypes = {
+  row: {
+    original: {
+      locked: PropTypes.bool.isRequired,
+    }.isRequired,
+  }.isRequired,
+  // injected
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(AccessColumn);

--- a/src/files-and-uploads/table-components/table-custom-columns/ActiveColumn.jsx
+++ b/src/files-and-uploads/table-components/table-custom-columns/ActiveColumn.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Icon } from '@edx/paragon';
+import { Check } from '@edx/paragon/icons';
+
+const ActiveColumn = ({ row }) => {
+  const { usageLocations } = row.original;
+  const numOfUsageLocations = usageLocations.length;
+  return numOfUsageLocations > 0 ? <Icon src={Check} /> : null;
+};
+
+ActiveColumn.propTypes = {
+  row: {
+    original: {
+      usageLocations: PropTypes.arrayOf(PropTypes.string).isRequired,
+    }.isRequired,
+  }.isRequired,
+};
+
+export default ActiveColumn;

--- a/src/files-and-uploads/table-components/table-custom-columns/MoreInfoColumn.jsx
+++ b/src/files-and-uploads/table-components/table-custom-columns/MoreInfoColumn.jsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import { PropTypes } from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  Button,
+  Icon,
+  IconButton,
+  ModalPopup,
+  Menu,
+  MenuItem,
+  useToggle,
+} from '@edx/paragon';
+import { MoreHoriz } from '@edx/paragon/icons';
+
+import messages from '../../messages';
+
+const MoreInfoColumn = ({
+  row,
+  handleLock,
+  handleBulkDownload,
+  handleOpenAssetInfo,
+  handleOpenDeleteConfirmation,
+  // injected
+  intl,
+}) => {
+  const [isOpen, , close, toggle] = useToggle();
+  const [target, setTarget] = useState(null);
+
+  const {
+    externalUrl,
+    locked,
+    portableUrl,
+    id,
+    wrapperType,
+    displayName,
+  } = row.original;
+  return (
+    <>
+      <IconButton src={MoreHoriz} iconAs={Icon} onClick={toggle} ref={setTarget} />
+      <ModalPopup
+        placement="left"
+        positionRef={target}
+        isOpen={isOpen}
+        onClose={close}
+        onEscapeKey={close}
+        style={{
+
+        }}
+      >
+        <Menu
+          className="border border-light-400"
+          style={{ overflowX: 'hidden', boxShadow: '0px 0px 0px #000', maxHeight: '500px' }}
+        >
+          {wrapperType === 'video' ? (
+            <MenuItem
+              as={Button}
+              variant="tertiary"
+              size="inline"
+              onClick={() => {
+                navigator.clipboard.writeText(id);
+                close();
+              }}
+            >
+              Copy video ID
+            </MenuItem>
+          ) : (
+            <>
+              <MenuItem
+                as={Button}
+                variant="tertiary"
+                size="inline"
+                onClick={() => {
+                  navigator.clipboard.writeText(portableUrl);
+                  close();
+                }}
+              >
+                {intl.formatMessage(messages.copyStudioUrlTitle)}
+              </MenuItem>
+              <MenuItem
+                as={Button}
+                variant="tertiary"
+                size="inline"
+                onClick={() => {
+                  navigator.clipboard.writeText(externalUrl);
+                  close();
+                }}
+              >
+                {intl.formatMessage(messages.copyWebUrlTitle)}
+              </MenuItem>
+              <MenuItem
+                as={Button}
+                variant="tertiary"
+                size="inline"
+                onClick={() => handleLock(id, !locked)}
+              >
+                {locked ? intl.formatMessage(messages.unlockMenuTitle) : intl.formatMessage(messages.lockMenuTitle)}
+              </MenuItem>
+            </>
+          )}
+          <MenuItem
+            as={Button}
+            variant="tertiary"
+            size="inline"
+            onClick={() => handleBulkDownload(
+              [{ original: { id, displayName } }],
+            )}
+          >
+            {intl.formatMessage(messages.downloadTitle)}
+          </MenuItem>
+          <MenuItem
+            as={Button}
+            variant="tertiary"
+            size="inline"
+            onClick={() => handleOpenAssetInfo(row.original)}
+          >
+            {intl.formatMessage(messages.infoTitle)}
+          </MenuItem>
+          <hr className="m-0" />
+          <MenuItem
+            as={Button}
+            variant="tertiary"
+            size="inline"
+            data-testid="open-delete-confirmation-button"
+            onClick={() => {
+              handleOpenDeleteConfirmation([{ original: row.original }]);
+              close();
+            }}
+          >
+            {intl.formatMessage(messages.deleteTitle)}
+          </MenuItem>
+        </Menu>
+      </ModalPopup>
+    </>
+  );
+};
+
+MoreInfoColumn.propTypes = {
+  row: {
+    original: {
+      externalUrl: PropTypes.string,
+      locked: PropTypes.bool,
+      portableUrl: PropTypes.string,
+      id: PropTypes.string.isRequired,
+      wrapperType: PropTypes.string,
+    }.isRequired,
+  }.isRequired,
+  handleLock: PropTypes.func.isRequired,
+  handleBulkDownload: PropTypes.func.isRequired,
+  handleOpenAssetInfo: PropTypes.func.isRequired,
+  handleOpenDeleteConfirmation: PropTypes.func.isRequired,
+  // injected
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(MoreInfoColumn);

--- a/src/files-and-uploads/table-components/table-custom-columns/StatusColumn.jsx
+++ b/src/files-and-uploads/table-components/table-custom-columns/StatusColumn.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Badge } from '@edx/paragon';
+
+const StatusColumn = ({ row }) => {
+  const { status } = row.original;
+  return (
+    <Badge variant="light">
+      {status}
+    </Badge>
+  );
+};
+
+StatusColumn.propTypes = {
+  row: {
+    original: {
+      status: PropTypes.string.isRequired,
+    }.isRequired,
+  }.isRequired,
+};
+
+export default StatusColumn;

--- a/src/files-and-uploads/table-components/table-custom-columns/ThumbnailColumn.jsx
+++ b/src/files-and-uploads/table-components/table-custom-columns/ThumbnailColumn.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Image, Icon } from '@edx/paragon';
+import { getSrc } from '../../data/utils';
+
+const ThumbnailColumn = ({ row }) => {
+  const {
+    thumbnail,
+    wrapperType,
+    externalUrl,
+  } = row.original;
+
+  const src = getSrc({ thumbnail, wrapperType, externalUrl });
+  return (
+    <div className="row align-items-center justify-content-center m-0 p-3">
+      {thumbnail ? (
+        <Image src={src} style={{ height: '76px', width: '135.71px' }} className="border rounded p-1" />
+      ) : (
+        <div className="row border justify-content-center align-items-center rounded m-0" style={{ height: '76px', width: '135.71px' }}>
+          <Icon src={src} style={{ height: '48px', width: '48px' }} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+ThumbnailColumn.propTypes = {
+  row: {
+    original: {
+      thumbnail: PropTypes.string,
+      wrapperType: PropTypes.string.isRequired,
+      externalUrl: PropTypes.string,
+    }.isRequired,
+  }.isRequired,
+};
+
+export default ThumbnailColumn;

--- a/src/files-and-uploads/table-components/table-custom-columns/index.js
+++ b/src/files-and-uploads/table-components/table-custom-columns/index.js
@@ -1,0 +1,13 @@
+import AccessColumn from './AccessColumn';
+import ActiveColumn from './ActiveColumn';
+import MoreInfoColumn from './MoreInfoColumn';
+import StatusColumn from './StatusColumn';
+import ThumbnailColumn from './ThumbnailColumn';
+
+export {
+  AccessColumn,
+  ActiveColumn,
+  MoreInfoColumn,
+  StatusColumn,
+  ThumbnailColumn,
+};


### PR DESCRIPTION
This PR updates the "list" view of assets to use a table layout. The current version lays the assets out in a list but uses cards to show the asset. With this change, a user can select all the assets in view for a bulk action and more easily sort the table's columns.

Testing

1. Switch to list view and see that the table renders
2. Click the more icon
3. Check that each of the items in menu function as expected.