### PR TITLE
fix: Missed favicon in Safari

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
       <title>Course Authoring | <%= process.env.SITE_NAME %></title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link rel="shortcut icon" href="<%= process.env.FAVICON_URL %>" type="image/x-icon" />
+      <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
### Description

The favicon is not currently displaying in Safari. After our investigation, we have found a way to fix it. We used the same approach as what was done in the account mfe. We changed the favicon inclusion in the index.html file, and now the favicon is being displayed in Safari.

<img width="1840" alt="Снимок экрана 2023-10-17 в 20 09 02" src="https://github.com/openedx/frontend-app-course-authoring/assets/19806032/aad831e2-b5e5-4c70-a68c-42a3b7cbb0ec">