### PR TITLE
fix: fixed issue of unable to call handle submit function on button c…

### DIFF
--- a/src/export-page/CourseExportPage.scss
+++ b/src/export-page/CourseExportPage.scss
@@ -1,8 +1,11 @@
-@import "./export-stepper/ExportStepper";
 @import "./export-footer/ExportFooter";
 
 .export {
   .help-sidebar {
     margin-top: 7.188rem;
+  }
+
+  .pgn__stepper-header-step-list {
+    flex-direction: column;
   }
 }

--- a/src/export-page/export-stepper/ExportStepper.scss
+++ b/src/export-page/export-stepper/ExportStepper.scss
@@ -1,3 +1,0 @@
-.pgn__stepper-header-step-list {
-  flex-direction: column;
-}

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
@@ -27,7 +27,7 @@ const AppConfigFormSaveButton = ({ intl, labelText }) => {
     // cancelable: (optional) a Boolean indicating whether the event can be canceled. The default is false.
     // cancelable: true cancels the untrusted event and safari, chrome cancel the untrusted event by default
     formRef.current.dispatchEvent(new Event('submit', {
-      cancelable: true,
+      cancelable: true, bubbles: true,
     }));
   }, [formRef]);
 


### PR DESCRIPTION
[INF-1139](https://2u-internal.atlassian.net/browse/INF-1139)

**Description**

After updating React and ReactDOM from version 16 to version 17 in the context of this [Pull Request](https://github.com/openedx/frontend-app-course-authoring/pull/514), we encountered an issue with the saving mechanism. The problem arose because the "Save" button in the footer was located outside the form element. In React version 17, when a user clicks the "Save" button, it no longer triggers the onSubmit event handler of the form, unlike in React version 16.

To resolve this issue, we added the "bubbles: true" option when dispatching the event for the form. This change ensures that the event bubbles up through the DOM, making it possible to trigger the onSubmit event handler of the form even when the "Save" button is located outside the form element.

Also Fixed UI glitch because of custom css added for Paragon class in [PR](https://github.com/openedx/frontend-app-course-authoring/pull/586).

**Screenshots**
**Before**

<img width="1792" alt="Screenshot 2023-10-25 at 9 04 51 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/72802712/f2431301-8393-471f-9c83-a3a19cf09a9b">

**After**

<img width="471" alt="Screenshot 2023-10-25 at 9 05 40 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/72802712/5c8eee91-2672-40df-8c66-8aeb038d1deb">

