### PR TITLE
feat: change filter status text

### DIFF
--- a/src/files-and-uploads/FilesAndUploads.jsx
+++ b/src/files-and-uploads/FilesAndUploads.jsx
@@ -42,6 +42,7 @@ import { AccessColumn, MoreInfoColumn, ThumbnailColumn } from './table-component
 import ApiStatusToast from './ApiStatusToast';
 import { clearErrors } from './data/slice';
 import getPageHeadTitle from '../generic/utils';
+import FilterStatus from './table-components/FilterStatus';
 
 const FilesAndUploads = ({
   courseId,
@@ -297,6 +298,7 @@ const FilesAndUploads = ({
           itemCount={totalCount}
           pageCount={Math.ceil(totalCount / 50)}
           data={assets}
+          FilterStatusComponent={FilterStatus}
         >
           {isEmpty(assets) && loadingStatus !== RequestStatus.IN_PROGRESS ? (
             <Dropzone

--- a/src/files-and-uploads/table-components/FilterStatus.jsx
+++ b/src/files-and-uploads/table-components/FilterStatus.jsx
@@ -1,0 +1,70 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { DataTableContext, Button } from '@edx/paragon';
+
+function FilterStatus({
+  className, variant, size, clearFiltersText, buttonClassName, showFilteredFields,
+}) {
+  const { state, setAllFilters, RowStatusComponent, page, rows } = useContext(DataTableContext);
+  if (!setAllFilters) {
+    return null;
+  }
+
+  const RowStatus = RowStatusComponent;
+
+  const pageSize = page?.length || rows?.length;
+
+  return (
+    <div className={className}>
+      <div className="pl-1">
+        <span>Filters applied</span>
+        {!!pageSize && ' ('}
+        <RowStatus className="d-inline" />
+        {!!pageSize && ')'}
+      </div>
+      <Button
+        className={buttonClassName}
+        variant={variant}
+        size={size}
+        onClick={() => setAllFilters([])}
+      >
+        {clearFiltersText === undefined
+          ? (
+            <FormattedMessage
+              id="pgn.DataTable.FilterStatus.clearFiltersText"
+              defaultMessage="Clear filters"
+              description="A text that appears on the `Clear filters` button"
+            />
+          )
+          : clearFiltersText}
+      </Button>
+    </div>
+  );
+}
+
+FilterStatus.defaultProps = {
+  /** Specifies class name to append to the base element. */
+  className: null,
+  /** Specifies class name to append to the button. */
+  buttonClassName: 'pgn__smart-status-button',
+  /** The visual style of the `FilterStatus`. */
+  variant: 'link',
+  /** The size of the `FilterStatus`. */
+  size: 'inline',
+  /** A text that appears on the `Clear filters` button, defaults to 'Clear filters'. */
+  clearFiltersText: undefined,
+  /** Whether to display applied filters. */
+  showFilteredFields: true,
+};
+
+FilterStatus.propTypes = {
+  className: PropTypes.string,
+  buttonClassName: PropTypes.string,
+  variant: PropTypes.string,
+  size: PropTypes.string,
+  clearFiltersText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  showFilteredFields: PropTypes.bool,
+};
+
+export default FilterStatus;

--- a/src/files-and-uploads/table-components/FilterStatus.jsx
+++ b/src/files-and-uploads/table-components/FilterStatus.jsx
@@ -1,12 +1,14 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { DataTableContext, Button } from '@edx/paragon';
 
-function FilterStatus({
-  className, variant, size, clearFiltersText, buttonClassName, showFilteredFields,
-}) {
-  const { state, setAllFilters, RowStatusComponent, page, rows } = useContext(DataTableContext);
+const FilterStatus = ({
+  className, variant, size, clearFiltersText, buttonClassName,
+}) => {
+  const {
+    setAllFilters, RowStatusComponent, page, rows,
+  } = useContext(DataTableContext);
   if (!setAllFilters) {
     return null;
   }
@@ -41,7 +43,7 @@ function FilterStatus({
       </Button>
     </div>
   );
-}
+};
 
 FilterStatus.defaultProps = {
   /** Specifies class name to append to the base element. */
@@ -54,8 +56,6 @@ FilterStatus.defaultProps = {
   size: 'inline',
   /** A text that appears on the `Clear filters` button, defaults to 'Clear filters'. */
   clearFiltersText: undefined,
-  /** Whether to display applied filters. */
-  showFilteredFields: true,
 };
 
 FilterStatus.propTypes = {
@@ -64,7 +64,6 @@ FilterStatus.propTypes = {
   variant: PropTypes.string,
   size: PropTypes.string,
   clearFiltersText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-  showFilteredFields: PropTypes.bool,
 };
 
 export default FilterStatus;


### PR DESCRIPTION
Changed the filter status text on the files and uploads table to display also the number of files, even when a filter is applied.

https://2u-internal.atlassian.net/browse/TNL-11086 (internal ticket)

I just copied most of paragon's `FilterStatus` component, made some adjustments, and then overrode the default component.