### PR TITLE
fix: modal exit redirect

### DIFF
--- a/src/custom-pages/CustomPages.jsx
+++ b/src/custom-pages/CustomPages.jsx
@@ -53,13 +53,11 @@ const CustomPages = ({
   const [orderedPages, setOrderedPages] = useState([]);
   const [currentPage, setCurrentPage] = useState();
   const [isOpen, open, close] = useToggle(false);
-  const [isEditModalOpen, openEditModal, closeEditModal] = useToggle(false);
 
   const courseDetails = useModel('courseDetails', courseId);
   document.title = getPageHeadTitle(courseDetails?.name, intl.formatMessage(messages.heading));
 
   const { config } = useContext(AppContext);
-  const location = useLocation();
   const learningCourseURL = `${config.LEARNING_BASE_URL}/course/${courseId}`;
 
   useEffect(() => {
@@ -79,15 +77,14 @@ const CustomPages = ({
     dispatch(updatePageOrder(courseId, newPageOrder));
   };
   const handleEditClose = () => (content) => {
-    navigate(location.pathname);
+    navigate(`/course/${courseId}/custom-pages`);
     if (!content?.metadata) {
-      closeEditModal();
+      setCurrentPage(null);
       return;
     }
     dispatch(updateSingleCustomPage({
       blockId: currentPage,
       metadata: { displayName: content.metadata.display_name },
-      onClose: closeEditModal,
       setCurrentPage,
     }));
   };
@@ -192,7 +189,6 @@ const CustomPages = ({
                       deletePageStatus,
                       courseId,
                       setCurrentPage,
-                      openEditModal,
                     }}
                   />
                 </SortableItem>
@@ -262,7 +258,6 @@ const CustomPages = ({
               <PageWrap>
                 <EditModal
                   courseId={courseId}
-                  isOpen={isEditModalOpen}
                   pageId={currentPage}
                   onClose={handleEditClose}
                 />

--- a/src/custom-pages/CustomPages.jsx
+++ b/src/custom-pages/CustomPages.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Routes, Route, useLocation, useNavigate,
-} from 'react-router-dom';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppContext, PageWrap } from '@edx/frontend-platform/react';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';


### PR DESCRIPTION
This PR fixes the Custom Page modal not closing on cancel and on close not removing `/editor` from the url.

Testing

1. Navigate to the custom pages.
2. Click the pencil icon to edit a page.
3. Click cancel.
4. Modal should close.
5. Footer and header should display as expected.
6. Edit the same page.
7. Make some edits.
8. Click Save.
9. Modal should close.
10. Footer and header should display as expected.