### PR TITLE
fix: fidelity typo in preference api

### DIFF
--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -199,7 +199,7 @@ export async function setTranscriptPreferences(courseId, preferences) {
     videoSourceLanguage,
   } = preferences;
   const postJson = {
-    cielo24_fideltiy: cielo24Fidelity?.toUpperCase(),
+    cielo24_fidelity: cielo24Fidelity?.toUpperCase(),
     cielo24_turnaround: cielo24Turnaround,
     global,
     preferred_languages: preferredLanguages,

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -345,7 +345,12 @@ export function updateTranscriptPreference({ courseId, data }) {
       dispatch(updateTranscriptPreferenceSuccess(preferences));
       dispatch(updateEditStatus({ editType: 'transcript', status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateErrors({ error: 'transcript', message: `Failed to update ${data.provider} transcripts settings.` }));
+      if (error.response?.data?.error) {
+        const message = error.response.data.error;
+        dispatch(updateErrors({ error: 'transcript', message }));
+      } else {
+        dispatch(updateErrors({ error: 'transcript', message: `Failed to update ${data.provider} transcripts settings.` }));
+      }
       dispatch(updateEditStatus({ editType: 'transcript', status: RequestStatus.FAILED }));
     }
   };

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -541,7 +541,7 @@ describe('TranscriptSettings', () => {
         expect(screen.getByText('Failed to update Cielo24 transcripts settings.')).toBeVisible();
       });
 
-      it('should show error alert wit default message on 3PlayMedia preferences update', async () => {
+      it('should show error alert with default message on 3PlayMedia preferences update', async () => {
         const threePlayButton = screen.getAllByLabelText('3PlayMedia radio')[0];
         await act(async () => {
           userEvent.click(threePlayButton);
@@ -574,7 +574,7 @@ describe('TranscriptSettings', () => {
         expect(screen.getByText('Failed to update 3PlayMedia transcripts settings.')).toBeVisible();
       });
 
-      it('should show error alert wit default message on 3PlayMedia preferences update', async () => {
+      it('should show error alert with default message on 3PlayMedia preferences update', async () => {
         const threePlayButton = screen.getAllByLabelText('3PlayMedia radio')[0];
         await act(async () => {
           userEvent.click(threePlayButton);

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -541,7 +541,7 @@ describe('TranscriptSettings', () => {
         expect(screen.getByText('Failed to update Cielo24 transcripts settings.')).toBeVisible();
       });
 
-      it('should show error alert on 3PlayMedia preferences update', async () => {
+      it('should show error alert wit default message on 3PlayMedia preferences update', async () => {
         const threePlayButton = screen.getAllByLabelText('3PlayMedia radio')[0];
         await act(async () => {
           userEvent.click(threePlayButton);
@@ -572,6 +572,39 @@ describe('TranscriptSettings', () => {
         expect(transcriptStatus).toEqual(RequestStatus.FAILED);
 
         expect(screen.getByText('Failed to update 3PlayMedia transcripts settings.')).toBeVisible();
+      });
+
+      it('should show error alert wit default message on 3PlayMedia preferences update', async () => {
+        const threePlayButton = screen.getAllByLabelText('3PlayMedia radio')[0];
+        await act(async () => {
+          userEvent.click(threePlayButton);
+        });
+        const updateButton = screen.getByText(messages.updateSettingsLabel.defaultMessage);
+        const turnaround = screen.getByText(messages.threePlayMediaTurnaroundPlaceholder.defaultMessage);
+        const source = screen.getByText(messages.threePlayMediaSourceLanguagePlaceholder.defaultMessage);
+
+        await waitFor(() => {
+          userEvent.click(turnaround);
+          userEvent.click(screen.getByText('2 hours'));
+
+          userEvent.click(source);
+          userEvent.click(screen.getByText('Spanish'));
+
+          const language = screen.getByText(messages.threePlayMediaTranscriptLanguagePlaceholder.defaultMessage);
+          userEvent.click(language);
+          userEvent.click(screen.getAllByText('English')[1]);
+        });
+        expect(updateButton).not.toHaveAttribute('disabled');
+
+        axiosMock.onPost(`${getApiBaseUrl()}/transcript_preferences/${courseId}`).reply(404, { error: 'Invalid turnaround.' });
+        await waitFor(() => {
+          userEvent.click(updateButton);
+        });
+        const { transcriptStatus } = store.getState().videos;
+
+        expect(transcriptStatus).toEqual(RequestStatus.FAILED);
+
+        expect(screen.getByText('Invalid turnaround.')).toBeVisible();
       });
     });
   });


### PR DESCRIPTION
This PR fixes the typo in the `transcript_preferences` api. Previous the json passed to the api was 
```
const postJson = {
    cielo24_fideltiy: cielo24Fidelity?.toUpperCase(),
    cielo24_turnaround: cielo24Turnaround,
    global,
    preferred_languages: preferredLanguages,
    provider,
    video_source_language: videoSourceLanguage,
    three_play_turnaround: threePlayTurnaround,
};
```
As a result the api threw an error because it was expecting `cielo24_fidelity` instead of `cielo24_fideltiy`.