### PR TITLE
fix: end date error when certificate row not shown

### DIFF
--- a/src/schedule-and-details/hooks.jsx
+++ b/src/schedule-and-details/hooks.jsx
@@ -9,6 +9,7 @@ import { validateScheduleAndDetails, updateWithDefaultValues } from './utils';
 const useSaveValuesPrompt = (
   courseId,
   updateDataQuery,
+  canShowCertificateAvailableDateField,
   initialEditedData = {},
 ) => {
   const intl = useIntl();
@@ -28,7 +29,7 @@ const useSaveValuesPrompt = (
   }, [initialEditedData]);
 
   useEffect(() => {
-    const errors = validateScheduleAndDetails(editedValues, intl);
+    const errors = validateScheduleAndDetails(editedValues, canShowCertificateAvailableDateField, intl);
     setErrorFields(errors);
   }, [editedValues]);
 

--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -54,22 +54,6 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
   document.title = getPageHeadTitle(course?.name, intl.formatMessage(messages.headingTitle));
 
   const {
-    errorFields,
-    savingStatus,
-    editedValues,
-    isQueryPending,
-    isEditableState,
-    showModifiedAlert,
-    showSuccessfulAlert,
-    dispatch,
-    handleResetValues,
-    handleValuesChange,
-    handleUpdateValues,
-    handleQueryProcessing,
-    handleInternetConnectionFailed,
-  } = useSaveValuesPrompt(courseId, updateCourseDetailsQuery, courseDetails);
-
-  const {
     platformName,
     isCreditCourse,
     upgradeDeadline,
@@ -90,6 +74,27 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     possiblePreRequisiteCourses,
     canShowCertificateAvailableDateField,
   } = courseSettings;
+
+  const {
+    errorFields,
+    savingStatus,
+    editedValues,
+    isQueryPending,
+    isEditableState,
+    showModifiedAlert,
+    showSuccessfulAlert,
+    dispatch,
+    handleResetValues,
+    handleValuesChange,
+    handleUpdateValues,
+    handleQueryProcessing,
+    handleInternetConnectionFailed,
+  } = useSaveValuesPrompt(
+    courseId,
+    updateCourseDetailsQuery,
+    canShowCertificateAvailableDateField,
+    courseDetails,
+  );
 
   const {
     org,

--- a/src/schedule-and-details/utils.js
+++ b/src/schedule-and-details/utils.js
@@ -18,7 +18,7 @@ const isDateBeforeOrEqual = (
   return new Date(dateFormer) <= new Date(dateLatter);
 };
 
-const validateScheduleAndDetails = (courseDetails, intl) => {
+const validateScheduleAndDetails = (courseDetails, canShowCertificateAvailableDate, intl) => {
   const errors = {};
   const {
     endDate,
@@ -34,7 +34,7 @@ const validateScheduleAndDetails = (courseDetails, intl) => {
     errors.startDate = intl.formatMessage(messages.errorMessage7);
   }
 
-  if (isDateBeforeOrEqual(certificateAvailableDate, endDate)) {
+  if (isDateBeforeOrEqual(certificateAvailableDate, endDate) && canShowCertificateAvailableDate) {
     errors.certificateAvailableDate = intl.formatMessage(messages.errorMessage6);
   }
 

--- a/src/schedule-and-details/utils.test.js
+++ b/src/schedule-and-details/utils.test.js
@@ -1,0 +1,294 @@
+import { CERTIFICATE_DISPLAY_BEHAVIOR } from './schedule-section/certificate-display-row';
+import { validateScheduleAndDetails } from './utils';
+
+const intl = { formatMessage: (message) => message };
+
+describe('validateScheduleAndDetails', () => {
+  describe('startDate', () => {
+    it('should return without start date errors', () => {
+      const errors = validateScheduleAndDetails({ startDate: '01/01/1998' }, false, intl);
+      const hasStartDateError = Object.keys(errors).includes('startDate');
+
+      expect(hasStartDateError).toBeFalsy();
+    });
+
+    it('should return with start date error', () => {
+      const errors = validateScheduleAndDetails({ startDate: null }, false, intl);
+      const hasStartDateError = Object.keys(errors).includes('startDate');
+
+      expect(hasStartDateError).toBeTruthy();
+    });
+  });
+
+  describe('endDate', () => {
+    it('should return without end date errors', () => {
+      const errors = validateScheduleAndDetails(
+        { startDate: '01/01/1998', endDate: '01/01/1999' },
+        false,
+        intl,
+      );
+      const hasEndDateError = Object.keys(errors).includes('endDate');
+
+      expect(hasEndDateError).toBeFalsy();
+    });
+
+    it('should return with end date error', () => {
+      const errors = validateScheduleAndDetails(
+        { startDate: '01/01/1998', endDate: '01/01/1997' },
+        false,
+        intl,
+      );
+      const hasEndDateError = Object.keys(errors).includes('endDate');
+
+      expect(hasEndDateError).toBeTruthy();
+    });
+  });
+
+  describe('enrollmentStart', () => {
+    it('should return without enrollment start errors when start dates are equal', () => {
+      const errors = validateScheduleAndDetails(
+        { startDate: '01/01/1998', enrollmentStart: '01/01/1998' },
+        false,
+        intl,
+      );
+      const hasEnrollmentStartError = Object.keys(errors).includes('enrollmentStart');
+
+      expect(hasEnrollmentStartError).toBeFalsy();
+    });
+
+    it('should return without enrollment start error when enrollment start is before course start', () => {
+      const errors = validateScheduleAndDetails(
+        { startDate: '01/01/1999', enrollmentStart: '01/01/1998' },
+        false,
+        intl,
+      );
+      const hasEnrollmentStartError = Object.keys(errors).includes('enrollmentStart');
+
+      expect(hasEnrollmentStartError).toBeFalsy();
+    });
+
+    it('should return without enrollment start error when enrollment start is before enrollment end', () => {
+      const errors = validateScheduleAndDetails(
+        { enrollmentEnd: '01/01/1999', enrollmentStart: '01/01/1998' },
+        false,
+        intl,
+      );
+      const hasEnrollmentStartError = Object.keys(errors).includes('enrollmentStart');
+
+      expect(hasEnrollmentStartError).toBeFalsy();
+    });
+
+    it('should return with enrollment start error when enrolllments starts after course start', () => {
+      const errors = validateScheduleAndDetails(
+        { startDate: '01/01/1998', enrollmentStart: '01/02/1998' },
+        false,
+        intl,
+      );
+      const hasEnrollmentStartError = Object.keys(errors).includes('enrollmentStart');
+
+      expect(hasEnrollmentStartError).toBeTruthy();
+    });
+
+    it('should return with enrollment start error when enrolllments starts after enrollment end', () => {
+      const errors = validateScheduleAndDetails(
+        { enrollmentEnd: '01/01/1998', enrollmentStart: '01/02/1998' },
+        false,
+        intl,
+      );
+      const hasEnrollmentStartError = Object.keys(errors).includes('enrollmentStart');
+
+      expect(hasEnrollmentStartError).toBeTruthy();
+    });
+  });
+
+  describe('enrollmentEnd', () => {
+    it('should return without enrollment start errors when end dates are equal', () => {
+      const errors = validateScheduleAndDetails(
+        { enrollmentEnd: '01/01/1998', endDate: '01/01/1999' },
+        false,
+        intl,
+      );
+      const hasEnrollmentEndError = Object.keys(errors).includes('enrollmentEnd');
+
+      expect(hasEnrollmentEndError).toBeFalsy();
+    });
+
+    it('should return without enrollment start error when enrollment end is before course end', () => {
+      const errors = validateScheduleAndDetails(
+        { enrollmentEnd: '01/01/1998', endDate: '01/01/1999' },
+        false,
+        intl,
+      );
+      const hasEnrollmentEndError = Object.keys(errors).includes('enrollmentEnd');
+
+      expect(hasEnrollmentEndError).toBeFalsy();
+    });
+
+    it('should return with enrollment date error', () => {
+      const errors = validateScheduleAndDetails(
+        { enrollmentEnd: '01/01/1998', endDate: '01/01/1997' },
+        false,
+        intl,
+      );
+      const hasEnrollmentEndError = Object.keys(errors).includes('enrollmentEnd');
+
+      expect(hasEnrollmentEndError).toBeTruthy();
+    });
+  });
+
+  describe('certificateAvailableDate', () => {
+    describe('with canShowCertificateAvailableDate false', () => {
+      it('should return without certificate available errors when dates are vaild', () => {
+        const errors = validateScheduleAndDetails(
+          { certificateAvailableDate: '01/01/1999', endDate: '01/01/1998' },
+          false,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+
+      it('should return without certificate available errors when dates are invaild', () => {
+        const errors = validateScheduleAndDetails(
+          { certificateAvailableDate: '01/01/1997', endDate: '01/01/1998' },
+          false,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+    });
+
+    describe('with canShowCertificateAvailableDate true', () => {
+      it('should return without certificate available errors when dates are vaild', () => {
+        const errors = validateScheduleAndDetails(
+          { certificateAvailableDate: '01/01/1999', endDate: '01/01/1998' },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+
+      it('should return with certificate available error', () => {
+        const errors = validateScheduleAndDetails(
+          { certificateAvailableDate: '01/01/1997', endDate: '01/01/1998' },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeTruthy();
+      });
+    });
+
+    describe('with certificatesDisplayBehavior equal to end_with_date', () => {
+      it('should return without certificate available errors when date has a value', () => {
+        const errors = validateScheduleAndDetails(
+          {
+            certificateAvailableDate: '01/01/1999',
+            certificatesDisplayBehavior: CERTIFICATE_DISPLAY_BEHAVIOR.endWithDate,
+          },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+
+      it('should return with certificate available errors when date is empty', () => {
+        const errors = validateScheduleAndDetails(
+          {
+            certificateAvailableDate: '',
+            certificatesDisplayBehavior: CERTIFICATE_DISPLAY_BEHAVIOR.endWithDate,
+          },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeTruthy();
+      });
+    });
+
+    describe('with canShowCertificateAvailableDate not equal to end_with_date', () => {
+      it('should return without certificate available errors when date is empty', () => {
+        const errors = validateScheduleAndDetails(
+          {
+            certificateAvailableDate: '',
+            certificatesDisplayBehavior: CERTIFICATE_DISPLAY_BEHAVIOR.end,
+          },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+
+      it('should return without certificate available errors when date is empty', () => {
+        const errors = validateScheduleAndDetails(
+          {
+            certificateAvailableDate: '',
+            certificatesDisplayBehavior: CERTIFICATE_DISPLAY_BEHAVIOR.earlyNoInfo,
+          },
+          true,
+          intl,
+        );
+        const hasCertificateAvailableError = Object.keys(errors).includes('certificateAvailableDate');
+
+        expect(hasCertificateAvailableError).toBeFalsy();
+      });
+    });
+  });
+
+  describe('entranceExamMinimumScore', () => {
+    it('should return without exam minimum score errors', () => {
+      const errors = validateScheduleAndDetails(
+        { entranceExamMinimumScorePct: '25' },
+        false,
+        intl,
+      );
+      const hasExamMinimumScoreError = Object.keys(errors).includes('entranceExamMinimumScorePct');
+
+      expect(hasExamMinimumScoreError).toBeFalsy();
+    });
+
+    it('should return with exam minimum score error with negative value', () => {
+      const errors = validateScheduleAndDetails(
+        { entranceExamMinimumScorePct: '-1' },
+        false,
+        intl,
+      );
+      const hasExamMinimumScoreError = Object.keys(errors).includes('entranceExamMinimumScorePct');
+
+      expect(hasExamMinimumScoreError).toBeTruthy();
+    });
+
+    it('should return with exam minimum score error with value greater than 100', () => {
+      const errors = validateScheduleAndDetails(
+        { entranceExamMinimumScorePct: '230' },
+        false,
+        intl,
+      );
+      const hasExamMinimumScoreError = Object.keys(errors).includes('entranceExamMinimumScorePct');
+
+      expect(hasExamMinimumScoreError).toBeTruthy();
+    });
+
+    it('should return with exam minimum score error with non-numerical value', () => {
+      const errors = validateScheduleAndDetails(
+        { entranceExamMinimumScorePct: 'test' },
+        false,
+        intl,
+      );
+      const hasExamMinimumScoreError = Object.keys(errors).includes('entranceExamMinimumScorePct');
+
+      expect(hasExamMinimumScoreError).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
JIRA Ticket: [TNL-11164](https://2u-internal.atlassian.net/browse/TNL-11164)

>The Schedule and details page shows a permanent "You've made some changes, but there are some errors". Not sure what the issue is, but the old experience does not have the same issue.

The validator for the Schedule and details page checks if the course end date is after the certificate available date. There is a default certificate available date, but is not shown to users unless the certificate row is displayed. The error message is only shown in the certificate row, so the user is notified of the error in the parent alert but not the details of the error. Now the validator only checks for the compatibility of the end date and certificate available date when the certificate row is displayed.

Testing
1. Navigate to the Schedule and details page.
2. Fill out the course end date.
3. Alert warning at the bottom of the screen should say that changes have been made and allow you to save.
4. Enable the WaffleSwitch `certificates.auto_certificate_generation`.
5. Reload the Schedule and details page.
6. Certificate available row should be visible.
7. Fill out the course end date with a date after the certificate available date.
8. Error should appear in the certificate row.
9. Alert warning at the bottom of the screen should say that changes have been made with errors and saving is disabled.