### PR TITLE
[ROLES-26] Helper function for ingesting permission data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "enzyme": "3.11.0",
         "enzyme-to-json": "^3.6.2",
         "glob": "7.2.3",
-        "husky": "^7.0.4",
+        "husky": "7.0.4",
         "jest-canvas-mock": "^2.5.2",
         "react-test-renderer": "17.0.2",
         "reactifex": "1.1.1",
@@ -192,11 +192,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dependencies": {
-        "@babel/types": "^7.23.3",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -526,15 +526,9 @@
       }
     },
     "node_modules/@babel/parser": {
-<<<<<<< HEAD
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
       "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-=======
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
->>>>>>> 5c3ba38... chore: add feature flag api
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1872,32 +1866,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-<<<<<<< HEAD
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
-=======
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
->>>>>>> 5c3ba38... chore: add feature flag api
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-<<<<<<< HEAD
         "@babel/parser": "^7.23.0",
         "@babel/types": "^7.23.0",
-=======
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
->>>>>>> 5c3ba38... chore: add feature flag api
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1906,9 +1886,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -6121,17 +6101,6 @@
         "react": "^17.0.0-0"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
->>>>>>> 5c3ba38... chore: add feature flag api
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -10752,16 +10721,10 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
-<<<<<<< HEAD
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
       "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
       "peer": true,
-=======
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
->>>>>>> 5c3ba38... chore: add feature flag api
       "engines": {
         "node": ">=14.16"
       }
@@ -24310,15 +24273,9 @@
       "license": "MIT"
     },
     "node_modules/tinymce": {
-<<<<<<< HEAD
       "version": "5.10.9",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.9.tgz",
       "integrity": "sha512-5bkrors87X9LhYX2xq8GgPHrIgJYHl87YNs+kBcjQ5I3CiUgzo/vFcGvT3MZQ9QHsEeYMhYO6a5CLGGffR8hMg=="
-=======
-      "version": "5.10.8",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.8.tgz",
-      "integrity": "sha512-iyoo3VGMAJhLMDdblAefKvYgBRk9kQi58GTwAmoieqsyggGsKZWlQl/YY6nTILFHUCA1FhYu0HdmM5YYjs17UQ=="
->>>>>>> 5c3ba38... chore: add feature flag api
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,11 +192,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -526,9 +526,15 @@
       }
     },
     "node_modules/@babel/parser": {
+<<<<<<< HEAD
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
       "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+=======
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+>>>>>>> 5c3ba38... chore: add feature flag api
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1866,18 +1872,32 @@
       }
     },
     "node_modules/@babel/traverse": {
+<<<<<<< HEAD
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
+=======
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+>>>>>>> 5c3ba38... chore: add feature flag api
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
+<<<<<<< HEAD
         "@babel/parser": "^7.23.0",
         "@babel/types": "^7.23.0",
+=======
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
+>>>>>>> 5c3ba38... chore: add feature flag api
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1886,9 +1906,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -6101,6 +6121,17 @@
         "react": "^17.0.0-0"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+>>>>>>> 5c3ba38... chore: add feature flag api
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -10721,10 +10752,16 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
+<<<<<<< HEAD
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
       "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
       "peer": true,
+=======
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+>>>>>>> 5c3ba38... chore: add feature flag api
       "engines": {
         "node": ">=14.16"
       }
@@ -24273,9 +24310,15 @@
       "license": "MIT"
     },
     "node_modules/tinymce": {
+<<<<<<< HEAD
       "version": "5.10.9",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.9.tgz",
       "integrity": "sha512-5bkrors87X9LhYX2xq8GgPHrIgJYHl87YNs+kBcjQ5I3CiUgzo/vFcGvT3MZQ9QHsEeYMhYO6a5CLGGffR8hMg=="
+=======
+      "version": "5.10.8",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.8.tgz",
+      "integrity": "sha512-iyoo3VGMAJhLMDdblAefKvYgBRk9kQi58GTwAmoieqsyggGsKZWlQl/YY6nTILFHUCA1FhYu0HdmM5YYjs17UQ=="
+>>>>>>> 5c3ba38... chore: add feature flag api
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "enzyme": "3.11.0",
         "enzyme-to-json": "^3.6.2",
         "glob": "7.2.3",
-        "husky": "7.0.4",
+        "husky": "^7.0.4",
         "jest-canvas-mock": "^2.5.2",
         "react-test-renderer": "17.0.2",
         "reactifex": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "enzyme": "3.11.0",
     "enzyme-to-json": "^3.6.2",
     "glob": "7.2.3",
-    "husky": "7.0.4",
+    "husky": "^7.0.4",
     "jest-canvas-mock": "^2.5.2",
     "react-test-renderer": "17.0.2",
     "reactifex": "1.1.1",

--- a/src/course-team/CourseTeam.jsx
+++ b/src/course-team/CourseTeam.jsx
@@ -24,7 +24,6 @@ import getPageHeadTitle from '../generic/utils';
 const CourseTeam = ({ courseId }) => {
   const intl = useIntl();
   const courseDetails = useModel('courseDetails', courseId);
-
   document.title = getPageHeadTitle(courseDetails?.name, intl.formatMessage(messages.headingTitle));
 
   const {

--- a/src/course-team/CourseTeam.jsx
+++ b/src/course-team/CourseTeam.jsx
@@ -18,13 +18,13 @@ import AddUserForm from './add-user-form/AddUserForm';
 import AddTeamMember from './add-team-member/AddTeamMember';
 import CourseTeamMember from './course-team-member/CourseTeamMember';
 import InfoModal from './info-modal/InfoModal';
-import { useCourseTeam } from './hooks';
+import { useCourseTeam, useUserPermissions } from './hooks';
 import getPageHeadTitle from '../generic/utils';
 
 const CourseTeam = ({ courseId }) => {
   const intl = useIntl();
-
   const courseDetails = useModel('courseDetails', courseId);
+
   document.title = getPageHeadTitle(courseDetails?.name, intl.formatMessage(messages.headingTitle));
 
   const {
@@ -55,6 +55,12 @@ const CourseTeam = ({ courseId }) => {
     handleInternetConnectionFailed,
   } = useCourseTeam({ intl, courseId });
 
+  const {
+    hasPermissions,
+  } = useUserPermissions();
+
+  const hasManageAllUsersPerm = hasPermissions('manage_all_users');
+
   if (isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <></>;
@@ -77,7 +83,7 @@ const CourseTeam = ({ courseId }) => {
                   <SubHeader
                     title={intl.formatMessage(messages.headingTitle)}
                     subtitle={intl.formatMessage(messages.headingSubtitle)}
-                    headerActions={isAllowActions && (
+                    headerActions={isAllowActions && hasManageAllUsersPerm && (
                       <Button
                         variant="primary"
                         iconBefore={IconAdd}
@@ -104,13 +110,13 @@ const CourseTeam = ({ courseId }) => {
                           role={role}
                           email={email}
                           currentUserEmail={currentUserEmail || ''}
-                          isAllowActions={isAllowActions}
+                          isAllowActions={isAllowActions && hasManageAllUsersPerm}
                           isHideActions={role === USER_ROLES.admin && isSingleAdmin}
                           onChangeRole={handleChangeRoleUserSubmit}
                           onDelete={handleOpenDeleteModal}
                         />
                       )) : null}
-                      {isShowAddTeamMember && (
+                      {isShowAddTeamMember && hasManageAllUsersPerm && (
                         <AddTeamMember
                           onFormOpen={openForm}
                           isButtonDisable={isFormVisible}

--- a/src/course-team/CourseTeam.jsx
+++ b/src/course-team/CourseTeam.jsx
@@ -83,7 +83,7 @@ const CourseTeam = ({ courseId }) => {
                   <SubHeader
                     title={intl.formatMessage(messages.headingTitle)}
                     subtitle={intl.formatMessage(messages.headingSubtitle)}
-                    headerActions={isAllowActions && hasManageAllUsersPerm && (
+                    headerActions={(isAllowActions || hasManageAllUsersPerm) && (
                       <Button
                         variant="primary"
                         iconBefore={IconAdd}
@@ -110,13 +110,13 @@ const CourseTeam = ({ courseId }) => {
                           role={role}
                           email={email}
                           currentUserEmail={currentUserEmail || ''}
-                          isAllowActions={isAllowActions && hasManageAllUsersPerm}
+                          isAllowActions={isAllowActions || hasManageAllUsersPerm}
                           isHideActions={role === USER_ROLES.admin && isSingleAdmin}
                           onChangeRole={handleChangeRoleUserSubmit}
                           onDelete={handleOpenDeleteModal}
                         />
                       )) : null}
-                      {isShowAddTeamMember && hasManageAllUsersPerm && (
+                      {(isShowAddTeamMember || hasManageAllUsersPerm) && (
                         <AddTeamMember
                           onFormOpen={openForm}
                           isButtonDisable={isFormVisible}

--- a/src/course-team/CourseTeam.test.jsx
+++ b/src/course-team/CourseTeam.test.jsx
@@ -180,7 +180,7 @@ describe('<CourseTeam />', () => {
     });
   });
 
-  it('not displays "Add New Member" and AddTeamMember component when isAllowActions is false', async () => {
+  it('not displays "Add New Member" and AddTeamMember component when isAllowActions or hasManageAllUsersPerm is false', async () => {
     cleanup();
     axiosMock
       .onGet(getCourseTeamApiUrl(courseId))
@@ -192,31 +192,11 @@ describe('<CourseTeam />', () => {
       .onGet(getUserPermissionsEnabledFlagUrl)
       .reply(200, { enabled: false });
 
-    const { queryByRole, queryByText } = render(<RootWrapper />);
+    const { queryByRole, queryByTestId } = render(<RootWrapper />);
 
     await waitFor(() => {
       expect(queryByRole('button', { name: messages.addNewMemberButton.defaultMessage })).not.toBeInTheDocument();
-      expect(queryByText('add-team-member')).not.toBeInTheDocument();
-    });
-  });
-
-  it('not displays "Add New Member" and AddTeamMember component when hasManageAllUsersPerm is false', async () => {
-    cleanup();
-    axiosMock
-      .onGet(getCourseTeamApiUrl(courseId))
-      .reply(200, {
-        ...courseTeamWithOneUser,
-        allowActions: false,
-      });
-    axiosMock
-      .onGet(getUserPermissionsEnabledFlagUrl)
-      .reply(200, { enabled: false });
-
-    const { queryByRole, queryByText } = render(<RootWrapper />);
-
-    await waitFor(() => {
-      expect(queryByRole('button', { name: messages.addNewMemberButton.defaultMessage })).not.toBeInTheDocument();
-      expect(queryByText('add-team-member')).not.toBeInTheDocument();
+      expect(queryByTestId('add-team-member')).not.toBeInTheDocument();
     });
   });
 

--- a/src/course-team/CourseTeam.test.jsx
+++ b/src/course-team/CourseTeam.test.jsx
@@ -14,7 +14,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import initializeStore from '../store';
 import { courseTeamMock, courseTeamWithOneUser, courseTeamWithoutUsers } from './__mocks__';
 import { getCourseTeamApiUrl, updateCourseTeamUserApiUrl } from './data/api';
-import { getUserPermissionsUrl } from '../generic/data/api';
+import { getUserPermissionsUrl, getUserPermissionsEnabledFlagUrl } from '../generic/data/api';
 import CourseTeam from './CourseTeam';
 import messages from './messages';
 import { USER_ROLES } from '../constants';
@@ -26,7 +26,7 @@ let store;
 const mockPathname = '/foo-bar';
 const courseId = '123';
 const userId = 3;
-const UserPermissionsData = { permissions: ['manage_all_users'] };
+const userPermissionsData = { permissions: ['manage_all_users'] };
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -57,8 +57,11 @@ describe('<CourseTeam />', () => {
     store = initializeStore();
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     axiosMock
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: true });
+    axiosMock
       .onGet(getUserPermissionsUrl(courseId, userId))
-      .reply(200, UserPermissionsData);
+      .reply(200, userPermissionsData);
   });
 
   it('render CourseTeam component with 3 team members correctly', async () => {
@@ -185,6 +188,9 @@ describe('<CourseTeam />', () => {
         ...courseTeamWithOneUser,
         allowActions: false,
       });
+    axiosMock
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: false });
 
     const { queryByRole, queryByText } = render(<RootWrapper />);
 
@@ -198,10 +204,13 @@ describe('<CourseTeam />', () => {
     cleanup();
     axiosMock
       .onGet(getCourseTeamApiUrl(courseId))
-      .reply(200, courseTeamWithOneUser);
+      .reply(200, {
+        ...courseTeamWithOneUser,
+        allowActions: false,
+      });
     axiosMock
-      .onGet(getUserPermissionsUrl(courseId, userId))
-      .reply(200, { permissions: [] });
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: false });
 
     const { queryByRole, queryByText } = render(<RootWrapper />);
 

--- a/src/course-team/course-team-member/CourseTeamMember.jsx
+++ b/src/course-team/course-team-member/CourseTeamMember.jsx
@@ -9,7 +9,6 @@ import {
   MailtoLink,
 } from '@edx/paragon';
 import { DeleteOutline } from '@edx/paragon/icons';
-import { useUserPermissions } from '../hooks';
 
 import messages from './messages';
 import { USER_ROLES, BADGE_STATES } from '../constants';
@@ -28,18 +27,11 @@ const CourseTeamMember = ({
   const isAdminRole = role === USER_ROLES.admin;
   const badgeColor = isAdminRole ? BADGE_STATES.admin : BADGE_STATES.staff;
 
-  const {
-    hasPermissions,
-  } = useUserPermissions();
-
-  const hasManageAllUsersPerm = hasPermissions('manage-all-users');
-
-  console.log({ hasManageAllUsersPermission: hasPermissions('manage-all-users') });
   return (
     <div className="course-team-member" data-testid="course-team-member">
       <div className="member-info">
         <Badge className={`badge-current-user bg-${badgeColor} text-light-100`}>
-          {(hasManageAllUsersPerm || isAdminRole)
+          {(isAdminRole)
             ? intl.formatMessage(messages.roleAdmin)
             : intl.formatMessage(messages.roleStaff)}
           {currentUserEmail === email && (
@@ -54,11 +46,11 @@ const CourseTeamMember = ({
         !isHideActions ? (
           <div className="member-actions">
             <Button
-              variant={(hasManageAllUsersPerm || isAdminRole) ? 'tertiary' : 'primary'}
+              variant={(isAdminRole) ? 'tertiary' : 'primary'}
               size="sm"
               onClick={() => onChangeRole(email, isAdminRole ? USER_ROLES.staff : USER_ROLES.admin)}
             >
-              {(hasManageAllUsersPerm || isAdminRole)
+              {(isAdminRole)
                 ? intl.formatMessage(messages.removeButton)
                 : intl.formatMessage(messages.addButton)}
             </Button>

--- a/src/course-team/course-team-member/CourseTeamMember.jsx
+++ b/src/course-team/course-team-member/CourseTeamMember.jsx
@@ -9,6 +9,7 @@ import {
   MailtoLink,
 } from '@edx/paragon';
 import { DeleteOutline } from '@edx/paragon/icons';
+import { useUserPermissions } from '../hooks';
 
 import messages from './messages';
 import { USER_ROLES, BADGE_STATES } from '../constants';
@@ -27,11 +28,18 @@ const CourseTeamMember = ({
   const isAdminRole = role === USER_ROLES.admin;
   const badgeColor = isAdminRole ? BADGE_STATES.admin : BADGE_STATES.staff;
 
+  const {
+    hasPermissions,
+  } = useUserPermissions();
+
+  const hasManageAllUsersPerm = hasPermissions('manage-all-users');
+
+  console.log({ hasManageAllUsersPermission: hasPermissions('manage-all-users') });
   return (
     <div className="course-team-member" data-testid="course-team-member">
       <div className="member-info">
         <Badge className={`badge-current-user bg-${badgeColor} text-light-100`}>
-          {isAdminRole
+          {(hasManageAllUsersPerm || isAdminRole)
             ? intl.formatMessage(messages.roleAdmin)
             : intl.formatMessage(messages.roleStaff)}
           {currentUserEmail === email && (
@@ -46,11 +54,13 @@ const CourseTeamMember = ({
         !isHideActions ? (
           <div className="member-actions">
             <Button
-              variant={isAdminRole ? 'tertiary' : 'primary'}
+              variant={(hasManageAllUsersPerm || isAdminRole) ? 'tertiary' : 'primary'}
               size="sm"
               onClick={() => onChangeRole(email, isAdminRole ? USER_ROLES.staff : USER_ROLES.admin)}
             >
-              {isAdminRole ? intl.formatMessage(messages.removeButton) : intl.formatMessage(messages.addButton)}
+              {(hasManageAllUsersPerm || isAdminRole)
+                ? intl.formatMessage(messages.removeButton)
+                : intl.formatMessage(messages.addButton)}
             </Button>
             <IconButtonWithTooltip
               src={DeleteOutline}

--- a/src/course-team/hooks.jsx
+++ b/src/course-team/hooks.jsx
@@ -6,6 +6,8 @@ import { useToggle } from '@edx/paragon';
 import { USER_ROLES } from '../constants';
 import { RequestStatus } from '../data/constants';
 import { useModel } from '../generic/model-store';
+import { fetchUserPermissionsQuery } from '../generic/data/thunks';
+import { getUserPermissions } from '../generic/data/selectors';
 import {
   changeRoleTeamUserQuery,
   createCourseTeamQuery,
@@ -96,6 +98,7 @@ const useCourseTeam = ({ courseId }) => {
 
   useEffect(() => {
     dispatch(fetchCourseTeamQuery(courseId));
+    dispatch(fetchUserPermissionsQuery(courseId));
   }, [courseId]);
 
   useEffect(() => {
@@ -136,14 +139,8 @@ const useCourseTeam = ({ courseId }) => {
 };
 
 const useUserPermissions = () => {
-  const { userId } = getAuthenticatedUser();
-
-  const hasPermissions = (check) => {
-    // New endpoint for getting user permissions
-
-    console.log({ userId, check });
-    return true;
-  };
+  const userPermissions = useSelector(getUserPermissions);
+  const hasPermissions = (checkPermissions) => userPermissions?.includes(checkPermissions);
 
   return {
     hasPermissions,

--- a/src/course-team/hooks.jsx
+++ b/src/course-team/hooks.jsx
@@ -135,5 +135,20 @@ const useCourseTeam = ({ courseId }) => {
   };
 };
 
+const useUserPermissions = () => {
+  const { userId } = getAuthenticatedUser();
+
+  const hasPermissions = (check) => {
+    // New endpoint for getting user permissions
+
+    console.log({ userId, check });
+    return true;
+  };
+
+  return {
+    hasPermissions,
+  };
+};
+
 // eslint-disable-next-line import/prefer-default-export
-export { useCourseTeam };
+export { useCourseTeam, useUserPermissions };

--- a/src/course-team/hooks.jsx
+++ b/src/course-team/hooks.jsx
@@ -6,8 +6,8 @@ import { useToggle } from '@edx/paragon';
 import { USER_ROLES } from '../constants';
 import { RequestStatus } from '../data/constants';
 import { useModel } from '../generic/model-store';
-import { fetchUserPermissionsQuery } from '../generic/data/thunks';
-import { getUserPermissions } from '../generic/data/selectors';
+import { fetchUserPermissionsQuery, fetchUserPermissionsEnabledFlag } from '../generic/data/thunks';
+import { getUserPermissions, getUserPermissionsEnabled } from '../generic/data/selectors';
 import {
   changeRoleTeamUserQuery,
   createCourseTeamQuery,
@@ -98,6 +98,7 @@ const useCourseTeam = ({ courseId }) => {
 
   useEffect(() => {
     dispatch(fetchCourseTeamQuery(courseId));
+    dispatch(fetchUserPermissionsEnabledFlag());
     dispatch(fetchUserPermissionsQuery(courseId));
   }, [courseId]);
 
@@ -139,8 +140,14 @@ const useCourseTeam = ({ courseId }) => {
 };
 
 const useUserPermissions = () => {
+  const userPermissionsEnabled = useSelector(getUserPermissionsEnabled);
   const userPermissions = useSelector(getUserPermissions);
-  const hasPermissions = (checkPermissions) => userPermissions?.includes(checkPermissions);
+  const hasPermissions = (checkPermissions) => {
+    if (userPermissionsEnabled) {
+      return userPermissions?.includes(checkPermissions);
+    }
+    return false;
+  };
 
   return {
     hasPermissions,

--- a/src/generic/data/api.js
+++ b/src/generic/data/api.js
@@ -1,5 +1,5 @@
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import { convertObjectToSnakeCase } from '../../utils';
 
@@ -7,6 +7,7 @@ export const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
 export const getCreateOrRerunCourseUrl = () => new URL('course/', getApiBaseUrl()).href;
 export const getCourseRerunUrl = (courseId) => new URL(`/api/contentstore/v1/course_rerun/${courseId}`, getApiBaseUrl()).href;
 export const getOrganizationsUrl = () => new URL('organizations', getApiBaseUrl()).href;
+export const getUserPermissionsUrl = (courseId, userId) => `${getApiBaseUrl()}/api/course_roles/v1/user_permissions/?course_id=${encodeURIComponent(courseId)}&user_id=${userId}`;
 
 /**
  * Get's organizations data.
@@ -40,5 +41,19 @@ export async function createOrRerunCourse(courseData) {
     getCreateOrRerunCourseUrl(),
     convertObjectToSnakeCase(courseData, true),
   );
+  return camelCaseObject(data);
+}
+
+/**
+ * Get user course roles permissions.
+ * @param {string} courseId
+ * @param {string} userId
+ * @returns {Promise<Object>}
+ */
+export async function getUserPermissions(courseId) {
+  const { userId } = getAuthenticatedUser();
+
+  const { data } = await getAuthenticatedHttpClient()
+    .get(getUserPermissionsUrl(courseId, userId));
   return camelCaseObject(data);
 }

--- a/src/generic/data/api.js
+++ b/src/generic/data/api.js
@@ -8,7 +8,7 @@ export const getCreateOrRerunCourseUrl = () => new URL('course/', getApiBaseUrl(
 export const getCourseRerunUrl = (courseId) => new URL(`/api/contentstore/v1/course_rerun/${courseId}`, getApiBaseUrl()).href;
 export const getOrganizationsUrl = () => new URL('organizations', getApiBaseUrl()).href;
 export const getUserPermissionsUrl = (courseId, userId) => `${getApiBaseUrl()}/api/course_roles/v1/user_permissions/?course_id=${encodeURIComponent(courseId)}&user_id=${userId}`;
-
+export const getUserPermissionsEnabledFlagUrl = new URL('/api/course_roles/v1/user_permissions/enabled/', getApiBaseUrl()).href;
 /**
  * Get's organizations data.
  * @returns {Promise<Object>}
@@ -56,4 +56,10 @@ export async function getUserPermissions(courseId) {
   const { data } = await getAuthenticatedHttpClient()
     .get(getUserPermissionsUrl(courseId, userId));
   return camelCaseObject(data);
+}
+
+export async function getUserPermissionsEnabledFlag() {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(getUserPermissionsEnabledFlagUrl);
+  return data || false;
 }

--- a/src/generic/data/api.test.js
+++ b/src/generic/data/api.test.js
@@ -26,6 +26,7 @@ describe('generic api calls', () => {
         roles: [],
       },
       userPermissions: [],
+      userPermissionsEnabled: false,
     });
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
   });

--- a/src/generic/data/api.test.js
+++ b/src/generic/data/api.test.js
@@ -9,9 +9,12 @@ import {
   getCreateOrRerunCourseUrl,
   getCourseRerunUrl,
   getCourseRerun,
+  getUserPermissions,
+  getUserPermissionsUrl,
 } from './api';
 
 let axiosMock;
+const courseId = 'course-123';
 
 describe('generic api calls', () => {
   beforeEach(() => {
@@ -22,6 +25,7 @@ describe('generic api calls', () => {
         administrator: true,
         roles: [],
       },
+      userPermissions: [],
     });
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
   });
@@ -41,7 +45,6 @@ describe('generic api calls', () => {
   });
 
   it('should get course rerun', async () => {
-    const courseId = 'course-mock-id';
     const courseRerunData = {
       allowUnicodeCourseId: false,
       courseCreatorStatus: 'granted',
@@ -71,5 +74,15 @@ describe('generic api calls', () => {
 
     expect(axiosMock.history.post[0].url).toEqual(getCreateOrRerunCourseUrl());
     expect(result).toEqual(courseRerunData);
+  });
+
+  it('should get user permissions', async () => {
+    const permissionsData = { permissions: ['manage_all_users'] };
+    const queryUrl = getUserPermissionsUrl(courseId, 3);
+    axiosMock.onGet(queryUrl).reply(200, permissionsData);
+    const result = await getUserPermissions(courseId);
+
+    expect(axiosMock.history.get[0].url).toEqual(queryUrl);
+    expect(result).toEqual(permissionsData);
   });
 });

--- a/src/generic/data/api.test.js
+++ b/src/generic/data/api.test.js
@@ -11,6 +11,8 @@ import {
   getCourseRerun,
   getUserPermissions,
   getUserPermissionsUrl,
+  getUserPermissionsEnabledFlag,
+  getUserPermissionsEnabledFlagUrl,
 } from './api';
 
 let axiosMock;
@@ -85,5 +87,15 @@ describe('generic api calls', () => {
 
     expect(axiosMock.history.get[0].url).toEqual(queryUrl);
     expect(result).toEqual(permissionsData);
+  });
+
+  it('should get user permissions enabled flag', async () => {
+    const permissionsEnabledData = { enabled: true };
+    const queryUrl = getUserPermissionsEnabledFlagUrl;
+    axiosMock.onGet(queryUrl).reply(200, permissionsEnabledData);
+    const result = await getUserPermissionsEnabledFlag();
+
+    expect(axiosMock.history.get[0].url).toEqual(queryUrl);
+    expect(result).toEqual(permissionsEnabledData);
   });
 });

--- a/src/generic/data/selectors.js
+++ b/src/generic/data/selectors.js
@@ -5,3 +5,4 @@ export const getCourseData = (state) => state.generic.createOrRerunCourse.course
 export const getCourseRerunData = (state) => state.generic.createOrRerunCourse.courseRerunData;
 export const getRedirectUrlObj = (state) => state.generic.createOrRerunCourse.redirectUrlObj;
 export const getPostErrors = (state) => state.generic.createOrRerunCourse.postErrors;
+export const getUserPermissions = (state) => state.generic.userPermissions.permissions;

--- a/src/generic/data/selectors.js
+++ b/src/generic/data/selectors.js
@@ -6,3 +6,4 @@ export const getCourseRerunData = (state) => state.generic.createOrRerunCourse.c
 export const getRedirectUrlObj = (state) => state.generic.createOrRerunCourse.redirectUrlObj;
 export const getPostErrors = (state) => state.generic.createOrRerunCourse.postErrors;
 export const getUserPermissions = (state) => state.generic.userPermissions.permissions;
+export const getUserPermissionsEnabled = (state) => state.generic.userPermissionsEnabled;

--- a/src/generic/data/slice.js
+++ b/src/generic/data/slice.js
@@ -9,6 +9,8 @@ const slice = createSlice({
     loadingStatuses: {
       organizationLoadingStatus: RequestStatus.IN_PROGRESS,
       courseRerunLoadingStatus: RequestStatus.IN_PROGRESS,
+      userPermissionsLoadingStatus: RequestStatus.IN_PROGRESS,
+      userPermissionsEnabledLoadingStatus: RequestStatus.IN_PROGRESS,
     },
     savingStatus: '',
     organizations: [],

--- a/src/generic/data/slice.js
+++ b/src/generic/data/slice.js
@@ -18,6 +18,7 @@ const slice = createSlice({
       redirectUrlObj: {},
       postErrors: {},
     },
+    userPermissions: [],
   },
   reducers: {
     fetchOrganizations: (state, { payload }) => {
@@ -41,6 +42,9 @@ const slice = createSlice({
     updatePostErrors: (state, { payload }) => {
       state.createOrRerunCourse.postErrors = payload;
     },
+    updateUserPermissions: (state, { payload }) => {
+      state.userPermissions = payload;
+    },
   },
 });
 
@@ -52,6 +56,7 @@ export const {
   updateSavingStatus,
   updateCourseData,
   updateRedirectUrlObj,
+  updateUserPermissions,
 } = slice.actions;
 
 export const {

--- a/src/generic/data/slice.js
+++ b/src/generic/data/slice.js
@@ -19,6 +19,7 @@ const slice = createSlice({
       postErrors: {},
     },
     userPermissions: [],
+    userPermissionsEnabled: false,
   },
   reducers: {
     fetchOrganizations: (state, { payload }) => {
@@ -45,6 +46,9 @@ const slice = createSlice({
     updateUserPermissions: (state, { payload }) => {
       state.userPermissions = payload;
     },
+    updateUserPermissionsEnabled: (state, { payload }) => {
+      state.userPermissionsEnabled = payload;
+    },
   },
 });
 
@@ -57,6 +61,7 @@ export const {
   updateCourseData,
   updateRedirectUrlObj,
   updateUserPermissions,
+  updateUserPermissionsEnabled,
 } = slice.actions;
 
 export const {

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -59,8 +59,9 @@ export function fetchUserPermissionsQuery(courseId) {
     try {
       const userPermissions = await getUserPermissions(courseId);
       dispatch(updateUserPermissions(userPermissions));
+      dispatch(updateLoadingStatuses({ userPermissionsLoadingStatus: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      console.trace({ error }); // eslint-disable-line no-console
+      dispatch(updateLoadingStatuses({ userPermissionsLoadingStatus: RequestStatus.FAILED }));
     }
   };
 }
@@ -70,9 +71,10 @@ export function fetchUserPermissionsEnabledFlag() {
     try {
       const data = await getUserPermissionsEnabledFlag();
       dispatch(updateUserPermissionsEnabled(data.enabled || false));
+      dispatch(updateLoadingStatuses({ userPermissionsEnabledLoadingStatus: RequestStatus.SUCCESSFUL }));
     } catch (error) {
       dispatch(updateUserPermissionsEnabled(false));
-      console.trace({ error }); // eslint-disable-line no-console
+      dispatch(updateLoadingStatuses({ userPermissionsEnabledLoadingStatus: RequestStatus.FAILED }));
     }
   };
 }

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -1,6 +1,6 @@
 import { RequestStatus } from '../../data/constants';
 import {
-  createOrRerunCourse, getOrganizations, getCourseRerun, getUserPermissions,
+  createOrRerunCourse, getOrganizations, getCourseRerun, getUserPermissions, getUserPermissionsEnabledFlag,
 } from './api';
 import {
   fetchOrganizations,
@@ -10,6 +10,7 @@ import {
   updateCourseRerunData,
   updateSavingStatus,
   updateUserPermissions,
+  updateUserPermissionsEnabled,
 } from './slice';
 
 export function fetchOrganizationsQuery() {
@@ -60,6 +61,18 @@ export function fetchUserPermissionsQuery(courseId) {
       dispatch(updateUserPermissions(userPermissions));
     } catch (error) {
       console.trace({ error }); // eslint-disable-line no-console
+    }
+  };
+}
+
+export function fetchUserPermissionsEnabledFlag() {
+  return async (dispatch) => {
+    try {
+      const data = await getUserPermissionsEnabledFlag();
+      dispatch(updateUserPermissionsEnabled(data.enabled || false));
+    } catch (error) {
+      dispatch(updateUserPermissionsEnabled(false));
+      console.trace({ error });
     }
   };
 }

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -72,7 +72,7 @@ export function fetchUserPermissionsEnabledFlag() {
       dispatch(updateUserPermissionsEnabled(data.enabled || false));
     } catch (error) {
       dispatch(updateUserPermissionsEnabled(false));
-      console.trace({ error });
+      console.trace({ error }); // eslint-disable-line no-console
     }
   };
 }

--- a/src/generic/data/thunks.js
+++ b/src/generic/data/thunks.js
@@ -1,5 +1,7 @@
 import { RequestStatus } from '../../data/constants';
-import { createOrRerunCourse, getOrganizations, getCourseRerun } from './api';
+import {
+  createOrRerunCourse, getOrganizations, getCourseRerun, getUserPermissions,
+} from './api';
 import {
   fetchOrganizations,
   updatePostErrors,
@@ -7,6 +9,7 @@ import {
   updateRedirectUrlObj,
   updateCourseRerunData,
   updateSavingStatus,
+  updateUserPermissions,
 } from './slice';
 
 export function fetchOrganizationsQuery() {
@@ -46,6 +49,17 @@ export function updateCreateOrRerunCourseQuery(courseData) {
     } catch (error) {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
+    }
+  };
+}
+
+export function fetchUserPermissionsQuery(courseId) {
+  return async (dispatch) => {
+    try {
+      const userPermissions = await getUserPermissions(courseId);
+      dispatch(updateUserPermissions(userPermissions));
+    } catch (error) {
+      console.trace({ error }); // eslint-disable-line no-console
     }
   };
 }


### PR DESCRIPTION
### Background 

This PR is to fetch the new (LoggedIn) User Permissions from the endpoint `/api/course_roles/v1/user_permissions/`.

### Changes done
- Add new function on generic data `api, slice, selector and thunk`
- Add a new hook for handling the permissions in the `CourseTeam` component.
- Add `UserPermissionsEnabledFlag` 
- Add specs


### Testing instructions
To test this code please use this branch for course-authoring and ROLES-2-course_roles_setup for edx-platform

1. Go to LMS admin and enable/create these waffle flags:
 - `contentstore.new_studio_mfe.use_new_course_team_page`
 - `course_roles.use_permission_checks`

2. Go to a Demo Course as a user with proper access to view CourseTeams in the CMS

3. **As LoggedIn Admin** (Same behavior as current):
  - You should see the *+ New team member* and *+ Add a new team member* buttons (Since we're using the `hasManageAllUsersPerm` as part of the condition [OR]).

4. **As a LoggedIn User**: 
- You'll have to disable `allow_actions` from this file `cms/djangoapps/contentstore/utils.py:1366` (you can hardcode this for testing).
- Enable `course_roles.use_permission_checks` flag enabled
- Enable the `manage_all_users` permission from this file `openedx/core/djangoapps/course_roles/views.py:49` (you can hardcode `'permissions': ['manage_all_users']`).
- You should still see:
  - *Course Team Members cards* 
  - *+ New team member* button
  - *+ Add a new team member* button