### PR TITLE
fix: opt out is not supported by lti proctoring

### DIFF
--- a/src/pages-and-resources/proctoring/Settings.jsx
+++ b/src/pages-and-resources/proctoring/Settings.jsx
@@ -350,7 +350,7 @@ const ProctoringSettings = ({ intl, onClose }) => {
         )}
 
         {/* ALLOW OPTING OUT OF PROCTORED EXAMS */}
-        { isEdxStaff && formValues.enableProctoredExams && (
+        { isEdxStaff && formValues.enableProctoredExams && !isLtiProvider(formValues.proctoringProvider) && (
           <fieldset aria-describedby="allowOptingOutHelpText">
             <Form.Group controlId="formAllowingOptingOut">
               <Form.Label as="legend" className="font-weight-bold">
@@ -358,6 +358,7 @@ const ProctoringSettings = ({ intl, onClose }) => {
               </Form.Label>
               <Form.RadioSet
                 name="allowOptingOut"
+                data-testid="allowOptingOutRadio"
                 value={formValues.allowOptingOut.toString()}
                 onChange={handleChange}
               >

--- a/src/pages-and-resources/proctoring/Settings.test.jsx
+++ b/src/pages-and-resources/proctoring/Settings.test.jsx
@@ -197,6 +197,7 @@ describe('ProctoredExamSettings', () => {
         fireEvent.change(selectElement, { target: { value: 'test_lti' } });
       });
       expect(screen.queryByTestId('escalationEmail')).toBeNull();
+      expect(screen.queryByTestId('allowOptingOutRadio')).toBeNull();
       expect(screen.queryByTestId('createZendeskTicketsYes')).toBeNull();
       expect(screen.queryByTestId('createZendeskTicketsNo')).toBeNull();
     });


### PR DESCRIPTION
This toggle does nothing if an LTI tool is selected. We should hide it in that case.

### 2U JIRA: [COSMO-56](https://2u-internal.atlassian.net/browse/COSMO-56?atlOrigin=eyJpIjoiNTFjMmQ2MTc3ODg5NDkxNWIwZWY4YjhkOGJkZDQ3ZDciLCJwIjoiaiJ9)