### PR TITLE
fix: active transcript preference not loading

### DIFF
--- a/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
@@ -37,7 +37,7 @@ const OrderTranscriptForm = ({
   }, [data]);
 
   const handleDiscard = () => {
-    setTranscriptType(activeTranscriptPreferences);
+    setTranscriptType(activeTranscriptPreferences?.provider);
     closeTranscriptSettings();
   };
 
@@ -147,7 +147,14 @@ const OrderTranscriptForm = ({
 
 OrderTranscriptForm.propTypes = {
   setTranscriptType: PropTypes.func.isRequired,
-  activeTranscriptPreferences: PropTypes.shape({}),
+  activeTranscriptPreferences: PropTypes.shape({
+    provider: PropTypes.string.isRequired,
+    cielo24Turnaround: PropTypes.string,
+    cielo24Fidelity: PropTypes.string,
+    preferredLanguages: PropTypes.arrayOf(PropTypes.string),
+    turnaround: PropTypes.string,
+    videoSourceLanguage: PropTypes.string,
+  }),
   transcriptType: PropTypes.string.isRequired,
   transcriptCredentials: PropTypes.shape({
     cielo24: PropTypes.bool.isRequired,

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -33,7 +33,7 @@ const TranscriptSettings = ({
     videoTranscriptSettings,
   } = pageSettings;
   const { transcriptionPlans } = videoTranscriptSettings || {};
-  const [transcriptType, setTranscriptType] = useState(activeTranscriptPreferences);
+  const [transcriptType, setTranscriptType] = useState(activeTranscriptPreferences?.provider);
 
   const handleOrderTranscripts = (data, provider) => {
     const noCredentials = isEmpty(transcriptCredentials) || data.apiKey;

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -111,7 +111,7 @@ describe('TranscriptSettings', () => {
     });
   });
 
-  describe('delete transcript preferences', () => {
+  describe('loading saved preference', () => {
     beforeEach(async () => {
       initializeMockApp({
         authenticatedUser: {
@@ -143,17 +143,53 @@ describe('TranscriptSettings', () => {
       renderComponent(defaultProps);
     });
 
-    it('api should succeed', async () => {
+    it('should load page with Cielo24 selected', async () => {
       const cielo24Button = screen.getByText(messages.cieloLabel.defaultMessage);
 
       expect(within(cielo24Button).getByLabelText('Cielo24 radio')).toHaveProperty('checked', true);
+    });
 
-      const updateButton = screen.getByText(messages.updateSettingsLabel.defaultMessage);
+  });
+
+  describe('delete transcript preferences', () => {
+    beforeEach(async () => {
+      initializeMockApp({
+        authenticatedUser: {
+          userId: 3,
+          username: 'abc123',
+          administrator: false,
+          roles: [],
+        },
+      });
+      store = initializeStore({
+        ...initialState,
+        videos: {
+          ...initialState.videos,
+          pageSettings: {
+            ...initialState.videos.pageSettings,
+            activeTranscriptPreferences: {
+              provider: 'Cielo24',
+              cielo24Fidelity: '',
+              cielo24Turnaround: '',
+              preferredLanguages: [],
+              threePlayTurnaround: '',
+              videoSourceLanguage: '',
+            },
+          },
+        },
+      });
+      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+      renderComponent(defaultProps);
       const noneButton = screen.getAllByLabelText('none radio')[0];
 
       await act(async () => {
         userEvent.click(noneButton);
       });
+    });
+
+    it('api should succeed', async () => {
+      const updateButton = screen.getByText(messages.updateSettingsLabel.defaultMessage);
 
       axiosMock.onDelete(`${getApiBaseUrl()}/transcript_preferences/${courseId}`).reply(204);
       await waitFor(() => {
@@ -166,11 +202,6 @@ describe('TranscriptSettings', () => {
 
     it('should show error alert', async () => {
       const updateButton = screen.getByText(messages.updateSettingsLabel.defaultMessage);
-      const noneButton = screen.getAllByLabelText('none radio')[0];
-
-      await act(async () => {
-        userEvent.click(noneButton);
-      });
 
       axiosMock.onDelete(`${getApiBaseUrl()}/transcript_preferences/${courseId}`).reply(404);
       await waitFor(() => {

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -148,7 +148,6 @@ describe('TranscriptSettings', () => {
 
       expect(within(cielo24Button).getByLabelText('Cielo24 radio')).toHaveProperty('checked', true);
     });
-
   });
 
   describe('delete transcript preferences', () => {


### PR DESCRIPTION
JIRA Ticket: [TNL-11199](https://2u-internal.atlassian.net/browse/TNL-11199)

> Transcript Settings panel does not automatically select the option with saved values when they exist
> Shows
> ![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/89558afe-4693-411f-8303-50918aee8c85)

This PR corrects the loading of the active transcript preferences. Previously the selected transcript option was given the full object of preferences instead of the provider so none of the options were selected on load. Now the correct option is selected when the settings are loaded.

Testing (locally)

*Will need to be fully tested in stage environment where the video pipeline is fully enabled

1. Replace (Lines 30 -34, `TranscriptSettings.jsx`)
```
const {
    activeTranscriptPreferences,
    transcriptCredentials,
    videoTranscriptSettings,
  } = pageSettings;
```
with
```
const {
    transcriptCredentials,
    videoTranscriptSettings,
} = pageSettings;
const activeTranscriptPreferences = {
    provider: 'Cielo 24',
    cielo24Fidelity: '',
    cielo24Turnaround: '',
    preferredLanguages: [],
    threePlayTurnaround: '',
    videoSourceLanguage: '',
};
```
2. Navigate to the Videos page
3. Click "Transcript settings"
4. Setting overlay should load with "Cielo24" selected
5. Undo code change
6. Reload page
7. Click "Transcript settings"
8. Setting overlay should load with "Order transcripts" button

