### PR TITLE
fix: table search filter

### DIFF
--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
@@ -58,7 +58,7 @@ export const getCheckedFilters = (state) => {
     if (isArray(updatedValues)) {
       allFilters.push(...updatedValues);
     } else {
-      allFilters.push(['displayName', updatedValues]);
+      allFilters.push([id, updatedValues]);
     }
   });
 

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isArray, isEmpty } from 'lodash';
 
 export const getFilterOptions = (columns) => {
   const allOptions = [];
@@ -37,7 +37,6 @@ export const getFilterOptions = (columns) => {
 export const getCheckedFilters = (state) => {
   const { filters } = state;
   const allFilters = [];
-
   filters.forEach(filter => {
     const { id, value } = filter;
     let updatedValues = value;
@@ -56,7 +55,11 @@ export const getCheckedFilters = (state) => {
       break;
     }
 
-    allFilters.push(...updatedValues);
+    if (isArray(updatedValues)) {
+      allFilters.push(...updatedValues);
+    } else {
+      allFilters.push(['displayName', updatedValues]);
+    }
   });
 
   return allFilters;
@@ -65,6 +68,12 @@ export const getCheckedFilters = (state) => {
 export const processFilters = (filters, columns, setAllFilters) => {
   const filterableColumns = columns.filter(column => column?.filterChoices);
   const allFilters = [];
+
+  const [displayNameFilter] = filters.filter(filter => isArray(filter));
+  if (displayNameFilter) {
+    const [id, filterValue] = displayNameFilter;
+    allFilters.push({ id, value: [filterValue] });
+  }
 
   filterableColumns.forEach(({ id, filterChoices }) => {
     const filterValues = filterChoices.map(choice => choice.value);

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
@@ -93,7 +93,6 @@ describe('getCheckboxFilters', () => {
     });
   });
 
-
   describe('filter with serach bar', () => {
     it('should equal array in array with displayName and value', () => {
       const state = {

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
@@ -92,6 +92,19 @@ describe('getCheckboxFilters', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+
+  describe('filter with serach bar', () => {
+    it('should equal array in array with displayName and value', () => {
+      const state = {
+        filters: [{ id: 'displayName', value: 'filter' }],
+      };
+      const expected = [['displayName', 'filter']];
+      const actual = getCheckedFilters(state);
+
+      expect(actual).toEqual(expected);
+    });
+  });
 });
 
 describe('getFilterOptions', () => {

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/utils.test.js
@@ -301,4 +301,17 @@ describe('processFilters', () => {
       expect(setAllFilters).toHaveBeenCalledWith(expectedParameter);
     });
   });
+
+  describe('filter with serach bar', () => {
+    it('should call setAllFitlers with displayName filter', () => {
+      const filters = [['displayName', 'search']];
+      const columns = [
+        { id: 'test', filterChoices: [{ name: 'Filter', value: 'filter' }] },
+      ];
+      const expectedParameter = [{ id: 'displayName', value: ['search'] }];
+      processFilters(filters, columns, setAllFilters);
+
+      expect(setAllFilters).toHaveBeenCalledWith(expectedParameter);
+    });
+  });
 });

--- a/src/files-and-videos/generic/table-components/utils.js
+++ b/src/files-and-videos/generic/table-components/utils.js
@@ -15,10 +15,12 @@ export const getFilters = (state, columns) => {
   const { filters } = state;
   const filterableColumns = columns.filter(column => column?.filterChoices);
   const allFilters = [];
+
   filters.forEach(filter => {
     const { id, value } = filter;
     const [filterColumn] = filterableColumns.filter(column => column.id === id);
     let currentFilters;
+  
     if (filterColumn) {
       currentFilters = getFilterDisplayName(filterColumn, value);
     } else {
@@ -27,6 +29,7 @@ export const getFilters = (state, columns) => {
     }
     allFilters.push(...currentFilters);
   });
+
   return allFilters;
 };
 

--- a/src/files-and-videos/generic/table-components/utils.js
+++ b/src/files-and-videos/generic/table-components/utils.js
@@ -33,7 +33,7 @@ export const getFilters = (state, columns) => {
 export const removeFilter = (filter, setFilter, setAllFilters, state) => {
   const { filters } = state;
   const [editedFilter] = filters.filter(currentFilter => currentFilter.value.includes(filter));
-  console.log(filters[0].value, filter);
+
   let updatedFilterValue;
   if (isArray(editedFilter?.value)) {
     updatedFilterValue = editedFilter.value.filter(value => value !== filter);

--- a/src/files-and-videos/generic/table-components/utils.js
+++ b/src/files-and-videos/generic/table-components/utils.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, isArray } from 'lodash';
 import messages from '../messages';
 
 const getFilterDisplayName = (column, values) => {
@@ -18,7 +18,12 @@ export const getFilters = (state, columns) => {
   filters.forEach(filter => {
     const { id, value } = filter;
     const [filterColumn] = filterableColumns.filter(column => column.id === id);
-    const currentFilters = getFilterDisplayName(filterColumn, value);
+    let currentFilters;
+    if (filterColumn) {
+      currentFilters = getFilterDisplayName(filterColumn, value);
+    } else {
+      currentFilters = [{ name: value, value }];
+    }
     allFilters.push(...currentFilters);
   });
   return allFilters;
@@ -27,7 +32,14 @@ export const getFilters = (state, columns) => {
 export const removeFilter = (filter, setFilter, setAllFilters, state) => {
   const { filters } = state;
   const [editedFilter] = filters.filter(currentFilter => currentFilter.value.includes(filter));
-  const updatedFilterValue = editedFilter.value.filter(value => value !== filter);
+
+  let updatedFilterValue;
+  if (isArray(editedFilter.value)) {
+    updatedFilterValue = editedFilter.value.filter(value => value !== filter);
+  } else {
+    updatedFilterValue = filter.includes(editedFilter.value) ? [] : editedFilter.value;
+  }
+
   if (isEmpty(updatedFilterValue)) {
     const updatedFilters = filters.filter(currentFilter => currentFilter.id !== editedFilter.id);
     setAllFilters(updatedFilters);

--- a/src/files-and-videos/generic/table-components/utils.js
+++ b/src/files-and-videos/generic/table-components/utils.js
@@ -20,7 +20,7 @@ export const getFilters = (state, columns) => {
     const { id, value } = filter;
     const [filterColumn] = filterableColumns.filter(column => column.id === id);
     let currentFilters;
-  
+
     if (filterColumn) {
       currentFilters = getFilterDisplayName(filterColumn, value);
     } else {

--- a/src/files-and-videos/generic/table-components/utils.js
+++ b/src/files-and-videos/generic/table-components/utils.js
@@ -22,7 +22,8 @@ export const getFilters = (state, columns) => {
     if (filterColumn) {
       currentFilters = getFilterDisplayName(filterColumn, value);
     } else {
-      currentFilters = [{ name: value, value }];
+      const [serachValue] = value;
+      currentFilters = [{ name: serachValue, value: serachValue }];
     }
     allFilters.push(...currentFilters);
   });
@@ -32,12 +33,12 @@ export const getFilters = (state, columns) => {
 export const removeFilter = (filter, setFilter, setAllFilters, state) => {
   const { filters } = state;
   const [editedFilter] = filters.filter(currentFilter => currentFilter.value.includes(filter));
-
+  console.log(filters[0].value, filter);
   let updatedFilterValue;
-  if (isArray(editedFilter.value)) {
+  if (isArray(editedFilter?.value)) {
     updatedFilterValue = editedFilter.value.filter(value => value !== filter);
   } else {
-    updatedFilterValue = filter.includes(editedFilter.value) ? [] : editedFilter.value;
+    updatedFilterValue = filter.includes(editedFilter?.value) ? [] : editedFilter.value;
   }
 
   if (isEmpty(updatedFilterValue)) {

--- a/src/files-and-videos/generic/table-components/utils.test.js
+++ b/src/files-and-videos/generic/table-components/utils.test.js
@@ -1,0 +1,107 @@
+import { getCurrentViewRange, getFilters, removeFilter } from './utils';
+
+describe('getCurrentViewRange', () => {
+  const intl = {
+    formatMessage: (name, { fileCount, rowCount }) => (
+      `Showing ${fileCount} of ${rowCount}`
+    ),
+  };
+  it('should return with intials row count', () => {
+    const data = {
+      filterRowCount: 25,
+      initialRowCount: 25,
+      fileCount: 12,
+      intl,
+    };
+    const expected = 'Showing 12 of 25';
+    const actual = getCurrentViewRange(data);
+
+    expect(actual).toEqual(expected);
+  });
+  it('should return with filter row count', () => {
+    const data = {
+      filterRowCount: 12,
+      initialRowCount: 25,
+      fileCount: 12,
+      intl,
+    };
+    const expected = 'Showing 12 of 12';
+    const actual = getCurrentViewRange(data);
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('getFilters', () => {
+  it('should return filter when columns is empty', () => {
+    const state = { filters: [{ id: 'test', value: 'unknown' }] };
+    const columns = [];
+    const expected = [{ name: 'unknown', value: 'unknown' }];
+    const actual = getFilters(state, columns);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return filtern for specific column', () => {
+    const state = { filters: [{ id: 'validColumn', value: ['filter1'] }] };
+    const columns = [{
+      id: 'validColumn',
+      filterChoices: [
+        { name: 'Filter 1', value: 'filter1' },
+        { name: 'Filter 2', value: 'filter2' },
+      ],
+    }];
+    const expected = [{ name: 'Filter 1', value: 'filter1' }];
+    const acutal = getFilters(state, columns);
+
+    expect(acutal).toEqual(expected);
+  });
+});
+
+describe('removeFilter', () => {
+  const setAllFilters = jest.fn();
+  const setFilter = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('state filter.value is an array', () => {
+    it('should call setAllFilters', () => {
+      const state = {
+        filters: [
+          { id: 'test', value: ['filter1'] },
+        ],
+      };
+      const filter = 'filter1';
+      removeFilter(filter, setFilter, setAllFilters, state);
+
+      expect(setAllFilters).toHaveBeenCalled();
+    });
+
+    it('should call setFilter', () => {
+      const state = {
+        filters: [
+          { id: 'test', value: ['filter1', 'filter2'] },
+        ],
+      };
+      const filter = 'filter1';
+      removeFilter(filter, setFilter, setAllFilters, state);
+
+      expect(setFilter).toHaveBeenCalled();
+    });
+  });
+  describe('state filter.value is not an array', () => {
+    it('should call setAllFilters', () => {
+      const state = {
+        filters: [
+          { id: 'test', value: 'filter1' },
+        ],
+      };
+      const filter = 'filter1';
+      removeFilter(filter, setFilter, setAllFilters, state);
+
+      expect(setAllFilters).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/files-and-videos/generic/table-components/utils.test.js
+++ b/src/files-and-videos/generic/table-components/utils.test.js
@@ -34,7 +34,7 @@ describe('getCurrentViewRange', () => {
 
 describe('getFilters', () => {
   it('should return filter when columns is empty', () => {
-    const state = { filters: [{ id: 'test', value: 'unknown' }] };
+    const state = { filters: [{ id: 'test', value: ['unknown'] }] };
     const columns = [];
     const expected = [{ name: 'unknown', value: 'unknown' }];
     const actual = getFilters(state, columns);

--- a/src/files-and-videos/generic/table-components/utils.test.js
+++ b/src/files-and-videos/generic/table-components/utils.test.js
@@ -6,6 +6,7 @@ describe('getCurrentViewRange', () => {
       `Showing ${fileCount} of ${rowCount}`
     ),
   };
+
   it('should return with intials row count', () => {
     const data = {
       filterRowCount: 25,
@@ -18,6 +19,7 @@ describe('getCurrentViewRange', () => {
 
     expect(actual).toEqual(expected);
   });
+
   it('should return with filter row count', () => {
     const data = {
       filterRowCount: 12,


### PR DESCRIPTION
JIRA Ticket: [TNL-11207](https://2u-internal.atlassian.net/browse/TNL-11207)

> I get an error if typing anything into search box. Typing one letter leads to error page.
> ![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/2e22cdd3-535b-4fbe-8d0e-b62bd8c4c9f6)

When making the updates to the filter function for display chips and modal, the search bar's filter capabilities were not accounted for. The search bar filters are not associated with a specific column, so when using it and error was thrown because the matching column could not be found. The filter functions now account for when there is not an associated column for the search filter.

Testing

1. Navigate to the Files page.
2. Type something in the search bar
3. A chip with a matching string should appear
4. Files should filter as expected
5. Open the Sort and filter modal
6. Select one of the filters and apply
7. Chips should show selected filter and search string
8. Remove each of the chip individually
9. All the files should be listed
* repeat for the videos page