### PR TITLE
fix: remove unnecessary course-v1 from courseId string

### DIFF
--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -44,7 +44,7 @@ export const getSettingMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
     title: intl.formatMessage(messages['header.links.courseTeam']),
   },
   {
-    href: `${studioBaseUrl}/group_configurations/course-v1:${courseId}`,
+    href: `${studioBaseUrl}/group_configurations/${courseId}`,
     title: intl.formatMessage(messages['header.links.groupConfigurations']),
   },
   {


### PR DESCRIPTION
### Description
This PR removes an extra `course-v1` in the Group Configurations href:

https://github.com/openedx/frontend-app-course-authoring/assets/64440265/3169c70c-9336-44bd-8bfc-b9a6ca4027e8


