### PR TITLE
fix: pagination style

### DIFF
--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -25,9 +25,9 @@ import {
   RowStatus,
   MoreInfoColumn,
   FilterStatus,
+  Footer,
 } from './table-components';
 import ApiStatusToast from './ApiStatusToast';
-import Footer from './table-components/Footer';
 
 const FileTable = ({
   files,

--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -27,6 +27,7 @@ import {
   FilterStatus,
 } from './table-components';
 import ApiStatusToast from './ApiStatusToast';
+import Footer from './table-components/Footer';
 
 const FileTable = ({
   files,
@@ -216,10 +217,10 @@ const FileTable = ({
           <div data-testid="files-data-table" className="bg-light-200">
             <DataTable.TableControlBar />
             <hr className="mb-5 border-light-700" />
-            { currentView === 'card' && <CardView CardComponent={fileCard} columnSizes={columnSizes} selectionPlacement="left" skeletonCardCount={5} /> }
+            { currentView === 'card' && <CardView CardComponent={fileCard} columnSizes={columnSizes} selectionPlacement="left" skeletonCardCount={6} /> }
             { currentView === 'list' && <DataTable.Table /> }
             <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFoundMessage)} />
-            <DataTable.TableFooter />
+            <Footer />
           </div>
         )}
 

--- a/src/files-and-videos/generic/table-components/Footer.jsx
+++ b/src/files-and-videos/generic/table-components/Footer.jsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { DataTableContext, Pagination, TableFooter } from '@edx/paragon';
+
+const Footer = () => {
+  const { pageOptions, pageCount, gotoPage, state } = useContext(DataTableContext);
+
+
+  if (pageOptions.length < 2) {
+    return null;
+  }
+
+  const pageIndex = state?.pageIndex;
+
+  return (
+    <TableFooter>
+      <Pagination
+        size="small"
+        currentPage={pageIndex + 1}
+        pageCount={pageCount}
+        paginationLabel="table pagination"
+        onPageSelect={(pageNum) => gotoPage(pageNum - 1)}
+      />
+    </TableFooter>
+  );
+};
+
+export default Footer;

--- a/src/files-and-videos/generic/table-components/Footer.jsx
+++ b/src/files-and-videos/generic/table-components/Footer.jsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
 import { DataTableContext, Pagination, TableFooter } from '@edx/paragon';
 
 const Footer = () => {
-  const { pageOptions, pageCount, gotoPage, state } = useContext(DataTableContext);
-
+  const {
+    pageOptions, pageCount, gotoPage, state,
+  } = useContext(DataTableContext);
 
   if (pageOptions.length < 2) {
     return null;

--- a/src/files-and-videos/generic/table-components/index.js
+++ b/src/files-and-videos/generic/table-components/index.js
@@ -2,6 +2,7 @@ import GalleryCard from './GalleryCard';
 import TableActions from './TableActions';
 import FilterStatus from './FilterStatus';
 import RowStatus from './RowStatus';
+import Footer from './Footer';
 import {
   AccessColumn,
   ActiveColumn,
@@ -15,6 +16,7 @@ export {
   GalleryCard,
   FilterStatus,
   RowStatus,
+  Footer,
   AccessColumn,
   ActiveColumn,
   MoreInfoColumn,

--- a/src/files-and-videos/index.scss
+++ b/src/files-and-videos/index.scss
@@ -3,13 +3,19 @@
 @import "files-and-videos/generic/table-components/GalleryCard";
 
 .files-table {
+
   #table-filters-dropdown {
     visibility: hidden;
   }
 
-  .pgn__data-table-layout-main {
-    background-color: $light-200;
+  .pgn__data-table-layout-wrapper {
+    overflow-x: visible;
+  }
 
+  .pgn__data-table-wrapper {
+    background-color: $light-200;
+    box-shadow: 0 0 0 #000;
+  
     .pgn__data-table-status-bar {
       padding: 12px 0;
 
@@ -25,6 +31,11 @@
         padding: 0 24px 24px 0;
         margin-bottom: 0;
       }
+    }
+
+    .pgn__data-table-footer {
+      border-top: none;
+      justify-content: center;
     }
   }
 

--- a/src/files-and-videos/index.scss
+++ b/src/files-and-videos/index.scss
@@ -3,7 +3,6 @@
 @import "files-and-videos/generic/table-components/GalleryCard";
 
 .files-table {
-
   #table-filters-dropdown {
     visibility: hidden;
   }
@@ -14,8 +13,8 @@
 
   .pgn__data-table-wrapper {
     background-color: $light-200;
-    box-shadow: 0 0 0 #000;
-  
+    box-shadow: 0 0 0;
+
     .pgn__data-table-status-bar {
       padding: 12px 0;
 

--- a/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/TranscriptTab.jsx
@@ -99,7 +99,7 @@ const TranscriptTab = ({
 
   return (
     <Stack gap={3}>
-      <div ref={divRef} style={{ overflowY: 'scroll', height: '310px' }} className="px-1 py-2">
+      <div ref={divRef} style={{ overflowY: 'auto', maxHeight: '310px' }} className="px-1 py-2">
         <ErrorAlert
           hideHeading={false}
           isError={transcriptStatus === RequestStatus.FAILED && !isEmpty(errors.transcript)}

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -82,7 +82,7 @@ const Transcript = ({
           key={`transcript-${language}`}
           data-testid={`transcript-${language}`}
         >
-          <div className="col-10 p-0">
+          <div className="col-9 p-0">
             <LanguageSelect
               options={languages}
               value={newLanguage}


### PR DESCRIPTION
JIRA Ticket: [TNL-11033](https://2u-internal.atlassian.net/browse/TNL-11033)

The default pagination style for the `DataTable` footer is the minimal and reduced variants of the `Pagination` component. Now the Files and Videos pages use the default variant for pagination.

Before
![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/f1eff622-2856-46b7-89fe-f5582fcf349b)

After
![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/c49a04af-6dfe-44c6-a904-d2d1bb87e630)
