### PR TITLE
feat: original fetch to includes usage metrics

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.test.jsx
+++ b/src/files-and-videos/files-page/FilesPage.test.jsx
@@ -356,7 +356,7 @@ describe('FilesAndUploads', () => {
         expect(assetMenuButton).toBeVisible();
 
         axiosMock.onPut(`${getAssetsUrl(courseId)}mOckID1`).reply(201, { locked: false });
-        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usage_locations: { 'mOckID1': [] } });
+        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usage_locations: { mOckID1: [] } });
         await waitFor(() => {
           fireEvent.click(within(assetMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByText('Info'));

--- a/src/files-and-videos/files-page/FilesPage.test.jsx
+++ b/src/files-and-videos/files-page/FilesPage.test.jsx
@@ -331,7 +331,7 @@ describe('FilesAndUploads', () => {
         const assetMenuButton = screen.getByTestId('file-menu-dropdown-mOckID1');
         expect(assetMenuButton).toBeVisible();
 
-        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usageLocations: ['subsection - unit / block'] });
+        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usage_locations: { mOckID1: ['subsection - unit / block'] } });
         await waitFor(() => {
           fireEvent.click(within(assetMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByText('Info'));
@@ -356,7 +356,7 @@ describe('FilesAndUploads', () => {
         expect(assetMenuButton).toBeVisible();
 
         axiosMock.onPut(`${getAssetsUrl(courseId)}mOckID1`).reply(201, { locked: false });
-        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usageLocations: [] });
+        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usage_locations: { 'mOckID1': [] } });
         await waitFor(() => {
           fireEvent.click(within(assetMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByText('Info'));

--- a/src/files-and-videos/files-page/data/api.js
+++ b/src/files-and-videos/files-page/data/api.js
@@ -82,7 +82,8 @@ export async function getDownload(selectedRows, courseId) {
 export async function getAssetUsagePaths({ courseId, assetId }) {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getAssetsUrl(courseId)}${assetId}/usage`);
-  return camelCaseObject(data);
+  const { usage_locations: usageLocations } = data;
+  return { usageLocations };
 }
 
 /**

--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -132,15 +132,18 @@ export function getUsagePaths({ asset, courseId }) {
 
     try {
       const { usageLocations } = await getAssetUsagePaths({ assetId: asset.id, courseId });
+      console.log(usageLocations);
+      const assetLocations = usageLocations[asset.id];
       dispatch(updateModel({
         modelType: 'assets',
         model: {
           id: asset.id,
-          usageLocations,
+          usageLocations: assetLocations,
         },
       }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
+      console.log(error);
       dispatch(updateErrors({ error: 'usageMetrics', message: `Failed to get usage metrics for ${asset.displayName}.` }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.FAILED }));
     }

--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -132,7 +132,6 @@ export function getUsagePaths({ asset, courseId }) {
 
     try {
       const { usageLocations } = await getAssetUsagePaths({ assetId: asset.id, courseId });
-      console.log(usageLocations);
       const assetLocations = usageLocations[asset.id];
       dispatch(updateModel({
         modelType: 'assets',
@@ -143,7 +142,6 @@ export function getUsagePaths({ asset, courseId }) {
       }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      console.log(error);
       dispatch(updateErrors({ error: 'usageMetrics', message: `Failed to get usage metrics for ${asset.displayName}.` }));
       dispatch(updateEditStatus({ editType: 'usageMetrics', status: RequestStatus.FAILED }));
     }

--- a/src/files-and-videos/files-page/data/utils.js
+++ b/src/files-and-videos/files-page/data/utils.js
@@ -32,7 +32,6 @@ export const updateFileValues = (files) => {
       ...file,
       wrapperType,
       dateAdded: utcDateTime,
-      usageLocations: [],
     });
   });
 

--- a/src/files-and-videos/generic/EditFileErrors.jsx
+++ b/src/files-and-videos/generic/EditFileErrors.jsx
@@ -74,7 +74,6 @@ EditFileErrors.propTypes = {
     delete: PropTypes.arrayOf(PropTypes.string).isRequired,
     lock: PropTypes.arrayOf(PropTypes.string),
     download: PropTypes.arrayOf(PropTypes.string).isRequired,
-    usageMetrics: PropTypes.arrayOf(PropTypes.string).isRequired,
     thumbnail: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   addFileStatus: PropTypes.string.isRequired,

--- a/src/files-and-videos/videos-page/data/utils.js
+++ b/src/files-and-videos/videos-page/data/utils.js
@@ -43,7 +43,6 @@ export const updateFileValues = (files) => {
       id: edxVideoId,
       wrapperType,
       dateAdded: created.toString(),
-      usageLocations: [],
       status: uploadStatus,
       thumbnail,
     });


### PR DESCRIPTION
JIRA Ticket: [TNL-11215](https://2u-internal.atlassian.net/browse/TNL-11215)
> “Active” checkmark does not show up in table view until after the Info modal has been loaded

This PR uses the update API endpoints for the video and file fetch that includes the usage locations for each of the files/videos. Previous, the check mark in the active column on the table view would only appear after a user loaded the corresponding info modal. The table is supposed to provide a quick view to the user for whether or not a video/file is in use. Now the column loads as expected and the rows/cards can properly be filtered on the active value.

This change is dependent on the `edx-platform` PR #[33746](https://github.com/openedx/edx-platform/pull/33746)

Testing
Follow the instructions in the [edx-platform PR](https://github.com/openedx/edx-platform/pull/33746)