### PR TITLE
fix: filter overwritten by sort

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.test.jsx
+++ b/src/files-and-videos/files-page/FilesPage.test.jsx
@@ -300,7 +300,11 @@ describe('FilesAndUploads', () => {
 
         const sortNameAscendingButton = screen.getByText(messages.sortByNameAscending.defaultMessage);
         fireEvent.click(sortNameAscendingButton);
-        fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+        await waitFor(() => {
+          fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+        });
+
         expect(screen.queryByText(messages.sortModalTitleLabel.defaultMessage)).toBeNull();
       });
 
@@ -317,7 +321,11 @@ describe('FilesAndUploads', () => {
 
         const sortBySizeDescendingButton = screen.getByText(messages.sortBySizeDescending.defaultMessage);
         fireEvent.click(sortBySizeDescendingButton);
-        fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+        await waitFor(() => {
+          fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+        });
+
         expect(screen.queryByText(messages.sortModalTitleLabel.defaultMessage)).toBeNull();
       });
     });

--- a/src/files-and-videos/generic/table-components/sort-and-filter-modal/SortAndFilterModal.jsx
+++ b/src/files-and-videos/generic/table-components/sort-and-filter-modal/SortAndFilterModal.jsx
@@ -44,11 +44,10 @@ const SortAndFilterModal = ({
       remove(e.target.value);
     }
   };
-
-  const handleApply = () => {
-    closeSort();
-    handleSort(sortBy);
+  const handleApply = async () => {
+    await handleSort(sortBy);
     processFilters(filterBy, columns, setAllFilters);
+    closeSort();
   };
 
   const handleClearAll = () => {

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -148,9 +148,14 @@ const VideosPage = ({
   const processingStatusColumn = {
     id: 'status',
     Header: '',
+    accessor: 'status',
     Cell: ({ row }) => StatusColumn({ row }),
     Filter: CheckboxFilter,
-    filterChoices: [{ name: intl.formatMessage(messages.processingCheckboxLabel), value: 'Processing' }],
+    filterChoices: [
+      { name: intl.formatMessage(messages.processingCheckboxLabel), value: 'Processing' },
+
+      { name: intl.formatMessage(messages.failedCheckboxLabel), value: 'Failed' },
+    ],
   };
   const videoThumbnailColumn = {
     id: 'courseVideoImageUrl',

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -351,7 +351,10 @@ describe('FilesAndUploads', () => {
           it('should be enabled and sort files by name', async () => {
             const sortNameAscendingButton = screen.getByText(messages.sortByNameAscending.defaultMessage);
             fireEvent.click(sortNameAscendingButton);
-            fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+            await waitFor(() => {
+              fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+            });
 
             expect(screen.queryByText(messages.sortModalTitleLabel.defaultMessage)).toBeNull();
           });
@@ -359,7 +362,10 @@ describe('FilesAndUploads', () => {
           it('sort button should be enabled and sort files by file size', async () => {
             const sortBySizeDescendingButton = screen.getByText(messages.sortBySizeDescending.defaultMessage);
             fireEvent.click(sortBySizeDescendingButton);
-            fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+            await waitFor(() => {
+              fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+            });
 
             expect(screen.queryByText(messages.sortModalTitleLabel.defaultMessage)).toBeNull();
           });
@@ -374,7 +380,10 @@ describe('FilesAndUploads', () => {
             fireEvent.click(transcribedCheckboxFilter);
             fireEvent.click(notTranscribedCheckboxFilter);
             fireEvent.click(transcribedCheckboxFilter);
-            fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+            await waitFor(() => {
+              fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+            });
 
             const galleryCards = screen.getAllByTestId('grid-card', { exact: false });
 
@@ -406,7 +415,10 @@ describe('FilesAndUploads', () => {
           it('should remove Transcribed filter chip', async () => {
             const transcribedCheckboxFilter = screen.getByText(videoMessages.transcribedCheckboxLabel.defaultMessage);
             fireEvent.click(transcribedCheckboxFilter);
-            fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+
+            await waitFor(() => {
+              fireEvent.click(screen.getByText(messages.applySortButton.defaultMessage));
+            });
 
             const imageFilterChip = screen.getByTestId('icon-after');
             fireEvent.click(imageFilterChip);

--- a/src/files-and-videos/videos-page/messages.js
+++ b/src/files-and-videos/videos-page/messages.js
@@ -33,6 +33,10 @@ const messages = defineMessages({
     id: 'course-authoring.files-and-videos.sort-and-filter.modal.filter.processingCheckbox.label',
     defaultMessage: 'Processing',
   },
+  failedCheckboxLabel: {
+    id: 'course-authoring.files-and-videos.sort-and-filter.modal.filter.failedCheckbox.label',
+    defaultMessage: 'Failed',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
JIRA Ticket: [TNL-11219](https://2u-internal.atlassian.net/browse/TNL-11219)

> The filters stop working whenever I use one of the Sort options in the Sort and filter button. It seems to be an order of operations issue. If I click on that and just change the filters, it works. However, if I change filters and select a sort option, it removes my filters and I can no longer use filters. 
> 
> Additionally, why do we have a filter for Processing but not Failed? Both seem to be possible states.

The calls for updating the sort and filters were not firing in a set order because the sort function is an async function. This PR fixes the order of the calls by adding an `await` on the sort function.

Testing

1. Navigate to the Videos page
2. Select a filter and apply
3. Videos should filter and show a matching filter chip
4. Reopen the Sort and filter modal
5. Select a sort while keeping the filter the same
6. Sort should apply with no change to the filter
7. Reopen the Sort and filter modal
8. Change the filter and apply
9. Sort should remain the same and the filter should update