### PR TITLE
fix: Fix data API URL handling

### DIFF
--- a/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
+++ b/src/generic/create-or-rerun-course/CreateOrRerunCourseForm.test.jsx
@@ -153,7 +153,7 @@ describe('<CreateOrRerunCourseForm />', () => {
         userEvent.type(runInput, '1');
         userEvent.click(createBtn);
       });
-      await axiosMock.onPost(getCreateOrRerunCourseUrl).reply(200, { url });
+      await axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url });
       await executeThunk(updateCreateOrRerunCourseQuery({ org: 'testX', run: 'some' }), store.dispatch);
 
       expect(window.location.assign).toHaveBeenCalledWith(`${process.env.STUDIO_BASE_URL}${url}`);
@@ -168,7 +168,7 @@ describe('<CreateOrRerunCourseForm />', () => {
       const numberInput = screen.getByPlaceholderText(messages.courseNumberPlaceholder.defaultMessage);
       const runInput = screen.getByPlaceholderText(messages.courseRunPlaceholder.defaultMessage);
       const createBtn = screen.getByRole('button', { name: messages.createButton.defaultMessage });
-      await axiosMock.onPost(getCreateOrRerunCourseUrl).reply(200, { url, destinationCourseKey });
+      await axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { url, destinationCourseKey });
 
       await act(async () => {
         userEvent.type(displayNameInput, 'foo course name');
@@ -250,7 +250,7 @@ describe('<CreateOrRerunCourseForm />', () => {
   it('shows alert error if postErrors presents', async () => {
     render(<RootWrapper {...props} />);
     await mockStore();
-    await axiosMock.onPost(getCreateOrRerunCourseUrl).reply(200, { errMsg: 'aaa' });
+    await axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, { errMsg: 'aaa' });
     await executeThunk(updateCreateOrRerunCourseQuery({ org: 'testX', run: 'some' }), store.dispatch);
 
     expect(screen.getByText('aaa')).toBeInTheDocument();

--- a/src/generic/data/api.js
+++ b/src/generic/data/api.js
@@ -4,9 +4,9 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { convertObjectToSnakeCase } from '../../utils';
 
 export const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-export const getCreateOrRerunCourseUrl = new URL('course/', getApiBaseUrl()).href;
+export const getCreateOrRerunCourseUrl = () => new URL('course/', getApiBaseUrl()).href;
 export const getCourseRerunUrl = (courseId) => new URL(`/api/contentstore/v1/course_rerun/${courseId}`, getApiBaseUrl()).href;
-export const getOrganizationsUrl = new URL('organizations', getApiBaseUrl()).href;
+export const getOrganizationsUrl = () => new URL('organizations', getApiBaseUrl()).href;
 
 /**
  * Get's organizations data.
@@ -14,7 +14,7 @@ export const getOrganizationsUrl = new URL('organizations', getApiBaseUrl()).hre
  */
 export async function getOrganizations() {
   const { data } = await getAuthenticatedHttpClient().get(
-    getOrganizationsUrl,
+    getOrganizationsUrl(),
   );
   return camelCaseObject(data);
 }
@@ -37,7 +37,7 @@ export async function getCourseRerun(courseId) {
  */
 export async function createOrRerunCourse(courseData) {
   const { data } = await getAuthenticatedHttpClient().post(
-    getCreateOrRerunCourseUrl,
+    getCreateOrRerunCourseUrl(),
     convertObjectToSnakeCase(courseData, true),
   );
   return camelCaseObject(data);

--- a/src/generic/data/api.test.js
+++ b/src/generic/data/api.test.js
@@ -66,10 +66,10 @@ describe('generic api calls', () => {
       org: 'edX',
       run: 'Demo_Course',
     };
-    axiosMock.onPost(getCreateOrRerunCourseUrl).reply(200, courseRerunData);
+    axiosMock.onPost(getCreateOrRerunCourseUrl()).reply(200, courseRerunData);
     const result = await createOrRerunCourse(courseRerunData);
 
-    expect(axiosMock.history.post[0].url).toEqual(getCreateOrRerunCourseUrl);
+    expect(axiosMock.history.post[0].url).toEqual(getCreateOrRerunCourseUrl());
     expect(result).toEqual(courseRerunData);
   });
 });

--- a/src/studio-home/organization-section/OrganizationSection.test.jsx
+++ b/src/studio-home/organization-section/OrganizationSection.test.jsx
@@ -42,7 +42,7 @@ describe('<OrganizationSection />', async () => {
     });
     store = initializeStore();
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    axiosMock.onDelete(getOrganizationsUrl).reply(200);
+    axiosMock.onDelete(getOrganizationsUrl()).reply(200);
     await executeThunk(fetchOrganizationsQuery(), store.dispatch);
     useSelector.mockReturnValue(['edX', 'org']);
   });


### PR DESCRIPTION
### Description

All configuration calls must handled asynchronously, otherwise they risk failure in runtime configuration scenarios.

### To reproduce

The failure is readily reproducible in `tutor local` nightly or quince deployments.  Simply navigate to a course's "Pages and Resources" page in Studio.  The MFE will fail with a `Uncaught TypeError: URL constructor: course/ is not a valid URL.` at [src/generic/data/api.js on line 7](https://github.com/openedx/frontend-app-course-authoring/blob/master/src/generic/data/api.js#L7).

### The fix

The fix is to make any and all such config assignments into function calls, so that they're resolved just-in-time, as opposed to at initial load time.