### PR TITLE
feat: add new library button

### DIFF
--- a/src/studio-home/StudioHome.jsx
+++ b/src/studio-home/StudioHome.jsx
@@ -42,7 +42,6 @@ const StudioHome = ({ intl }) => {
     studioRequestEmail,
     libraryAuthoringMfeUrl,
     redirectToLibraryAuthoringMfe,
-    splitStudioHome,
   } = studioHomeData;
 
   function getHeaderButtons() {
@@ -68,25 +67,23 @@ const StudioHome = ({ intl }) => {
       );
     }
 
-    let libraryHref = `${getConfig().STUDIO_BASE_URL}/home#libraries-tab`;
-    if (splitStudioHome) {
-      libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
-    }
+    let libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
     if (redirectToLibraryAuthoringMfe) {
       libraryHref = `${libraryAuthoringMfeUrl}/create`;
-      headerButtons.push(
-        <Button
-          variant="outline-primary"
-          iconBefore={AddIcon}
-          size="sm"
-          disabled={showNewCourseContainer}
-          href={libraryHref}
-          data-testid="new-library-button"
-        >
-          {intl.formatMessage(messages.addNewLibraryBtnText)}
-        </Button>,
-      );
     }
+
+    headerButtons.push(
+      <Button
+        variant="outline-primary"
+        iconBefore={AddIcon}
+        size="sm"
+        disabled={showNewCourseContainer}
+        href={libraryHref}
+        data-testid="new-library-button"
+      >
+        {intl.formatMessage(messages.addNewLibraryBtnText)}
+      </Button>,
+    );
 
     return headerButtons;
   }

--- a/src/studio-home/StudioHome.test.jsx
+++ b/src/studio-home/StudioHome.test.jsx
@@ -116,15 +116,16 @@ describe('<StudioHome />', async () => {
   });
 
   describe('render new library button', () => {
-    it('should not show button', async () => {
+    it('href should include home_library', async () => {
       useSelector.mockReturnValue({
         ...studioHomeMock,
         courseCreatorStatus: COURSE_CREATOR_STATES.granted,
       });
+      const studioBaseUrl = 'http://localhost:18010';
 
-      const { queryByTestId } = render(<RootWrapper />);
-      const createNewLibraryButton = queryByTestId('new-library-button');
-      expect(createNewLibraryButton).toBeNull();
+      const { getByTestId } = render(<RootWrapper />);
+      const createNewLibraryButton = getByTestId('new-library-button');
+      expect(createNewLibraryButton.getAttribute('href')).toBe(`${studioBaseUrl}/home_library`);
     });
     it('href should include create', async () => {
       useSelector.mockReturnValue({


### PR DESCRIPTION
JIRA Ticket: [TNL-11234](https://2u-internal.atlassian.net/browse/TNL-11234)

The new library button is not shown on the home screen. This prevents users from creating a new library unless them remember the specific url for the legacy library page.

Testing
1. Navigate to the course-authoring home page
2. Should show "New library" button next to "New course" button
3. Click "New library"
4. Should take you back to the legacy library page