### PR TITLE
feat: update usage metrics to be a hyperlink

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.test.jsx
+++ b/src/files-and-videos/files-page/FilesPage.test.jsx
@@ -339,7 +339,15 @@ describe('FilesAndUploads', () => {
         const assetMenuButton = screen.getByTestId('file-menu-dropdown-mOckID1');
         expect(assetMenuButton).toBeVisible();
 
-        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`).reply(201, { usage_locations: { mOckID1: ['subsection - unit / block'] } });
+        axiosMock.onGet(`${getAssetsUrl(courseId)}mOckID1/usage`)
+          .reply(201, {
+            usage_locations: {
+              mOckID1: [{
+                display_location: 'subsection - unit / block',
+                url: 'base/unit_id#block_id',
+              }],
+            },
+          });
         await waitFor(() => {
           fireEvent.click(within(assetMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByText('Info'));

--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -1,4 +1,6 @@
 import { isEmpty } from 'lodash';
+import { camelCaseObject } from '@edx/frontend-platform';
+
 import { RequestStatus } from '../../../data/constants';
 import {
   addModel,
@@ -139,7 +141,7 @@ export function getUsagePaths({ asset, courseId }) {
         modelType: 'assets',
         model: {
           id: asset.id,
-          usageLocations: assetLocations,
+          usageLocations: camelCaseObject(assetLocations),
           activeStatus,
         },
       }));

--- a/src/files-and-videos/generic/UsageMetricsMessage.jsx
+++ b/src/files-and-videos/generic/UsageMetricsMessage.jsx
@@ -1,7 +1,12 @@
 import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
-import { Hyperlink, Icon, Row, Spinner } from '@edx/paragon';
+import {
+  Hyperlink,
+  Icon,
+  Row,
+  Spinner,
+} from '@edx/paragon';
 import { ErrorOutline } from '@edx/paragon/icons';
 import isEmpty from 'lodash/isEmpty';
 import { RequestStatus } from '../../data/constants';
@@ -20,15 +25,13 @@ const UsageMetricsMessage = ({
       <FormattedMessage {...messages.usageNotInUseMessage} />
     ) : (
       <ul className="p-0">
-        {usageLocations.map(location => {
-          console.log(location);
-          return (
+        {usageLocations.map(location => (
           <li key={`usage-location-${location.displayLocation}`} style={{ listStyle: 'none' }}>
             <Hyperlink destination={`${getConfig().STUDIO_BASE_URL}${location.url}`} target="_blank">
               {location.displayLocation}
             </Hyperlink>
           </li>
-        )})}
+        ))}
       </ul>
     );
   } else if (usagePathStatus === RequestStatus.FAILED) {

--- a/src/files-and-videos/generic/UsageMetricsMessage.jsx
+++ b/src/files-and-videos/generic/UsageMetricsMessage.jsx
@@ -1,6 +1,7 @@
 import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
-import { Icon, Row, Spinner } from '@edx/paragon';
+import { Hyperlink, Icon, Row, Spinner } from '@edx/paragon';
 import { ErrorOutline } from '@edx/paragon/icons';
 import isEmpty from 'lodash/isEmpty';
 import { RequestStatus } from '../../data/constants';
@@ -19,11 +20,15 @@ const UsageMetricsMessage = ({
       <FormattedMessage {...messages.usageNotInUseMessage} />
     ) : (
       <ul className="p-0">
-        {usageLocations.map(location => (
-          <li key={`usage-location-${location}`} style={{ listStyle: 'none' }}>
-            {location}
+        {usageLocations.map(location => {
+          console.log(location);
+          return (
+          <li key={`usage-location-${location.displayLocation}`} style={{ listStyle: 'none' }}>
+            <Hyperlink destination={`${getConfig().STUDIO_BASE_URL}${location.url}`} target="_blank">
+              {location.displayLocation}
+            </Hyperlink>
           </li>
-        ))}
+        )})}
       </ul>
     );
   } else if (usagePathStatus === RequestStatus.FAILED) {

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -440,7 +440,12 @@ describe('FilesAndUploads', () => {
           expect(videoMenuButton).toBeVisible();
 
           axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1/usage`)
-            .reply(201, { usageLocations: ['subsection - unit / block'] });
+            .reply(201, {
+              usageLocations: [{
+                display_location: 'subsection - unit / block',
+                url: 'base/unit_id#block_id',
+              }],
+            });
           await waitFor(() => {
             fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
             fireEvent.click(screen.getByText('Info'));


### PR DESCRIPTION
## Description

This PR updates the list items in the usage section of the info modal to be hyperlinks. The links lead to the xblock where the asset/video are located.

## Supporting information

JIRA Ticket: [TNL-11158](https://2u-internal.atlassian.net/browse/TNL-11158)

> This list is found on bottom left hand side of info modal. Users can currently see if a given asset is in the course, and how many times it is in the course. What is considered a “game changer” is to make that list clickable so that they can know where in the course the asset is. 

## Testing instructions

1. Open a course and navigate to the Files page (MFE version)
2. Open the info modal for an asset that you know is used in the course
3. Info modal should show all the locations that the asset is used and on hover show a valid link
4. Click on one of the links
5. Unit page should open in a new tab
6. One the xblocks finish loading, the xblock that uses the asset should scroll into view.

## Other information

This PR is dependent on `edx-platform` PR #[33855](https://github.com/openedx/edx-platform/pull/33855)