### PR TITLE
fix: visibility of transcript dropdowns

### DIFF
--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/LanguageSelect.jsx
@@ -24,7 +24,7 @@ const LanguageSelect = ({
       >
         {currentSelection}
       </Dropdown.Toggle>
-      <Dropdown.Menu className="m-0">
+      <Dropdown.Menu className="m-0 position-fixed">
         <div style={{ height: '230px', overflowY: 'scroll' }}>
           {Object.entries(options).map(([valueKey, text]) => {
             if (valueKey === value) {

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -54,18 +54,19 @@ const Transcript = ({
     <>
       {isConfirmationOpen ? (
         <Card className="my-2">
-          <Card.Header title={(<FormattedMessage {...messages.deleteConfirmationHeader} />)} />
+          <Card.Header className="h3" title={(<FormattedMessage {...messages.deleteConfirmationHeader} />)} />
           <Card.Body>
             <Card.Section>
               <FormattedMessage {...messages.deleteConfirmationMessage} />
             </Card.Section>
             <Card.Footer>
-              <Button variant="tertiary" className="mb-2 mb-sm-0" onClick={closeConfirmation}>
+              <Button size="sm" variant="tertiary" className="mb-2 mb-sm-0" onClick={closeConfirmation}>
                 <FormattedMessage {...messages.cancelDeleteLabel} />
               </Button>
               <Button
                 variant="danger"
                 className="mb-2 mb-sm-0"
+                size="sm"
                 onClick={() => {
                   handleTranscript({ language: transcript }, 'delete');
                   closeConfirmation();

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/TranscriptMenu.jsx
@@ -22,7 +22,7 @@ export const TranscriptActionMenu = ({
       alt="Actions dropdown"
       data-testid={`${language}-transcript-menu`}
     />
-    <Dropdown.Menu className="video_transcript Action Menu">
+    <Dropdown.Menu className="video_transcript position-fixed">
       <Dropdown.Item
         key={`transcript-actions-${language}-replace`}
         onClick={input.click}


### PR DESCRIPTION
This PR fixes the visibility of the language dropdown and menu dropdown for transcripts when the height of the transcript tab is less than the height of the dropdown container.

Testing
1. Navigate to the Videos page
2. Open the info modal for a video with five or less transcripts
3. Click on one of the languages
4. The whole dropdown should be visible
5. Click on the menu (...)
6. The whole dropdown should be visible