### PR TITLE
fix: video downloads

### DIFF
--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -57,6 +57,7 @@ const FileTable = ({
   };
   const [currentView, setCurrentView] = useState(defaultVal);
   const [isDeleteOpen, setDeleteOpen, setDeleteClose] = useToggle(false);
+  const [isDownloadOpen, setDownloadOpen, setDownloadClose] = useToggle(false);
   const [isAssetInfoOpen, openAssetInfo, closeAssetinfo] = useToggle(false);
   const [isAddOpen, setAddOpen, setAddClose] = useToggle(false);
   const [selectedRows, setSelectedRows] = useState([]);
@@ -114,6 +115,8 @@ const FileTable = ({
 
   const handleBulkDownload = useCallback(async (selectedFlatRows) => {
     handleErrorReset({ errorType: 'download' });
+    setSelectedRows(selectedFlatRows);
+    setDownloadOpen();
     handleDownloadFile(selectedFlatRows);
   }, []);
 
@@ -237,6 +240,14 @@ const FileTable = ({
           selectedRowCount={selectedRows.length}
           isOpen={isAddOpen}
           setClose={setAddClose}
+          setSelectedRows={setSelectedRows}
+          fileType={fileType}
+        />
+        <ApiStatusToast
+          actionType={intl.formatMessage(messages.apiStatusDownloadingAction)}
+          selectedRowCount={selectedRows.length}
+          isOpen={isDownloadOpen}
+          setClose={setDownloadClose}
           setSelectedRows={setSelectedRows}
           fileType={fileType}
         />

--- a/src/files-and-videos/generic/messages.js
+++ b/src/files-and-videos/generic/messages.js
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'course-authoring.files-and-upload.apiStatus.deletingAction.message',
     defaultMessage: 'Deleting',
   },
+  apiStatusDownloadingAction: {
+    id: 'course-authoring.files-and-upload.apiStatus.downloadingAction.message',
+    defaultMessage: 'Downloading',
+  },
   fileSizeError: {
     id: 'course-authoring.files-and-upload.addFiles.error.fileSize',
     defaultMessage: 'Uploaded file(s) must be 20 MB or less. Please resize file(s) and try again.',

--- a/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/MoreInfoColumn.jsx
@@ -33,6 +33,7 @@ const MoreInfoColumn = ({
     id,
     wrapperType,
     displayName,
+    downloadLink,
   } = row.original;
   return (
     <>
@@ -99,7 +100,7 @@ const MoreInfoColumn = ({
             as={Button}
             variant="tertiary"
             onClick={() => handleBulkDownload(
-              [{ original: { id, displayName } }],
+              [{ original: { id, displayName, downloadLink } }],
             )}
           >
             {intl.formatMessage(messages.downloadTitle)}

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -82,7 +82,7 @@ const VideosPage = ({
 
   const handleAddFile = (file) => dispatch(addVideoFile(courseId, file));
   const handleDeleteFile = (id) => dispatch(deleteVideoFile(courseId, id));
-  const handleDownloadFile = (selectedRows) => dispatch(fetchVideoDownload({ selectedRows }));
+  const handleDownloadFile = (selectedRows) => dispatch(fetchVideoDownload({ selectedRows, courseId }));
   const handleUsagePaths = (video) => dispatch(getUsagePaths({ video, courseId }));
   const handleErrorReset = (error) => dispatch(resetErrors(error));
   const handleFileOrder = ({ newFileIdOrder, sortType }) => {

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -36,7 +36,7 @@ import {
   addVideoThumbnail,
   fetchVideoDownload,
 } from './data/thunks';
-import { getVideosUrl, getCoursVideosApiUrl, getApiBaseUrl } from './data/api';
+import { getVideosUrl, getCourseVideosApiUrl, getApiBaseUrl } from './data/api';
 import videoMessages from './messages';
 import messages from '../generic/messages';
 
@@ -127,8 +127,8 @@ describe('FilesAndUploads', () => {
         const mockFetchResponse = Promise.resolve(mockResponseData);
         global.fetch = jest.fn().mockImplementation(() => mockFetchResponse);
 
-        axiosMock.onPost(getCoursVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
-        axiosMock.onGet(getCoursVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
+        axiosMock.onPost(getCourseVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
+        axiosMock.onGet(getCourseVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
 
         Object.defineProperty(dropzone, 'files', {
           value: [file],
@@ -223,8 +223,8 @@ describe('FilesAndUploads', () => {
         const mockFetchResponse = Promise.resolve(mockResponseData);
         global.fetch = jest.fn().mockImplementation(() => mockFetchResponse);
 
-        axiosMock.onPost(getCoursVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
-        axiosMock.onGet(getCoursVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
+        axiosMock.onPost(getCourseVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
+        axiosMock.onGet(getCourseVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
 
         const addFilesButton = screen.getAllByLabelText('file-input')[3];
         await act(async () => {
@@ -263,7 +263,7 @@ describe('FilesAndUploads', () => {
         const deleteButton = screen.getByText(messages.deleteTitle.defaultMessage).closest('a');
         expect(deleteButton).not.toHaveClass('disabled');
 
-        axiosMock.onDelete(`${getCoursVideosApiUrl(courseId)}/mOckID1`).reply(204);
+        axiosMock.onDelete(`${getCourseVideosApiUrl(courseId)}/mOckID1`).reply(204);
 
         fireEvent.click(deleteButton);
         expect(screen.getByText('Delete video(s) confirmation')).toBeVisible();
@@ -322,8 +322,7 @@ describe('FilesAndUploads', () => {
         await waitFor(() => {
           fireEvent.click(actionsButton);
         });
-        axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1`).reply(200, { download_link: 'http://download.org' });
-        axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID5`).reply(200, { download_link: 'http://download.org' });
+        axiosMock.onPut(`${getVideosUrl(courseId)}/download`).reply(200, null);
 
         const downloadButton = screen.getByText(messages.downloadTitle.defaultMessage).closest('a');
         expect(downloadButton).not.toHaveClass('disabled');
@@ -507,7 +506,6 @@ describe('FilesAndUploads', () => {
         const videoMenuButton = screen.getByTestId('file-menu-dropdown-mOckID1');
         expect(videoMenuButton).toBeVisible();
 
-        axiosMock.onGet(`${getVideosUrl(courseId)}/mOckID1`).reply(200, { download_link: 'test' });
         await waitFor(() => {
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByText('Download'));
@@ -527,7 +525,7 @@ describe('FilesAndUploads', () => {
         expect(fileMenuButton).toBeVisible();
 
         await waitFor(() => {
-          axiosMock.onDelete(`${getCoursVideosApiUrl(courseId)}/mOckID1`).reply(204);
+          axiosMock.onDelete(`${getCourseVideosApiUrl(courseId)}/mOckID1`).reply(204);
           fireEvent.click(within(fileMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByTestId('open-delete-confirmation-button'));
           expect(screen.getByText('Delete video(s) confirmation')).toBeVisible();
@@ -549,7 +547,7 @@ describe('FilesAndUploads', () => {
         const errorMessage = 'File download.png exceeds maximum size of 5 GB.';
         renderComponent();
         await mockStore(RequestStatus.SUCCESSFUL);
-        axiosMock.onPost(getCoursVideosApiUrl(courseId)).reply(413, { error: errorMessage });
+        axiosMock.onPost(getCourseVideosApiUrl(courseId)).reply(413, { error: errorMessage });
         const addFilesButton = screen.getAllByLabelText('file-input')[3];
         await act(async () => {
           userEvent.upload(addFilesButton, file);
@@ -564,7 +562,7 @@ describe('FilesAndUploads', () => {
       it('404 add file should show error', async () => {
         renderComponent();
         await mockStore(RequestStatus.SUCCESSFUL);
-        axiosMock.onPost(getCoursVideosApiUrl(courseId)).reply(404);
+        axiosMock.onPost(getCourseVideosApiUrl(courseId)).reply(404);
         const addFilesButton = screen.getAllByLabelText('file-input')[3];
         await act(async () => {
           userEvent.upload(addFilesButton, file);
@@ -599,8 +597,8 @@ describe('FilesAndUploads', () => {
         const mockFetchResponse = Promise.reject(mockResponseData);
         global.fetch = jest.fn().mockImplementation(() => mockFetchResponse);
 
-        axiosMock.onPost(getCoursVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
-        axiosMock.onGet(getCoursVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
+        axiosMock.onPost(getCourseVideosApiUrl(courseId)).reply(204, generateNewVideoApiResponse());
+        axiosMock.onGet(getCourseVideosApiUrl(courseId)).reply(200, generateAddVideoApiResponse());
         const addFilesButton = screen.getAllByLabelText('file-input')[3];
         await act(async () => {
           userEvent.upload(addFilesButton, file);
@@ -621,7 +619,7 @@ describe('FilesAndUploads', () => {
         expect(videoMenuButton).toBeVisible();
 
         await waitFor(() => {
-          axiosMock.onDelete(`${getCoursVideosApiUrl(courseId)}/mOckID1`).reply(404);
+          axiosMock.onDelete(`${getCourseVideosApiUrl(courseId)}/mOckID1`).reply(404);
           fireEvent.click(within(videoMenuButton).getByLabelText('file-menu-toggle'));
           fireEvent.click(screen.getByTestId('open-delete-confirmation-button'));
           expect(screen.getByText('Delete video(s) confirmation')).toBeVisible();
@@ -675,9 +673,11 @@ describe('FilesAndUploads', () => {
         const downloadButton = screen.getByText(messages.downloadTitle.defaultMessage).closest('a');
         expect(downloadButton).not.toHaveClass('disabled');
 
+        axiosMock.onPut(`${getVideosUrl(courseId)}/download`).reply(404);
+
         await waitFor(() => {
           fireEvent.click(downloadButton);
-          executeThunk(fetchVideoDownload([{ original: { displayName: 'mOckID1', id: '2' } }]), store.dispatch);
+          executeThunk(fetchVideoDownload([{ original: { displayName: 'mOckID1', id: '2', downloadLink: 'test' } }]), store.dispatch);
         });
 
         const updateStatus = store.getState().videos.updatingStatus;

--- a/src/files-and-videos/videos-page/data/api.test.js
+++ b/src/files-and-videos/videos-page/data/api.test.js
@@ -1,9 +1,26 @@
-import { getDownload } from './api';
 import 'file-saver';
+import MockAdapter from 'axios-mock-adapter';
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { getDownload, getVideosUrl } from './api';
 
 jest.mock('file-saver');
 
+let axiosMock;
+
 describe('api.js', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
   describe('getDownload', () => {
     describe('selectedRows length is undefined or less than zero', () => {
       it('should return with no files selected error if selectedRows is empty', async () => {
@@ -18,36 +35,39 @@ describe('api.js', () => {
       });
     });
     describe('selectedRows length is greater than one', () => {
+      beforeEach(() => {
+        axiosMock.onPut(`${getVideosUrl('SoMEiD')}/download`).reply(200, null);
+      });
       it('should not throw error when blob returns null', async () => {
         const expected = [];
         const actual = await getDownload([
           { original: { displayName: 'test1', downloadLink: 'test1.com' } },
           { original: { displayName: 'test2', id: '2', downloadLink: 'test2.com' } },
-        ]);
+        ], 'SoMEiD');
         expect(actual).toEqual(expected);
       });
       it('should return error if row does not contain .original attribute', async () => {
-        const expected = ['Failed to download video.'];
+        const expected = ['Cannot find download file for video.'];
         const actual = await getDownload([
           { asset: { displayName: 'test1', id: '1' } },
           { original: { displayName: 'test2', id: '2', downloadLink: 'test1.com' } },
-        ]);
-        expect(actual).toEqual(expected);
-      });
-      it('should return error if original does not contain .downloadLink attribute', async () => {
-        const expected = ['Cannot find download file for test2.'];
-        const actual = await getDownload([
-          { original: { displayName: 'test2', id: '2' } },
-        ]);
+        ], 'SoMEiD');
         expect(actual).toEqual(expected);
       });
     });
     describe('selectedRows length equals one', () => {
+      it('should return error if original does not contain .downloadLink attribute', async () => {
+        const expected = ['Cannot find download file for test2.'];
+        const actual = await getDownload([
+          { original: { displayName: 'test2', id: '2' } },
+        ], 'SoMEiD');
+        expect(actual).toEqual(expected);
+      });
       it('should return error if row does not contain .original ancestor', async () => {
         const expected = ['Failed to download video.'];
         const actual = await getDownload([
           { asset: { displayName: 'test1', id: '1', download_link: 'test1.com' } },
-        ]);
+        ], 'SoMEiD');
         expect(actual).toEqual(expected);
       });
     });

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -287,16 +287,20 @@ export function getUsagePaths({ video, courseId }) {
   };
 }
 
-export function fetchVideoDownload({ selectedRows }) {
+export function fetchVideoDownload({ selectedRows, courseId }) {
   return async (dispatch) => {
     dispatch(updateEditStatus({ editType: 'download', status: RequestStatus.IN_PROGRESS }));
-    const errors = await getDownload(selectedRows);
-    if (isEmpty(errors)) {
+    try {
+      const errors = await getDownload(selectedRows, courseId);
       dispatch(updateEditStatus({ editType: 'download', status: RequestStatus.SUCCESSFUL }));
-    } else {
-      errors.forEach(error => {
-        dispatch(updateErrors({ error: 'download', message: error }));
-      });
+      if (!isEmpty(errors)) {
+        errors.forEach(error => {
+          dispatch(updateErrors({ error: 'download', message: error }));
+        });
+        dispatch(updateEditStatus({ editType: 'download', status: RequestStatus.FAILED }));
+      }
+    } catch (error) {
+      dispatch(updateErrors({ error: 'download', message: 'Failed to download zip file of videos.' }));
       dispatch(updateEditStatus({ editType: 'download', status: RequestStatus.FAILED }));
     }
   };


### PR DESCRIPTION
JIRA Tickets: [TNL-11228](https://2u-internal.atlassian.net/browse/TNL-11228), [TNL-11265](https://2u-internal.atlassian.net/browse/TNL-11265)

This PR fixes individual videos not downloading in the list view and multiple video downloads. Previously individual videos would not download in the list video because the `downloadLink` was not passed to the download function. Additionally when trying to download multiple videos, only the first video would download because the file saver would open the videos in a new tab. This forced the users browser to enforce its pop-up blocker. Now the backend downloads the files and puts them in a zipped folder which is downloaded via the frontend.

**This PR is dependent on `edx-platform` PR #[33882](https://github.com/openedx/edx-platform/pull/33882)**

Testing

Single file download (list view)
1. Load the videos page
2. Switch to the list view
3. Click on the menu button (...)
4. Click Download
5. File should download as expected

Multiple file download
1. Load the videos page
3. Select at least two videos to download
4. Click Actions
5. Click Download
6. Downloading toast should appear
7. Zip file should download
8. Extract files from zip
9. Should contain selected videos

