### PR TITLE
fix: grading segment number ranges

### DIFF
--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.jsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.jsx
@@ -42,7 +42,7 @@ const GradingScaleSegment = ({
         />
       )}
       <span className="grading-scale-segment-content-number m-0">
-        {gradingSegments[idx === 0 ? 0 : idx - 1]?.previous} - {value}
+        {gradingSegments[idx === 0 ? 0 : idx - 1]?.previous} - {value === 100 ? value : value - 1}
       </span>
     </div>
     {idx !== gradingSegments.length && idx - 1 !== 0 && (


### PR DESCRIPTION
JIRA Ticket: [TNL-11260](https://2u-internal.atlassian.net/browse/TNL-11260)
> See image. Notice 14 is in both F and D ranges, etc.

This PR fixes the numeric ranges displayed for a section. Previously the end range for a segment was equal to the start range of the next segment. This can be confusing for the user to know where the grade would actual fall on the scale. With this change, the end range of a segment will be one less than the start range of the next segment.

Before
![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/14d51fd6-2cc8-4f5e-95a1-7be628fe1525)

After
<img width="1046" alt="Screenshot 2023-12-06 at 10 08 29 AM" src="https://github.com/openedx/frontend-app-course-authoring/assets/42981026/8f8aff15-86d7-4047-bdf5-bdbb57d5273f">

Testing
1. Navigate to the grading page
2. Check that the grading scale segments end range do not equal the next segments start range