### PR TITLE
fix: wrong min count alert showing

### DIFF
--- a/src/grading-settings/assignment-section/AssignmentSection.test.jsx
+++ b/src/grading-settings/assignment-section/AssignmentSection.test.jsx
@@ -62,10 +62,10 @@ describe('<AssignmentSection />', () => {
   it('checking correct assignment weight of total grade value', async () => {
     const { getByTestId } = render(<RootWrapper setGradingData={setGradingData} />);
     await waitFor(() => {
-      const assignmentShortLabelInput = getByTestId('assignment-weight-input');
-      expect(assignmentShortLabelInput.value).toBe('100');
-      fireEvent.change(assignmentShortLabelInput, { target: { value: '123' } });
-      expect(testObj.graders[0].weight).toBe('123');
+      const assignmentWeightInput = getByTestId('assignment-weight-input');
+      expect(assignmentWeightInput.value).toBe('100');
+      fireEvent.change(assignmentWeightInput, { target: { value: '123' } });
+      expect(testObj.graders[0].weight).toBe(123);
     });
   });
   it('checking correct assignment total number value', async () => {
@@ -74,7 +74,7 @@ describe('<AssignmentSection />', () => {
       const assignmentTotalNumberInput = getByTestId('assignment-minCount-input');
       expect(assignmentTotalNumberInput.value).toBe('1');
       fireEvent.change(assignmentTotalNumberInput, { target: { value: '123' } });
-      expect(testObj.graders[0].minCount).toBe('123');
+      expect(testObj.graders[0].minCount).toBe(123);
     });
   });
   it('checking correct assignment number of droppable value', async () => {
@@ -83,7 +83,7 @@ describe('<AssignmentSection />', () => {
       const assignmentNumberOfDroppableInput = getByTestId('assignment-dropCount-input');
       expect(assignmentNumberOfDroppableInput.value).toBe('1');
       fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '2' } });
-      expect(testObj.graders[0].dropCount).toBe('2');
+      expect(testObj.graders[0].dropCount).toBe(2);
     });
   });
   it('checking correct error msg if dropCount have negative number or empty string', async () => {
@@ -100,20 +100,20 @@ describe('<AssignmentSection />', () => {
   it('checking correct error msg if minCount have negative number or empty string', async () => {
     const { getByText, getByTestId } = render(<RootWrapper />);
     await waitFor(() => {
-      const assignmentNumberOfDroppableInput = getByTestId('assignment-minCount-input');
-      expect(assignmentNumberOfDroppableInput.value).toBe('1');
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '-2' } });
+      const assignmentMinCountInput = getByTestId('assignment-minCount-input');
+      expect(assignmentMinCountInput.value).toBe('1');
+      fireEvent.change(assignmentMinCountInput, { target: { value: '-2' } });
       expect(getByText(messages.totalNumberErrorMessage.defaultMessage)).toBeInTheDocument();
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '' } });
+      fireEvent.change(assignmentMinCountInput, { target: { value: '' } });
       expect(getByText(messages.totalNumberErrorMessage.defaultMessage)).toBeInTheDocument();
     });
   });
   it('checking correct error msg if total weight have negative number', async () => {
     const { getByText, getByTestId } = render(<RootWrapper />);
     await waitFor(() => {
-      const assignmentNumberOfDroppableInput = getByTestId('assignment-weight-input');
-      expect(assignmentNumberOfDroppableInput.value).toBe('100');
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '-100' } });
+      const assignmentWeightInput = getByTestId('assignment-weight-input');
+      expect(assignmentWeightInput.value).toBe('100');
+      fireEvent.change(assignmentWeightInput, { target: { value: '-100' } });
       expect(getByText(messages.weightOfTotalGradeErrorMessage.defaultMessage)).toBeInTheDocument();
     });
   });

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -34,7 +34,12 @@ const AssignmentSection = ({
   }
 
   const handleAssignmentChange = (e, assignmentId) => {
-    const { name, value } = e.target;
+    const { name, value, type: inputType } = e.target;
+
+    let inputValue = value;
+    if (inputType === 'number') {
+      inputValue = parseInt(value, 10);
+    }
 
     setShowSavePrompt(true);
 
@@ -42,7 +47,7 @@ const AssignmentSection = ({
       ...prevState,
       graders: graders.map(grader => {
         if (grader.id === assignmentId) {
-          return { ...grader, [name]: value };
+          return { ...grader, [name]: inputValue };
         }
         return grader;
       }),
@@ -66,7 +71,7 @@ const AssignmentSection = ({
   return (
     <div className="assignment-items">
       {graders?.map((gradeField) => {
-        const courseAssignmentUsage = courseAssignmentLists[gradeField.type.toLowerCase()];
+        const courseAssignmentUsage = courseAssignmentLists[gradeField.type];
         const showDefinedCaseAlert = gradeField.minCount !== courseAssignmentUsage?.length
             && Boolean(courseAssignmentUsage?.length);
         const showNotDefinedCaseAlert = !courseAssignmentUsage?.length && Boolean(gradeField.type);


### PR DESCRIPTION
JIRA Ticket: [TNL-11243](https://2u-internal.atlassian.net/browse/TNL-11243)
> Wrong alert showing for assignment usage

This PR fixes the wrong assignment count when the number of assignments that use the assignment type equals the assignment type's total number. This PR also fixes the number fields for an assignment being saved as a string. This prevented some of the equality checks from returning the correct answer because strings were being compared to numbers.

Testing

1. Open a course where no subsections have their assignment types set
2. In the course outline, navigate to a subsection
3. Click on the gear icon
4. In the "Grade As" section, select an assignment type
5. Navigate to the grading page
6. Find the assignment type that was select for the subsection
7. The assignment type should have success alert
8. Change the total number field
9. The alert should change to its warning state
10. Change the total number field back to the previous number
11. The alert should change back to its success state