### PR TITLE
fix: update transcript settings default logic

### DIFF
--- a/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
@@ -25,6 +25,9 @@ const OrderTranscriptForm = ({
   const [data, setData] = useState(activeTranscriptPreferences || { videoSourceLanguage: '' });
 
   const [validCieloTranscriptionPlan, validThreePlayTranscriptionPlan] = checkTranscriptionPlans(transcriptionPlans);
+  useEffect(() => {
+    setTranscriptType(activeTranscriptPreferences?.provider || 'order');
+  }, []);
 
   let [cieloHasCredentials, threePlayHasCredentials] = checkCredentials(transcriptCredentials);
   useEffect(() => {

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -35,9 +35,8 @@ const TranscriptSettings = ({
     isAiTranslationsEnabled,
   } = pageSettings;
   const { transcriptionPlans } = videoTranscriptSettings || {};
-  const [transcriptType, setTranscriptType] = useState(activeTranscriptPreferences?.provider);
+  const [transcriptType, setTranscriptType] = useState(null);
   const [isAiTranslations, setIsAiTranslations] = useState(false);
-  const [isOrderComponentOpened, setIsOrderComponentOpened] = useState(false);
 
   const handleOrderTranscripts = (data, provider) => {
     const noCredentials = isEmpty(transcriptCredentials) || data.apiKey;
@@ -63,16 +62,13 @@ const TranscriptSettings = ({
           <>
             <ActionRow>
               <TransitionReplace>
-                {transcriptType && isOrderComponentOpened ? (
+                {transcriptType ? (
                   <IconButton
                     key="back-button"
                     size="sm"
                     iconAs={Icon}
                     src={ChevronLeft}
-                    onClick={() => {
-                      setTranscriptType(null);
-                      setIsOrderComponentOpened(false);
-                    }}
+                    onClick={() => setTranscriptType(null)}
                     alt="back button to main transcript settings view"
                   />
                 ) : (
@@ -85,7 +81,7 @@ const TranscriptSettings = ({
               <IconButton size="sm" iconAs={Icon} src={Close} onClick={closeTranscriptSettings} alt="close settings" />
             </ActionRow>
             <TransitionReplace>
-              { transcriptType && isOrderComponentOpened ? (
+              { transcriptType ? (
                 <div key="transcript-settings">
                   <OrderTranscriptForm
                     {...{
@@ -104,10 +100,7 @@ const TranscriptSettings = ({
               ) : (
                 <div key="transcript-type-selection" className="mt-3">
                   <Collapsible.Advanced
-                    onOpen={() => {
-                      setTranscriptType(transcriptType || 'order');
-                      setIsOrderComponentOpened(true);
-                    }}
+                    onOpen={() => setTranscriptType('order')}
                   >
                     <Collapsible.Trigger
                       className="row m-0 justify-content-between align-items-center"
@@ -121,7 +114,7 @@ const TranscriptSettings = ({
             </TransitionReplace>
           </>
         )}
-        {(!isOrderComponentOpened && isAiTranslationsEnabled) && (
+        {(!transcriptType && isAiTranslationsEnabled) && (
           <TransitionReplace>
             <AITranslationsComponent
               setIsAiTranslations={setIsAiTranslations}

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -37,6 +37,7 @@ const TranscriptSettings = ({
   const { transcriptionPlans } = videoTranscriptSettings || {};
   const [transcriptType, setTranscriptType] = useState(activeTranscriptPreferences?.provider);
   const [isAiTranslations, setIsAiTranslations] = useState(false);
+  const [isOrderComponentOpened, setIsOrderComponentOpened] = useState(false);
 
   const handleOrderTranscripts = (data, provider) => {
     const noCredentials = isEmpty(transcriptCredentials) || data.apiKey;
@@ -62,13 +63,16 @@ const TranscriptSettings = ({
           <>
             <ActionRow>
               <TransitionReplace>
-                {transcriptType ? (
+                {transcriptType && isOrderComponentOpened ? (
                   <IconButton
                     key="back-button"
                     size="sm"
                     iconAs={Icon}
                     src={ChevronLeft}
-                    onClick={() => setTranscriptType(null)}
+                    onClick={() => {
+                      setTranscriptType(null);
+                      setIsOrderComponentOpened(false);
+                    }}
                     alt="back button to main transcript settings view"
                   />
                 ) : (
@@ -81,7 +85,7 @@ const TranscriptSettings = ({
               <IconButton size="sm" iconAs={Icon} src={Close} onClick={closeTranscriptSettings} alt="close settings" />
             </ActionRow>
             <TransitionReplace>
-              {transcriptType ? (
+              { transcriptType && isOrderComponentOpened ? (
                 <div key="transcript-settings">
                   <OrderTranscriptForm
                     {...{
@@ -100,7 +104,10 @@ const TranscriptSettings = ({
               ) : (
                 <div key="transcript-type-selection" className="mt-3">
                   <Collapsible.Advanced
-                    onOpen={() => setTranscriptType('order')}
+                    onOpen={() => {
+                      setTranscriptType(transcriptType || 'order');
+                      setIsOrderComponentOpened(true);
+                    }}
                   >
                     <Collapsible.Trigger
                       className="row m-0 justify-content-between align-items-center"
@@ -114,7 +121,7 @@ const TranscriptSettings = ({
             </TransitionReplace>
           </>
         )}
-        {(!transcriptType && isAiTranslationsEnabled) && (
+        {(!isOrderComponentOpened && isAiTranslationsEnabled) && (
           <TransitionReplace>
             <AITranslationsComponent
               setIsAiTranslations={setIsAiTranslations}

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -144,6 +144,10 @@ describe('TranscriptSettings', () => {
     });
 
     it('should load page with Cielo24 selected', async () => {
+      const orderButton = screen.getByText(messages.orderTranscriptsTitle.defaultMessage);
+      await act(async () => {
+        userEvent.click(orderButton);
+      });
       const cielo24Button = screen.getByText(messages.cieloLabel.defaultMessage);
 
       expect(within(cielo24Button).getByLabelText('Cielo24 radio')).toHaveProperty('checked', true);
@@ -180,6 +184,10 @@ describe('TranscriptSettings', () => {
       axiosMock = new MockAdapter(getAuthenticatedHttpClient());
 
       renderComponent(defaultProps);
+      const orderButton = screen.getByText(messages.orderTranscriptsTitle.defaultMessage);
+      await act(async () => {
+        userEvent.click(orderButton);
+      });
       const noneButton = screen.getAllByLabelText('none radio')[0];
 
       await act(async () => {


### PR DESCRIPTION
### Summary

This fixes an issue where when the `transcriptType` is set to a 3rd party translations service such Cielo or 3playMedia, on clicking the Transcript Settings button/link, the view bypasses the initial view of the settings panel and displays the order component view thereby preventing the option to select/view the ai-translations component.