### PR TITLE
[FC-0036] feat: Add filter taxonomies by orgs

### DIFF
--- a/src/generic/data/api.js
+++ b/src/generic/data/api.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
@@ -9,8 +10,8 @@ export const getCourseRerunUrl = (courseId) => new URL(`/api/contentstore/v1/cou
 export const getOrganizationsUrl = () => new URL('organizations', getApiBaseUrl()).href;
 
 /**
- * Get's organizations data.
- * @returns {Promise<Object>}
+ * Get's organizations data. Returns list of organization names.
+ * @returns {Promise<string[]>}
  */
 export async function getOrganizations() {
   const { data } = await getAuthenticatedHttpClient().get(
@@ -32,7 +33,7 @@ export async function getCourseRerun(courseId) {
 
 /**
  * Create or rerun course with data.
- * @param {object} data
+ * @param {object} courseData
  * @returns {Promise<Object>}
  */
 export async function createOrRerunCourse(courseData) {

--- a/src/generic/data/apiHooks.js
+++ b/src/generic/data/apiHooks.js
@@ -1,0 +1,15 @@
+// @ts-check
+import { useQuery } from '@tanstack/react-query';
+import { getOrganizations } from './api';
+
+/**
+ * Builds the query to get a list of available organizations
+ */
+export const useOrganizationListData = () => (
+  useQuery({
+    queryKey: ['organizationList'],
+    queryFn: () => getOrganizations(),
+  })
+);
+
+export default useOrganizationListData;

--- a/src/taxonomy/TaxonomyListPage.scss
+++ b/src/taxonomy/TaxonomyListPage.scss
@@ -1,0 +1,7 @@
+.taxonomy-orgs-filter-selector {
+  // Without this, the default bold styling for the focused option
+  // in the org select menu is too thick
+  .pgn__menu-item:focus {
+    font-weight: bold;
+  }
+}

--- a/src/taxonomy/TaxonomyListPage.test.jsx
+++ b/src/taxonomy/TaxonomyListPage.test.jsx
@@ -1,6 +1,10 @@
 import React, { useMemo } from 'react';
+import MockAdapter from 'axios-mock-adapter';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
 import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
 import { AppProvider } from '@edx/frontend-platform/react';
 import { act, render, fireEvent } from '@testing-library/react';
 
@@ -11,6 +15,8 @@ import { useTaxonomyListDataResponse, useIsTaxonomyListDataLoaded } from './data
 import { TaxonomyContext } from './common/context';
 
 let store;
+let axiosMock;
+const queryClient = new QueryClient();
 const mockSetToastMessage = jest.fn();
 const mockDeleteTaxonomy = jest.fn();
 const taxonomies = [{
@@ -18,6 +24,8 @@ const taxonomies = [{
   name: 'Taxonomy',
   description: 'This is a description',
 }];
+const organizationsListUrl = 'http://localhost:18010/organizations';
+const organizations = ['Org 1', 'Org 2'];
 
 jest.mock('./data/apiHooks', () => ({
   useTaxonomyListDataResponse: jest.fn(),
@@ -39,14 +47,16 @@ const RootWrapper = () => {
     <AppProvider store={store}>
       <IntlProvider locale="en" messages={{}}>
         <TaxonomyContext.Provider value={context}>
-          <TaxonomyListPage intl={injectIntl} />
+          <QueryClientProvider client={queryClient}>
+            <TaxonomyListPage intl={injectIntl} />
+          </QueryClientProvider>
         </TaxonomyContext.Provider>
       </IntlProvider>
     </AppProvider>
   );
 };
 
-describe('<TaxonomyListPage />', async () => {
+describe('<TaxonomyListPage />', () => {
   beforeEach(async () => {
     initializeMockApp({
       authenticatedUser: {
@@ -57,6 +67,8 @@ describe('<TaxonomyListPage />', async () => {
       },
     });
     store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onGet(organizationsListUrl).reply(200, organizations);
   });
 
   it('should render page and page title correctly', () => {
@@ -117,5 +129,76 @@ describe('<TaxonomyListPage />', async () => {
 
     expect(mockDeleteTaxonomy).toBeCalledTimes(1);
     expect(mockSetToastMessage).toBeCalledWith(`"${taxonomies[0].name}" deleted`);
+  });
+
+  it('should show all "All taxonomies", "Unassigned" and org names in taxonomy org filter', async () => {
+    useIsTaxonomyListDataLoaded.mockReturnValue(true);
+    useTaxonomyListDataResponse.mockReturnValue({
+      results: taxonomies,
+    });
+
+    const {
+      getByTestId,
+      getByText,
+      getByRole,
+      getAllByText,
+    } = render(<RootWrapper />);
+
+    expect(getByTestId('taxonomy-orgs-filter-selector')).toBeInTheDocument();
+    // Check that the default filter is set to 'All taxonomies' when page is loaded
+    expect(getByText('All taxonomies')).toBeInTheDocument();
+
+    // Open the taxonomies org filter select menu
+    fireEvent.click(getByRole('button', { name: 'All taxonomies' }));
+
+    // Check that the select menu shows 'All taxonomies' option
+    // along with the default selected one
+    expect(getAllByText('All taxonomies').length).toBe(2);
+    // Check that the select manu shows 'Unassigned' option
+    expect(getByText('Unassigned')).toBeInTheDocument();
+    // Check that the select menu shows the 'Org 1' option
+    expect(getByText('Org 1')).toBeInTheDocument();
+    // Check that the select menu shows the 'Org 2' option
+    expect(getByText('Org 2')).toBeInTheDocument();
+  });
+
+  it('should fetch taxonomies with correct params for org filters', async () => {
+    useIsTaxonomyListDataLoaded.mockReturnValue(true);
+    useTaxonomyListDataResponse.mockReturnValue({
+      results: taxonomies,
+    });
+
+    const { getByRole } = render(<RootWrapper />);
+
+    // Open the taxonomies org filter select menu
+    const taxonomiesFilterSelectMenu = await getByRole('button', { name: 'All taxonomies' });
+    fireEvent.click(taxonomiesFilterSelectMenu);
+
+    // Check that the 'Unassigned' option is correctly called
+    fireEvent.click(getByRole('link', { name: 'Unassigned' }));
+
+    expect(useTaxonomyListDataResponse).toBeCalledWith('Unassigned');
+
+    // Open the taxonomies org filter select menu again
+    fireEvent.click(taxonomiesFilterSelectMenu);
+
+    // Check that the 'Org 1' option is correctly called
+    fireEvent.click(getByRole('link', { name: 'Org 1' }));
+    expect(useTaxonomyListDataResponse).toBeCalledWith('Org 1');
+
+    // Open the taxonomies org filter select menu again
+    fireEvent.click(taxonomiesFilterSelectMenu);
+
+    // Check that the 'Org 2' option is correctly called
+    fireEvent.click(getByRole('link', { name: 'Org 2' }));
+    expect(useTaxonomyListDataResponse).toBeCalledWith('Org 2');
+
+    // Open the taxonomies org filter select menu again
+    fireEvent.click(taxonomiesFilterSelectMenu);
+
+    // Check that the 'All' option is correctly called, it should show as
+    // 'All' rather than 'All taxonomies' in the select menu since its not selected
+    fireEvent.click(getByRole('link', { name: 'All' }));
+    expect(useTaxonomyListDataResponse).toBeCalledWith('All taxonomies');
   });
 });

--- a/src/taxonomy/data/api.js
+++ b/src/taxonomy/data/api.js
@@ -9,7 +9,11 @@ export const getTaxonomyListApiUrl = (org) => {
   url.searchParams.append('enabled', 'true');
   url.searchParams.append('page_size', '500'); // For the tagging MVP, we don't paginate the taxonomy list
   if (org !== undefined) {
-    url.searchParams.append('org', org);
+    if (org === 'Unassigned') {
+      url.searchParams.append('unassigned', 'true');
+    } else if (org !== 'All taxonomies') {
+      url.searchParams.append('org', org);
+    }
   }
   return url.href;
 };

--- a/src/taxonomy/data/api.test.js
+++ b/src/taxonomy/data/api.test.js
@@ -45,8 +45,12 @@ describe('taxonomy api calls', () => {
     window.location = location;
   });
 
-  it('should get taxonomy list data with org', async () => {
-    const org = 'testOrg';
+  it.each([
+    undefined,
+    'All taxonomies',
+    'Unassigned',
+    'testOrg',
+  ])('should get taxonomy list data for \'%s\' org filter', async (org) => {
     axiosMock.onGet(getTaxonomyListApiUrl(org)).reply(200, taxonomyListMock);
     const result = await getTaxonomyListData(org);
 

--- a/src/taxonomy/data/apiHooks.jsx
+++ b/src/taxonomy/data/apiHooks.jsx
@@ -20,7 +20,7 @@ import { getTaxonomyListData, deleteTaxonomy } from './api';
  */
 const useTaxonomyListData = (org) => (
   useQuery({
-    queryKey: ['taxonomyList'],
+    queryKey: ['taxonomyList', org],
     queryFn: () => getTaxonomyListData(org),
   })
 );

--- a/src/taxonomy/index.scss
+++ b/src/taxonomy/index.scss
@@ -1,3 +1,4 @@
+@import "taxonomy/TaxonomyListPage";
 @import "taxonomy/taxonomy-card/TaxonomyCard";
 @import "taxonomy/delete-dialog/DeleteDialog";
 @import "taxonomy/system-defined-badge/SystemDefinedBadge";

--- a/src/taxonomy/messages.js
+++ b/src/taxonomy/messages.js
@@ -29,6 +29,14 @@ const messages = defineMessages({
     id: 'course-authoring.taxonomy-list.select.org.default',
     defaultMessage: 'All taxonomies',
   },
+  orgAllValue: {
+    id: 'course-authoring.taxonomy-list.select.org.all',
+    defaultMessage: 'All',
+  },
+  orgUnassignedValue: {
+    id: 'course-authoring.taxonomy-list.select.org.unassigned',
+    defaultMessage: 'Unassigned',
+  },
   usageLoadingMessage: {
     id: 'course-authoring.taxonomy-list.spinner.loading',
     defaultMessage: 'Loading',


### PR DESCRIPTION
## Description

This allows for filter taxonomies on the taxonomy list page by selecting organization name, all taxonomies, or unassigned taxonomies.

<img width="380" alt="Screen Shot 2023-12-18 at 5 02 10 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/6829768/9e2d3d4f-e709-44dc-a371-a5624881e263">


## Supporting Information
Related Tickets:
- Closes https://github.com/openedx/modular-learning/issues/108

## Testing instructions
1. Make sure you have the latest changes from edx-platform master in your local devstack
2. Make sure you have sample data from https://github.com/open-craft/taxonomy-sample-data/
3. Run the MFE and head to http://localhost:2001/taxonomies
4. Confirm that the select menu appears and defaults to 'All taxonomies', and all taxonomies are listed
5. Confirm that changing the selected filter fetches different taxonomies for each filter selected

____
Private-ref:
 - [FAL-3544](https://tasks.opencraft.com/browse/FAL-3544)
