### PR TITLE
fix: uploading progress percentage

### DIFF
--- a/src/import-page/data/api.test.jsx
+++ b/src/import-page/data/api.test.jsx
@@ -29,7 +29,7 @@ describe('API Functions', () => {
     const data = { importStatus: 1 };
     axiosMock.onPost(postImportCourseApiUrl(courseId)).reply(200, data);
 
-    const result = await startCourseImporting(courseId, file);
+    const result = await startCourseImporting(courseId, file, {}, jest.fn());
     expect(axiosMock.history.post[0].url).toEqual(postImportCourseApiUrl(courseId));
     expect(result).toEqual(data);
   });

--- a/src/import-page/data/thunks.js
+++ b/src/import-page/data/thunks.js
@@ -6,7 +6,7 @@ import { RequestStatus } from '../../data/constants';
 import { setImportCookie } from '../utils';
 import { getImportStatus, startCourseImporting } from './api';
 import {
-  reset, updateCurrentStage, updateError, updateFileName,
+  reset, updateCurrentStage, updateError, updateFileName, updateProgress,
   updateImportTriggered, updateLoadingStatus, updateSavingStatus, updateSuccessDate,
 } from './slice';
 import { IMPORT_STAGES, LAST_IMPORT_COOKIE_NAME } from './constants';
@@ -44,9 +44,14 @@ export function handleProcessUpload(courseId, fileData, requestConfig, handleErr
       const file = fileData.get('file');
       dispatch(reset());
       dispatch(updateSavingStatus(RequestStatus.PENDING));
-      dispatch(updateImportTriggered(true));
       dispatch(updateFileName(file.name));
-      const { importStatus } = await startCourseImporting(courseId, file, requestConfig);
+      dispatch(updateImportTriggered(true));
+      const { importStatus } = await startCourseImporting(
+        courseId,
+        file,
+        requestConfig,
+        (percent) => dispatch(updateProgress(percent)),
+      );
       dispatch(updateCurrentStage(importStatus));
       setImportCookie(moment().valueOf(), importStatus === IMPORT_STAGES.SUCCESS, file.name);
       dispatch(updateSavingStatus(RequestStatus.SUCCESSFUL));

--- a/src/import-page/file-section/FileSection.jsx
+++ b/src/import-page/file-section/FileSection.jsx
@@ -11,7 +11,6 @@ import { IMPORT_STAGES } from '../data/constants';
 import {
   getCurrentStage, getError, getFileName, getImportTriggered,
 } from '../data/selectors';
-import { updateProgress } from '../data/slice';
 import messages from './messages';
 import { handleProcessUpload } from '../data/thunks';
 
@@ -42,7 +41,6 @@ const FileSection = ({ intl, courseId }) => {
                   handleError,
                 ))
               }
-              onUploadProgress={(percent) => dispatch(updateProgress(percent))}
               accept={{ 'application/gzip': ['.tar.gz'] }}
               data-testid="dropzone"
             />

--- a/src/import-page/import-stepper/ImportStepper.jsx
+++ b/src/import-page/import-stepper/ImportStepper.jsx
@@ -95,7 +95,7 @@ const ImportStepper = ({ intl, courseId }) => {
       <h3 className="mt-4">{intl.formatMessage(messages.stepperHeaderTitle)}</h3>
       <CourseStepper
         courseId={courseId}
-        percent={progress}
+        percent={currentStage === IMPORT_STAGES.UPLOADING ? progress : null}
         steps={steps}
         activeKey={currentStage}
         hasError={hasError}


### PR DESCRIPTION
JIRA Ticket: [TNL-11308](https://2u-internal.atlassian.net/browse/TNL-11308)

When chunking the uploaded file was introduced, the upload progress percentage began to loop for each chunks upload. The looping of percentages is confusing to users as it seems like the upload is stuck in an infinite loop and they do not know how much the file has successfully uploaded. This PR fixes the progress bar so it updates after each chunk is uploaded.

Test
1. Export the current content of your course
2. Open the network tab in DevTools
3. Import the recently exported file
4. Progress percentage in Uploading step should only reach 100% one time even when the file is chunked multiple times (confirm number of chunks in network tab)