### PR TITLE
feat: Add v2 lib components content tags support

### DIFF
--- a/src/content-tags-drawer/data/api.js
+++ b/src/content-tags-drawer/data/api.js
@@ -29,7 +29,8 @@ export const getTaxonomyTagsApiUrl = (taxonomyId, options = {}) => {
   return url.href;
 };
 export const getContentTaxonomyTagsApiUrl = (contentId) => new URL(`api/content_tagging/v1/object_tags/${contentId}/`, getApiBaseUrl()).href;
-export const getContentDataApiUrl = (contentId) => new URL(`/xblock/outline/${contentId}`, getApiBaseUrl()).href;
+export const getXBlockContentDataApiURL = (contentId) => new URL(`/xblock/outline/${contentId}`, getApiBaseUrl()).href;
+export const getLibraryContentDataApiUrl = (contentId) => new URL(`/api/libraries/v2/blocks/${contentId}/`, getApiBaseUrl()).href;
 
 /**
  * Get all tags that belong to taxonomy.
@@ -59,7 +60,10 @@ export async function getContentTaxonomyTagsData(contentId) {
  * @returns {Promise<import("./types.mjs").ContentData>}
  */
 export async function getContentData(contentId) {
-  const { data } = await getAuthenticatedHttpClient().get(getContentDataApiUrl(contentId));
+  const url = contentId.startsWith('lb:')
+    ? getLibraryContentDataApiUrl(contentId)
+    : getXBlockContentDataApiURL(contentId);
+  const { data } = await getAuthenticatedHttpClient().get(url);
   return camelCaseObject(data);
 }
 

--- a/src/content-tags-drawer/data/api.test.js
+++ b/src/content-tags-drawer/data/api.test.js
@@ -13,7 +13,8 @@ import {
 import {
   getTaxonomyTagsApiUrl,
   getContentTaxonomyTagsApiUrl,
-  getContentDataApiUrl,
+  getXBlockContentDataApiURL,
+  getLibraryContentDataApiUrl,
   getTaxonomyTagsData,
   getContentTaxonomyTagsData,
   getContentData,
@@ -87,12 +88,21 @@ describe('content tags drawer api calls', () => {
     expect(result).toEqual(contentTaxonomyTagsMock[contentId]);
   });
 
-  it('should get content data', async () => {
+  it('should get content data for course component', async () => {
     const contentId = 'block-v1:SampleTaxonomyOrg1+STC1+2023_1+type@vertical+block@aaf8b8eb86b54281aeeab12499d2cb0b';
-    axiosMock.onGet(getContentDataApiUrl(contentId)).reply(200, contentDataMock);
+    axiosMock.onGet(getXBlockContentDataApiURL(contentId)).reply(200, contentDataMock);
     const result = await getContentData(contentId);
 
-    expect(axiosMock.history.get[0].url).toEqual(getContentDataApiUrl(contentId));
+    expect(axiosMock.history.get[0].url).toEqual(getXBlockContentDataApiURL(contentId));
+    expect(result).toEqual(contentDataMock);
+  });
+
+  it('should get content data for V2 library component', async () => {
+    const contentId = 'lb:SampleTaxonomyOrg1:NTL1:html:a3eded6b-2106-429a-98be-63533d563d79';
+    axiosMock.onGet(getLibraryContentDataApiUrl(contentId)).reply(200, contentDataMock);
+    const result = await getContentData(contentId);
+
+    expect(axiosMock.history.get[0].url).toEqual(getLibraryContentDataApiUrl(contentId));
     expect(result).toEqual(contentDataMock);
   });
 


### PR DESCRIPTION
## Description

Add support for fetching content data for Library V2 components in content tags drawer.

## Supporting Information
Related Tickets:
- Needed for https://github.com/openedx/frontend-app-library-authoring/pull/400

## Testing Instructions

- Follow the testing/setup instructions in https://github.com/openedx/frontend-app-course-authoring/pull/737 and make sure the content tags drawer still functions as expected for course components
- Perform the testing instructions mentioned in https://github.com/openedx/frontend-app-library-authoring/pull/400 to confirm the changes is working correctly

---
Private-ref: [FAL-3599](https://tasks.opencraft.com/browse/FAL-3599)
