### PR TITLE
fix: video upload api body

### DIFF
--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -186,7 +186,7 @@ export async function uploadVideo(
   })
     .then(async (response) => {
       if (!response.ok) {
-        throw new Error()
+        throw new Error();
       }
       await getAuthenticatedHttpClient()
         .post(getCourseVideosApiUrl(courseId), [{

--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -174,17 +174,20 @@ export async function uploadVideo(
   uploadFile,
   edxVideoId,
 ) {
-  const formData = new FormData();
-  formData.append('uploaded-file', uploadFile);
   const uploadErrors = [];
   await fetch(uploadUrl, {
     method: 'PUT',
-    body: formData,
     headers: {
-      'Content-Type': 'multipart/form-data',
+      'Content-Disposition': `attachment; filename="${uploadFile.name}"`,
+      'Content-Type': uploadFile.type,
     },
+    multipart: false,
+    body: uploadFile,
   })
-    .then(async () => {
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error()
+      }
       await getAuthenticatedHttpClient()
         .post(getCourseVideosApiUrl(courseId), [{
           edxVideoId,


### PR DESCRIPTION
JIRA Ticket: [TNL-11350](https://2u-internal.atlassian.net/browse/TNL-11350)

> Users can successfully upload videos, but they never leave the processing stage. Looking at the network tab it looks like the upload to AWS fails, but the user is never notified of the failure.

This PR fixes the `PUT` to AWS to more closely align with the legacy API that uses AJAX and JQuery. This PR allow properly handles the failure state of the `PUT` request when the API return a failure message.

Note: This PR requires a successfully set up video pipeline to properly test

Testing

1. Navigate to the videos page
2. Open network tab
3. Upload a video
4. Video should appear with processing badge on thumbnail
5. Check the network tab to see that that video successfully sent to AWS
6. Reload page and a bit of time
7. Video should no longer have processing page and show default thumbnail