### PR TITLE
fix: react-router basepath was not set, breaking this MFE on tutor instances

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,7 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
 import {
-  APP_INIT_ERROR, APP_READY, subscribe, initialize, mergeConfig,
+  APP_INIT_ERROR, APP_READY, subscribe, initialize, mergeConfig, getConfig, getPath,
 } from '@edx/frontend-platform';
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
 import React, { useEffect } from 'react';
@@ -71,6 +71,9 @@ const App = () => {
         )}
       </Route>,
     ),
+    {
+      basename: getPath(getConfig().PUBLIC_PATH),
+    },
   );
 
   return (


### PR DESCRIPTION
The PR https://github.com/openedx/frontend-app-course-authoring/pull/723 changed how `react-router` is initialized, but introduced a bug where the router `basename` was not set properly. This would not cause issues on edx.org prod nor devstack, but it breaks tutor-based environments where all the MFEs are served from the same host.

Before this fix: http://apps.local.overhang.io:2001/course-authoring/home gives a 404
After this fix: http://apps.local.overhang.io:2001/course-authoring/home shows the Studio home

Same for other URLs.

Screenshot of the error:

![Screenshot 2024-01-09 at 1 20 23 PM](https://github.com/openedx/frontend-app-course-authoring/assets/945577/211d88e4-1a28-4a78-8703-bdec495669c1)

Note: the fix just follows [how `frontend-platform` sets the `basename`](https://github.com/search?q=repo%3Aopenedx%2Ffrontend-platform%20PUBLIC_PATH&type=code).

Private-ref: FAL-3537