### PR TITLE
fix: export page timestamp

### DIFF
--- a/src/export-page/data/thunks.js
+++ b/src/export-page/data/thunks.js
@@ -45,17 +45,10 @@ export function fetchExportStatus(courseId) {
   return async (dispatch) => {
     dispatch(updateLoadingStatus({ status: RequestStatus.IN_PROGRESS }));
     try {
-      const { exportStatus, exportOutput, exportError } = await getExportStatus(courseId);
+      const {
+        exportStatus, exportOutput, exportError,
+      } = await getExportStatus(courseId);
       dispatch(updateCurrentStage(Math.abs(exportStatus)));
-
-      if (exportOutput) {
-        if (exportOutput.startsWith('/')) {
-          dispatch(updateDownloadPath(`${getConfig().STUDIO_BASE_URL}${exportOutput}`));
-        } else {
-          dispatch(updateDownloadPath(exportOutput));
-        }
-        dispatch(updateSuccessDate(moment().valueOf()));
-      }
 
       const cookies = new Cookies();
       const cookieData = cookies.get(LAST_EXPORT_COOKIE_NAME);
@@ -68,6 +61,15 @@ export function fetchExportStatus(courseId) {
         const errorUnitUrl = exportError.editUnitUrl || null;
         dispatch(updateError({ msg: errorMessage, unitUrl: errorUnitUrl }));
         dispatch(updateIsErrorModalOpen(true));
+      }
+
+      if (exportOutput && !cookieData?.completed) {
+        if (exportOutput.startsWith('/')) {
+          dispatch(updateDownloadPath(`${getConfig().STUDIO_BASE_URL}${exportOutput}`));
+        } else {
+          dispatch(updateDownloadPath(exportOutput));
+        }
+        dispatch(updateSuccessDate(moment().valueOf()));
       }
 
       dispatch(updateLoadingStatus({ status: RequestStatus.SUCCESSFUL }));

--- a/src/export-page/data/thunks.test.js
+++ b/src/export-page/data/thunks.test.js
@@ -1,0 +1,117 @@
+import { fetchExportStatus } from './thunks';
+import * as api from './api';
+import { EXPORT_STAGES } from './constants';
+
+describe('fetchExportStatus thunk', () => {
+  const dispatch = jest.fn();
+  const getState = jest.fn();
+  const courseId = 'course-123';
+  const exportStatus = 2;
+  const exportOutput = 'export output';
+  const exportError = 'export error';
+  let mockGetExportStatus;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetExportStatus = jest.spyOn(api, 'getExportStatus').mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError,
+    });
+  });
+
+  it('should dispatch updateCurrentStage with export status', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: exportStatus,
+      type: 'exportPage/updateCurrentStage',
+    });
+  });
+
+  it('should dispatch updateError with export error', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: {
+        msg: exportError,
+        unitUrl: null,
+      },
+      type: 'exportPage/updateError',
+    });
+  });
+
+  it('should dispatch updateIsErrorModalOpen with true if export error', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: true,
+      type: 'exportPage/updateIsErrorModalOpen',
+    });
+  });
+
+  it('should dispatch updateIsErrorModalOpen with false if no export error', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError: null,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: false,
+      type: 'exportPage/updateIsErrorModalOpen',
+    });
+  });
+
+  it('should dispatch updateDownloadPath with export output', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus,
+      exportOutput,
+      exportError,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: exportOutput,
+      type: 'exportPage/updateDownloadPath',
+    });
+  });
+
+  it('should dispatch updateSuccessDate with current date if export status is success', async () => {
+    mockGetExportStatus.mockResolvedValue({
+      exportStatus:
+        EXPORT_STAGES.SUCCESS,
+      exportOutput,
+      exportError,
+    });
+
+    await fetchExportStatus(courseId)(dispatch, getState);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: expect.any(Number),
+      type: 'exportPage/updateSuccessDate',
+    });
+  });
+});


### PR DESCRIPTION
Internal issue: https://2u-internal.atlassian.net/browse/TNL-11334

The timestamp of the new export page was always showing the current time, not the export time.

### How to test:

- go to export page for a very small course (so export won't take long for you to test)
- create an export. Check timestamp
- wait 1 minute, refresh page
- export should not show current time but previous timestamp
- create new export
- now timestamp should show new time