### PR TITLE
fix: dont allow course detail page to break editor

### DIFF
--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -54,9 +54,9 @@ const CourseAuthoringPage = ({ courseId, children }) => {
   const courseDetailStatus = useSelector(state => state.courseDetail.status);
   const inProgress = courseDetailStatus === RequestStatus.IN_PROGRESS;
   const { pathname } = useLocation();
-  const showHeader = !pathname.includes('/editor');
+  const isEditor = pathname.includes('/editor');
 
-  if (courseDetailStatus === RequestStatus.NOT_FOUND) {
+  if (courseDetailStatus === RequestStatus.NOT_FOUND && !isEditor) {
     return (
       <NotFoundAlert />
     );
@@ -72,8 +72,8 @@ const CourseAuthoringPage = ({ courseId, children }) => {
       using url pattern containing /editor/,
       we shouldn't have the header and footer on these pages.
       This functionality will be removed in TNL-9591 */}
-      {inProgress ? showHeader && <Loading />
-        : (showHeader && (
+      {inProgress ? !isEditor && <Loading />
+        : (!isEditor && (
           <AppHeader
             courseNumber={courseNumber}
             courseOrg={courseOrg}
@@ -83,7 +83,7 @@ const CourseAuthoringPage = ({ courseId, children }) => {
         )
         )}
       {children}
-      {!inProgress && showHeader && <StudioFooter />}
+      {!inProgress && !isEditor && <StudioFooter />}
     </div>
   );
 };


### PR DESCRIPTION
At the moment, editors served from V1 libraries are broken because they use the course authoring MFE url (because they use editors in the same way courses do).

This was introduced here: https://github.com/openedx/frontend-app-course-authoring/pull/761

This fix fixes that.