### PR TITLE
fix: mov files not being allowed on video upload

### DIFF
--- a/src/files-and-videos/videos-page/data/utils.js
+++ b/src/files-and-videos/videos-page/data/utils.js
@@ -110,11 +110,19 @@ export const getSupportedFormats = (supportedFileFormats) => {
     let format;
     if (isArray(value)) {
       value.forEach(val => {
-        format = key.replace('*', val.substring(1));
+        if (val === '.mov') {
+          format = key.replace('*', 'quicktime');
+        } else {
+          format = key.replace('*', val.substring(1));
+        }
         supportedFormats.push(format);
       });
     } else {
-      format = key.replace('*', value?.substring(1));
+      if (value === '.mov') {
+        format = key.replace('*', 'quicktime');
+      } else {
+        format = key.replace('*', value.substring(1));
+      }
       supportedFormats.push(format);
     }
   });

--- a/src/files-and-videos/videos-page/data/utils.test.js
+++ b/src/files-and-videos/videos-page/data/utils.test.js
@@ -24,7 +24,7 @@ describe('getSupportedFormats', () => {
     expect(expected).toEqual(actual);
   });
   it('should return array of valid file types', () => {
-    const expected = ['video/mp4', 'video/mov'];
+    const expected = ['video/mp4', 'video/quicktime'];
     const actual = getSupportedFormats({ 'video/*': ['.mp4', '.mov'] });
     expect(expected).toEqual(actual);
   });

--- a/src/files-and-videos/videos-page/data/utils.test.js
+++ b/src/files-and-videos/videos-page/data/utils.test.js
@@ -23,6 +23,11 @@ describe('getSupportedFormats', () => {
     const actual = getSupportedFormats({ 'image/*': '.png' });
     expect(expected).toEqual(actual);
   });
+  it('should return video/quicktime for .mov', () => {
+    const expected = ['video/quicktime'];
+    const actual = getSupportedFormats({ 'video/*': '.mov' });
+    expect(expected).toEqual(actual);
+  });
   it('should return array of valid file types', () => {
     const expected = ['video/mp4', 'video/quicktime'];
     const actual = getSupportedFormats({ 'video/*': ['.mp4', '.mov'] });


### PR DESCRIPTION
The previous parser for video file types converted `{'video/*': [.mov]}` to `video/mov`. However `video/mov` is not a valid mime type. `.mov` files actually have the mime type `video/quicktime`. This PR fixes this mime type error.

Testing

1. Navigate to a course that has videos
2. Navigate to the Videos page (ensure that the .env variable `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN` is true)
3. Click "Add Videos"
4. Confirm that both `.mp4` and `.mov` are allowed.