### PR TITLE
feat: add missing transcript setting update date

### DIFF
--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -339,6 +339,7 @@ export function clearAutomatedTranscript({ courseId }) {
 
     try {
       await deleteTranscriptPreferences(courseId);
+      dispatch(updateTranscriptPreferenceSuccess({ modified: new Date() }));
       dispatch(updateEditStatus({ editType: 'transcript', status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
       dispatch(updateErrors({ error: 'transcript', message: 'Failed to update order transcripts settings.' }));

--- a/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/OrderTranscriptForm.jsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  FormattedMessage,
+  FormattedDate,
+  injectIntl,
+  intlShape,
+} from '@edx/frontend-platform/i18n';
 import { Button, SelectableBox, Stack } from '@edx/paragon';
 import { ErrorAlert } from '@edx/frontend-lib-content-components';
 import Cielo24Form from './Cielo24Form';
@@ -143,6 +148,19 @@ const OrderTranscriptForm = ({
         <Button variant="tertiary" onClick={handleDiscard}>
           <FormattedMessage {...messages.discardSettingsLabel} />
         </Button>
+        {activeTranscriptPreferences?.modified && (
+          <div className="row m-0 x-small">
+            <div className="mr-1">
+              <FormattedMessage {...messages.lastUpdatedMessage} />
+            </div>
+            <FormattedDate
+              value={data.modified}
+              year="numeric"
+              month="long"
+              day="2-digit"
+            />
+          </div>
+        )}
       </Stack>
     </>
   );
@@ -157,6 +175,7 @@ OrderTranscriptForm.propTypes = {
     preferredLanguages: PropTypes.arrayOf(PropTypes.string),
     turnaround: PropTypes.string,
     videoSourceLanguage: PropTypes.string,
+    modified: PropTypes.instanceOf(Date),
   }),
   transcriptType: PropTypes.string.isRequired,
   transcriptCredentials: PropTypes.shape({

--- a/src/files-and-videos/videos-page/transcript-settings/messages.js
+++ b/src/files-and-videos/videos-page/transcript-settings/messages.js
@@ -45,8 +45,13 @@ const messages = defineMessages({
   },
   discardSettingsLabel: {
     id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.discardSettings.label',
-    defaultMessage: 'Discard settings',
+    defaultMessage: 'Discard changes',
     description: 'Label for order transcript discard settings button',
+  },
+  lastUpdatedMessage: {
+    id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.lastUpdated.message',
+    defaultMessage: 'Last updated',
+    description: 'Message that lets user know when the update was made to transcript settings',
   },
   threePlayMediaTurnaroundLabel: {
     id: 'course-authoring.video-uploads.transcriptSettings.orderTranscripts.3PlayMedia.turnaround.label',


### PR DESCRIPTION
JIRA Ticket: [TNL-11261](https://2u-internal.atlassian.net/browse/TNL-11261)

> On the new CA MFE videos page, the Transcript Settings pane has a “Discard Settings” button that should be labeled “Discard Changes”
> 
> Below this should be a small text line saying when the last updated timestamp was.  This is to be in parity with the legacy UI feature.

Testing

1. Navigate to the Videos page (ensure that the .env variable `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN` is true)
2. Click "Transcript settings"
3. Click "Order Transcripts"
4. Click "None"
5. Discard button should read "Discard changes"
6. Click "Update settings"
7. "Last updated {current date / Month Date, Year} " should appear below buttons