### PR TITLE
fix: gallery card text and load

### DIFF
--- a/src/files-and-videos/videos-page/VideoThumbnail.jsx
+++ b/src/files-and-videos/videos-page/VideoThumbnail.jsx
@@ -33,7 +33,7 @@ const VideoThumbnail = ({
   let addThumbnailMessage = 'Add thumbnail';
   if (allowThumbnailUpload) {
     if (thumbnail) {
-      addThumbnailMessage = 'Edit thumbnail';
+      addThumbnailMessage = 'Replace thumbnail';
     }
   }
   const supportedFiles = videoImageSettings?.supportedFileFormats

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -60,6 +60,10 @@ export function fetchVideos(courseId) {
 
     try {
       const { previousUploads, ...data } = await getVideos(courseId);
+      dispatch(setPageSettings({ ...data }));
+      // Previous uploads are the current videos associated with a course.
+      // If previous uploads are empty there is no need to add an empty model
+      // or loop through and empty list so automatically set loading to successful
       if (isEmpty(previousUploads)) {
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
       } else {
@@ -68,7 +72,6 @@ export function fetchVideos(courseId) {
         dispatch(setVideoIds({
           videoIds: parsedVideos.map(video => video.id),
         }));
-        dispatch(setPageSettings({ ...data }));
         parsedVideos.forEach(async (video, indx) => {
           const isLast = parsedVideos.length - 1 === indx;
           fetchUsageLocation(video.id, dispatch, courseId, isLast);

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -37,7 +37,7 @@ import {
 
 import { updateFileValues } from './utils';
 
-async function fetchUsageLocation(videoId, dispatch, courseId) {
+async function fetchUsageLocation(videoId, dispatch, courseId, isLast) {
   const { usageLocations } = await getVideoUsagePaths({ videoId, courseId });
   const activeStatus = usageLocations?.length > 0 ? 'active' : 'inactive';
 
@@ -49,6 +49,9 @@ async function fetchUsageLocation(videoId, dispatch, courseId) {
       activeStatus,
     },
   }));
+  if (isLast) {
+    dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
+  }
 }
 
 export function fetchVideos(courseId) {
@@ -57,16 +60,20 @@ export function fetchVideos(courseId) {
 
     try {
       const { previousUploads, ...data } = await getVideos(courseId);
-      const parsedVideos = updateFileValues(previousUploads);
-      dispatch(addModels({ modelType: 'videos', models: parsedVideos }));
-      dispatch(setVideoIds({
-        videoIds: parsedVideos.map(video => video.id),
-      }));
-      dispatch(setPageSettings({ ...data }));
-      dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
-      parsedVideos.forEach(async (video) => {
-        fetchUsageLocation(video.id, dispatch, courseId);
-      });
+      if (isEmpty(previousUploads)) {
+        dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
+      } else {
+        const parsedVideos = updateFileValues(previousUploads);
+        dispatch(addModels({ modelType: 'videos', models: parsedVideos }));
+        dispatch(setVideoIds({
+          videoIds: parsedVideos.map(video => video.id),
+        }));
+        dispatch(setPageSettings({ ...data }));
+        parsedVideos.forEach(async (video, indx) => {
+          const isLast = parsedVideos.length - 1 === indx;
+          fetchUsageLocation(video.id, dispatch, courseId, isLast);
+        });
+      }
     } catch (error) {
       if (error.response && error.response.status === 403) {
         dispatch(updateLoadingStatus({ status: RequestStatus.DENIED }));

--- a/src/files-and-videos/videos-page/data/utils.js
+++ b/src/files-and-videos/videos-page/data/utils.js
@@ -26,7 +26,15 @@ export const updateFileValues = (files, isNewFile) => {
       status,
       transcripts,
     } = file;
-    const wrapperType = 'video';
+
+    let wrapperType;
+    if (clientVideoId.endsWith('.mov')) {
+      wrapperType = 'MOV';
+    } else if (clientVideoId.endsWith('.mp4')) {
+      wrapperType = 'MP4';
+    } else {
+      wrapperType = 'Unknown';
+    }
 
     let thumbnail = courseVideoImageUrl;
     if (thumbnail && thumbnail.startsWith('/')) {

--- a/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
+++ b/src/files-and-videos/videos-page/factories/mockApiResponses.jsx
@@ -125,7 +125,7 @@ export const generateFetchVideosApiResponse = () => ({
     },
     {
       edx_video_id: 'mOckID5',
-      clientVideoId: 'mOckID5.mp4',
+      clientVideoId: 'mOckID5',
       created: '',
       courseVideoImageUrl: 'http:/video',
       transcripts: ['en'],


### PR DESCRIPTION
JIRA Tickets [TNL-11354](https://2u-internal.atlassian.net/browse/TNL-11354)
> On Video Page and in Info Modal, hovering over the thumbnail prompts me to “Edit Thumbnail”. However, technically I can’t edit it, only replace it so it is more accurate to say “Replace Thumbnail”.
[TNL-11355](https://2u-internal.atlassian.net/browse/TNL-11355)
> Every tile has a little label that says “Video”. This seems wholly unnecessary on a page that can only have videos. The mocks present the file suffix (MOV, MP4). I’m not sure how valuable that information is either but either way it feels odd.

Testing
1. Open the Videos page
2. After the page loads, make sure you are in the gallery view
3. For each video, check that each card has the correct video type chip (MOV, MP4, Unknown)
   * the chip is determined by the suffix of the video name
 4. Hover over a thumbnail that hasn't been set
 5. Button should read "Add thumbnail"
 6. Hover over a thumbnail that has been set
 7. Button should read "Replace thumbnail"