### PR TITLE
feat: add search highlight/expand  and "no tags" message [FC-0036]

### DIFF
--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -123,7 +123,8 @@ const ContentTagsCollapsible = ({ contentId, taxonomyAndTagsData }) => {
 
   const handleSearchChange = React.useCallback((value) => {
     if (value === '') {
-      // No need to debounce when search term cleared
+      // No need to debounce when search term cleared. Clear debounce function
+      handleSearch.cancel();
       setSearchTerm('');
     } else {
       handleSearch(value);

--- a/src/content-tags-drawer/ContentTagsCollapsible.test.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.test.jsx
@@ -18,12 +18,12 @@ jest.mock('./data/apiHooks', () => ({
   })),
   useTaxonomyTagsData: jest.fn(() => ({
     hasMorePages: false,
-    tagPages: [{
+    tagPages: {
       isLoading: true,
       isError: false,
       canAddTag: false,
       data: [],
-    }],
+    },
   })),
 }));
 
@@ -85,7 +85,7 @@ describe('<ContentTagsCollapsible />', () => {
     useTaxonomyTagsData.mockReturnValue({
       hasMorePages: false,
       canAddTag: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
         data: [{
@@ -119,7 +119,7 @@ describe('<ContentTagsCollapsible />', () => {
           canChangeTag: false,
           canDeleteTag: false,
         }],
-      }],
+      },
     });
   }
 

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
@@ -13,11 +13,11 @@ import { useTaxonomyTagsData } from './data/apiHooks';
 jest.mock('./data/apiHooks', () => ({
   useTaxonomyTagsData: jest.fn(() => ({
     hasMorePages: false,
-    tagPages: [{
+    tagPages: {
       isLoading: true,
       isError: false,
       data: [],
-    }],
+    },
   })),
 }));
 
@@ -70,7 +70,7 @@ describe('<ContentTagsDropDownSelector />', () => {
   it('should render taxonomy tags drop down selector with no sub tags', async () => {
     useTaxonomyTagsData.mockReturnValue({
       hasMorePages: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
         data: [{
@@ -82,7 +82,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           id: 12345,
           subTagsUrl: null,
         }],
-      }],
+      },
     });
 
     await act(async () => {
@@ -104,7 +104,7 @@ describe('<ContentTagsDropDownSelector />', () => {
   it('should render taxonomy tags drop down selector with sub tags', async () => {
     useTaxonomyTagsData.mockReturnValue({
       hasMorePages: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
         data: [{
@@ -116,7 +116,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           id: 12345,
           subTagsUrl: 'http://localhost:18010/api/content_tagging/v1/taxonomies/4/tags/?parent_tag=Tag%202',
         }],
-      }],
+      },
     });
 
     await act(async () => {
@@ -137,7 +137,7 @@ describe('<ContentTagsDropDownSelector />', () => {
   it('should expand on click taxonomy tags drop down selector with sub tags', async () => {
     useTaxonomyTagsData.mockReturnValueOnce({
       hasMorePages: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
         data: [{
@@ -149,7 +149,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           id: 12345,
           subTagsUrl: 'http://localhost:18010/api/content_tagging/v1/taxonomies/4/tags/?parent_tag=Tag%202',
         }],
-      }],
+      },
     });
 
     await act(async () => {
@@ -177,7 +177,7 @@ describe('<ContentTagsDropDownSelector />', () => {
       // Mock useTaxonomyTagsData again since it gets called in the recursive call
       useTaxonomyTagsData.mockReturnValueOnce({
         hasMorePages: false,
-        tagPages: [{
+        tagPages: {
           isLoading: false,
           isError: false,
           data: [{
@@ -189,7 +189,7 @@ describe('<ContentTagsDropDownSelector />', () => {
             id: 12346,
             subTagsUrl: null,
           }],
-        }],
+        },
       });
 
       // Expand the dropdown to see the subtags selectors
@@ -205,7 +205,7 @@ describe('<ContentTagsDropDownSelector />', () => {
   it('should expand on enter key taxonomy tags drop down selector with sub tags', async () => {
     useTaxonomyTagsData.mockReturnValueOnce({
       hasMorePages: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
         data: [{
@@ -217,7 +217,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           id: 12345,
           subTagsUrl: 'http://localhost:18010/api/content_tagging/v1/taxonomies/4/tags/?parent_tag=Tag%202',
         }],
-      }],
+      },
     });
 
     await act(async () => {
@@ -245,7 +245,7 @@ describe('<ContentTagsDropDownSelector />', () => {
       // Mock useTaxonomyTagsData again since it gets called in the recursive call
       useTaxonomyTagsData.mockReturnValueOnce({
         hasMorePages: false,
-        tagPages: [{
+        tagPages: {
           isLoading: false,
           isError: false,
           data: [{
@@ -257,7 +257,7 @@ describe('<ContentTagsDropDownSelector />', () => {
             id: 12346,
             subTagsUrl: null,
           }],
-        }],
+        },
       });
 
       // Expand the dropdown to see the subtags selectors
@@ -273,9 +273,10 @@ describe('<ContentTagsDropDownSelector />', () => {
   it('should render taxonomy tags drop down selector and change search term', async () => {
     useTaxonomyTagsData.mockReturnValueOnce({
       hasMorePages: false,
-      tagPages: [{
+      tagPages: {
         isLoading: false,
         isError: false,
+        isSuccess: true,
         data: [{
           value: 'Tag 1',
           externalId: null,
@@ -285,7 +286,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           id: 12345,
           subTagsUrl: null,
         }],
-      }],
+      },
     });
 
     const initalSearchTerm = 'test 1';
@@ -316,6 +317,52 @@ describe('<ContentTagsDropDownSelector />', () => {
       await waitFor(() => {
         expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, updatedSearchTerm);
       });
+
+      // Clean search term
+      const cleanSearchTerm = '';
+      rerender(<ContentTagsDropDownSelectorComponent
+        key={`selector-${data.taxonomyId}`}
+        taxonomyId={data.taxonomyId}
+        level={data.level}
+        tagsTree={data.tagsTree}
+        searchTerm={cleanSearchTerm}
+      />);
+
+      await waitFor(() => {
+        expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, cleanSearchTerm);
+      });
+    });
+  });
+
+  it('should render "noTag" message if search doesnt return taxonomies', async () => {
+    useTaxonomyTagsData.mockReturnValueOnce({
+      hasMorePages: false,
+      tagPages: {
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        data: [],
+      },
+    });
+
+    const searchTerm = 'uncommon search term';
+    await act(async () => {
+      const { getByText } = render(
+        <ContentTagsDropDownSelectorComponent
+          key={`selector-${data.taxonomyId}`}
+          taxonomyId={data.taxonomyId}
+          level={data.level}
+          tagsTree={data.tagsTree}
+          searchTerm={searchTerm}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, searchTerm);
+      });
+
+      const message = `No tags found with the search term "${searchTerm}"`;
+      expect(getByText(message)).toBeInTheDocument();
     });
   });
 });

--- a/src/content-tags-drawer/data/api.js
+++ b/src/content-tags-drawer/data/api.js
@@ -75,8 +75,8 @@ export async function getContentData(contentId) {
  * @returns {Promise<import("./types.mjs").ContentTaxonomyTagsData>}
  */
 export async function updateContentTaxonomyTags(contentId, taxonomyId, tags) {
-  const url = getContentTaxonomyTagsApiUrl(contentId);
-  const params = { taxonomy: taxonomyId };
-  const { data } = await getAuthenticatedHttpClient().put(url, { tags }, { params });
+  let url = getContentTaxonomyTagsApiUrl(contentId);
+  url = `${url}&taxonomy=${taxonomyId}`;
+  const { data } = await getAuthenticatedHttpClient().put(url, { tags });
   return camelCaseObject(data[contentId]);
 }

--- a/src/content-tags-drawer/data/api.test.js
+++ b/src/content-tags-drawer/data/api.test.js
@@ -110,11 +110,10 @@ describe('content tags drawer api calls', () => {
     const contentId = 'block-v1:SampleTaxonomyOrg1+STC1+2023_1+type@vertical+block@aaf8b8eb86b54281aeeab12499d2cb0b';
     const taxonomyId = 3;
     const tags = ['flat taxonomy tag 100', 'flat taxonomy tag 3856'];
-    axiosMock.onPut(`${getContentTaxonomyTagsApiUrl(contentId)}`).reply(200, updateContentTaxonomyTagsMock);
+    axiosMock.onPut(`${getContentTaxonomyTagsApiUrl(contentId)}&taxonomy=${taxonomyId}`).reply(200, updateContentTaxonomyTagsMock);
     const result = await updateContentTaxonomyTags(contentId, taxonomyId, tags);
 
-    expect(axiosMock.history.put[0].url).toEqual(`${getContentTaxonomyTagsApiUrl(contentId)}`);
-    expect(axiosMock.history.put[0].params).toEqual({ taxonomy: taxonomyId });
+    expect(axiosMock.history.put[0].url).toEqual(`${getContentTaxonomyTagsApiUrl(contentId)}&taxonomy=${taxonomyId}`);
     expect(result).toEqual(updateContentTaxonomyTagsMock[contentId]);
   });
 });

--- a/src/content-tags-drawer/data/apiHooks.test.jsx
+++ b/src/content-tags-drawer/data/apiHooks.test.jsx
@@ -67,9 +67,12 @@ describe('useTaxonomyTagsData', () => {
       ],
     };
 
-    useQueries.mockReturnValue([
-      { data: mockData, isLoading: false, isError: false },
-    ]);
+    useQueries.mockReturnValue([{
+      data: mockData,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+    }]);
 
     const { result } = renderHook(() => useTaxonomyTagsData(taxonomyId));
 
@@ -83,10 +86,11 @@ describe('useTaxonomyTagsData', () => {
     expect(result.current.hasMorePages).toEqual(false);
     // Only includes the first 2 tags because the other 2 would be
     // in the nested dropdown
-    expect(result.current.tagPages).toEqual([
+    expect(result.current.tagPages).toEqual(
       {
         isLoading: false,
         isError: false,
+        isSuccess: true,
         data: [
           {
             value: 'tag 1',
@@ -108,7 +112,7 @@ describe('useTaxonomyTagsData', () => {
           },
         ],
       },
-    ]);
+    );
   });
 });
 

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -21,6 +21,10 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.load-more-tags.button',
     defaultMessage: 'Load more',
   },
+  noTagsFoundMessage: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.no-tags-found',
+    defaultMessage: 'No tags found with the search term "{searchTerm}"',
+  },
   taxonomyTagsCheckboxAriaLabel: {
     id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.selectable-box.aria.label',
     defaultMessage: '{tag} checkbox',


### PR DESCRIPTION
## Description
This PR makes minor improvements in the search taxonomy UI.
- It expands taxonomies that match the search and highlight the search term.
- Add "No tag found with search term '....'" message.

![tag-search](https://github.com/openedx/frontend-app-course-authoring/assets/849463/04c8933c-c0aa-4d4e-987e-741d1b742c47)

## Suporting Information
- Part of https://github.com/openedx/modular-learning/issues/176

## Testing instructions
Open the tagging drawer and check the search responses to different queries

___
Private-ref: [FAL-3615](https://tasks.opencraft.com/browse/FAL-3615)