### PR TITLE
feat: replace ai translations edx component with the openedx version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/frontend-component-ai-translations-edx": "^1.4.2",
+        "@edx/frontend-component-ai-translations": "^1.4.0",
         "@edx/frontend-component-footer": "^12.3.0",
         "@edx/frontend-component-header": "^4.7.0",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
@@ -2543,17 +2543,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/@edx/frontend-component-ai-translations-edx": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-ai-translations-edx/-/frontend-component-ai-translations-edx-1.4.2.tgz",
-      "integrity": "sha512-+gs9eDDonLcvikfclslOO0Y53WLi+RrKKB7PqpQcpojwhFJc5ZY+3Hk+tYtElheOBcrZJsptBtgExwQIH8Uqnw==",
+    "node_modules/@edx/frontend-component-ai-translations": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-ai-translations/-/frontend-component-ai-translations-1.4.0.tgz",
+      "integrity": "sha512-Y+XjfkyExqu1N6gt1bZnrW6+C/eqrwh+Xx21xt9TcsNoy8c/Gf3zPpoExrREpaI+OB4FNAP9KQHlOGcLQV7NQQ==",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-platform": "5.6.1",
-        "@edx/paragon": "21.5.6",
+        "@edx/paragon": "^21.5.6",
         "babel-polyfill": "6.26.0",
-        "prop-types": "^15.5.10",
-        "react-responsive": "8.2.0"
+        "prop-types": "15.8.1",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-responsive": "8.2.0",
+        "react-router-dom": "6.16.0"
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -2562,7 +2564,17 @@
         "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
-    "node_modules/@edx/frontend-component-ai-translations-edx/node_modules/react-responsive": {
+    "node_modules/@edx/frontend-component-ai-translations/node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/@edx/frontend-component-ai-translations/node_modules/react-responsive": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
       "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/frontend-component-ai-translations-edx": "^1.4.2",
+    "@edx/frontend-component-ai-translations": "^1.4.0",
     "@edx/frontend-component-footer": "^12.3.0",
     "@edx/frontend-component-header": "^4.7.0",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -11,7 +11,7 @@ import {
   TransitionReplace,
 } from '@edx/paragon';
 import { ChevronLeft, ChevronRight, Close } from '@edx/paragon/icons';
-import AITranslationsComponent from '@edx/frontend-component-ai-translations-edx';
+import AITranslationsComponent from '@edx/frontend-component-ai-translations';
 import OrderTranscriptForm from './OrderTranscriptForm';
 import messages from './messages';
 import {
@@ -116,12 +116,14 @@ const TranscriptSettings = ({
         )}
         {(!transcriptType && isAiTranslationsEnabled) && (
           <TransitionReplace>
-            <AITranslationsComponent
-              setIsAiTranslations={setIsAiTranslations}
-              closeTranscriptSettings={closeTranscriptSettings}
-              courseId={courseId}
-              key="ai-component"
-            />
+            <div data-testid="ai-translations-component">
+              <AITranslationsComponent
+                setIsAiTranslations={setIsAiTranslations}
+                closeTranscriptSettings={closeTranscriptSettings}
+                courseId={courseId}
+                key="ai-component"
+              />
+            </div>
           </TransitionReplace>
         )}
       </div>

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -691,7 +691,7 @@ describe('TranscriptSettings', () => {
     });
 
     it('doesn\'t display AI translations component if not enabled', () => {
-      expect(screen.queryByText('/Get free translations/')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('ai-translations-component')).not.toBeInTheDocument();
     });
   });
 
@@ -721,8 +721,8 @@ describe('TranscriptSettings', () => {
     });
 
     it('displays AI translations component if enabled', () => {
-      const component = screen.getByText(/Get free translations/);
-      expect(component).toBeVisible();
+      const component = screen.getByTestId('ai-translations-component');
+      expect(component).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### Summary
This PR replaces `@edx/frontend-component-ai-translations-edx` package with `@edx/frontend-component-ai-translations`. `@edx/frontend-component-ai-translations` is the public version and should be the default for CA MFE. `@edx/frontend-component-ai-translations-edx` will replace `@edx/frontend-component-ai-translations` at build time via `edx-internal`.