### PR TITLE
fix: error handling for save api call

### DIFF
--- a/src/schedule-and-details/data/thunks.js
+++ b/src/schedule-and-details/data/thunks.js
@@ -41,6 +41,7 @@ export function updateCourseDetailsQuery(courseId, details) {
       dispatch(updateCourseDetailsSuccess(detailsValues));
       return true;
     } catch (error) {
+      console.log('test',error)
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
       return false;
     }

--- a/src/schedule-and-details/hooks.jsx
+++ b/src/schedule-and-details/hooks.jsx
@@ -17,6 +17,7 @@ const useSaveValuesPrompt = (
   const savingStatus = useSelector(getSavingStatus);
   const [editedValues, setEditedValues] = useState(initialEditedData);
   const [showSuccessfulAlert, setShowSuccessfulAlert] = useState(false);
+  const [showFailedAlert, setShowFailedAlert] = useState(false);
   const [showModifiedAlert, setShowModifiedAlert] = useState(false);
   const [isQueryPending, setIsQueryPending] = useState(false);
   const [isEditableState, setIsEditableState] = useState(false);
@@ -36,6 +37,7 @@ const useSaveValuesPrompt = (
   const handleValuesChange = (value, fieldName) => {
     setIsEditableState(true);
     setShowSuccessfulAlert(false);
+    setShowFailedAlert(false);
 
     if (editedValues[fieldName] !== value) {
       setEditedValues((prevEditedValues) => ({
@@ -54,6 +56,7 @@ const useSaveValuesPrompt = (
     setEditedValues(initialEditedData || {});
     setShowModifiedAlert(false);
     setShowSuccessfulAlert(false);
+    setShowFailedAlert(false);
   };
 
   const handleUpdateValues = () => {
@@ -64,11 +67,13 @@ const useSaveValuesPrompt = (
   const handleInternetConnectionFailed = () => {
     setShowModifiedAlert(false);
     setShowSuccessfulAlert(false);
+    setShowFailedAlert(false);
     setIsQueryPending(false);
   };
 
   const handleQueryProcessing = () => {
     setShowSuccessfulAlert(false);
+    setShowFailedAlert(false);
     dispatch(updateDataQuery(courseId, updateWithDefaultValues(editedValues)));
   };
 
@@ -77,6 +82,15 @@ const useSaveValuesPrompt = (
       setIsQueryPending(false);
       setShowSuccessfulAlert(true);
       setTimeout(() => setShowSuccessfulAlert(false), 15000);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+
+      if (!isEditableState) {
+        setShowModifiedAlert(false);
+      }
+    } else if (savingStatus === RequestStatus.FAILED) {
+      setIsQueryPending(false);
+      setShowFailedAlert(true);
+      setTimeout(() => setShowFailedAlert(false), 15000);
       window.scrollTo({ top: 0, behavior: 'smooth' });
 
       if (!isEditableState) {
@@ -93,6 +107,7 @@ const useSaveValuesPrompt = (
     isEditableState,
     showModifiedAlert,
     showSuccessfulAlert,
+    showFailedAlert,
     dispatch,
     setErrorFields,
     handleResetValues,

--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -84,6 +84,7 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     isEditableState,
     showModifiedAlert,
     showSuccessfulAlert,
+    showFailedAlert,
     dispatch,
     handleResetValues,
     handleValuesChange,
@@ -182,6 +183,19 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
             )}
             aria-describedby={intl.formatMessage(
               messages.alertSuccessAriaDescribedby,
+            )}
+          />
+          <AlertMessage
+            show={showFailedAlert}
+            variant="danger"
+            icon={CheckCircleIcon}
+            title={intl.formatMessage(messages.alertFail)}
+            aria-hidden="true"
+            aria-labelledby={intl.formatMessage(
+              messages.alertFailAriaLabelledby,
+            )}
+            aria-describedby={intl.formatMessage(
+              messages.alertFailAriaDescribedby,
             )}
           />
           <header>

--- a/src/schedule-and-details/messages.js
+++ b/src/schedule-and-details/messages.js
@@ -57,6 +57,18 @@ const messages = defineMessages({
     id: 'course-authoring.schedule.alert.success',
     defaultMessage: 'Your changes have been saved.',
   },
+  alertFailAriaLabelledby: {
+    id: 'course-authoring.schedule.alert.fail.aria.labelledby',
+    defaultMessage: 'alert-confirmation-title',
+  },
+  alertFailAriaDescribedby: {
+    id: 'course-authoring.schedule.alert.fail.aria.describedby',
+    defaultMessage: 'alert-confirmation-description',
+  },
+  alertFail: {
+    id: 'course-authoring.schedule.alert.failed',
+    defaultMessage: 'We encountered an error when saving your changes.',
+  },
   errorMessage1: {
     id: 'course-authoring.schedule.schedule-section.error-message-1',
     defaultMessage: 'The certificates display behavior must be \'A date after the course end date\' if certificate available date is set.',


### PR DESCRIPTION
This change adds error handling for when saving schedule and details page fails. The code follows the alert pattern set up for a successful save.

JIRA: https://2u-internal.atlassian.net/browse/TNL-11379