### PR TITLE
feat: xblock status component and copy & paste unit option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@fortawesome/react-fontawesome": "0.2.0",
         "@reduxjs/toolkit": "1.9.7",
         "@tanstack/react-query": "4.36.1",
+        "broadcast-channel": "^7.0.0",
         "classnames": "2.2.6",
         "core-js": "3.8.1",
         "email-validator": "2.0.4",
@@ -2022,18 +2023,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "license": "MIT",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
+      "integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "license": "MIT"
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -9271,6 +9274,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-7.0.0.tgz",
+      "integrity": "sha512-a2tW0Ia1pajcPBOGUF2jXlDnvE9d5/dg6BG9h60OmRUcZVr/veUrU8vEQFwwQIhwG3KVzYwSk3v2nRRGFgQDXQ==",
+      "dependencies": {
+        "@babel/runtime": "7.23.4",
+        "oblivious-set": "1.4.0",
+        "p-queue": "6.6.2",
+        "unload": "2.4.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/pubkey"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -21972,6 +21989,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.4.0.tgz",
+      "integrity": "sha512-szyd0ou0T8nsAqHtprRcP3WidfsN1TnAR5yWXf2mFCEr5ek3LEOkT6EZ/92Xfs74HIdyhG5WkGxIssMU0jBaeg==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -22201,6 +22226,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -22208,6 +22248,17 @@
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -27380,6 +27431,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
+      "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==",
+      "funding": {
+        "url": "https://github.com/sponsors/pubkey"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@fortawesome/react-fontawesome": "0.2.0",
     "@reduxjs/toolkit": "1.9.7",
     "@tanstack/react-query": "4.36.1",
+    "broadcast-channel": "^7.0.0",
     "classnames": "2.2.6",
     "core-js": "3.8.1",
     "email-validator": "2.0.4",

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,8 @@ export const NOTIFICATION_MESSAGES = {
   saving: 'Saving',
   duplicating: 'Duplicating',
   deleting: 'Deleting',
+  copying: 'Copying',
+  pasting: 'Pasting',
   empty: '',
 };
 

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -97,6 +97,8 @@ const CourseOutline = ({ courseId }) => {
     handleSubsectionDragAndDrop,
     handleVideoSharingOptionChange,
     handleUnitDragAndDrop,
+    handleCopyToClipboardClick,
+    handlePasteClipboardClick,
   } = useCourseOutline({ courseId });
 
   const [sections, setSections] = useState(sectionsList);
@@ -351,6 +353,7 @@ const CourseOutline = ({ courseId }) => {
                                         section,
                                         section.childInfo.children,
                                       )}
+                                      onPasteClick={handlePasteClipboardClick}
                                     >
                                       <DraggableList
                                         itemList={subsection.childInfo.children}
@@ -381,6 +384,7 @@ const CourseOutline = ({ courseId }) => {
                                               subsection,
                                               subsection.childInfo.children,
                                             )}
+                                            onCopyToClipboardClick={handleCopyToClipboardClick}
                                           />
                                         ))}
                                       </DraggableList>

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -55,6 +55,7 @@ const CourseOutline = ({ courseId }) => {
     statusBarData,
     courseActions,
     sectionsList,
+    isCustomRelativeDatesActive,
     isLoading,
     isReIndexShow,
     showErrorAlert,
@@ -311,6 +312,8 @@ const CourseOutline = ({ courseId }) => {
                                 section={section}
                                 index={sectionIndex}
                                 canMoveItem={canMoveItem(sections)}
+                                isSelfPaced={statusBarData.isSelfPaced}
+                                isCustomRelativeDatesActive={isCustomRelativeDatesActive}
                                 savingStatus={savingStatus}
                                 onOpenHighlightsModal={handleOpenHighlightsModal}
                                 onOpenPublishModal={openPublishModal}
@@ -334,6 +337,8 @@ const CourseOutline = ({ courseId }) => {
                                       subsection={subsection}
                                       index={subsectionIndex}
                                       canMoveItem={canMoveItem(section.childInfo.children)}
+                                      isSelfPaced={statusBarData.isSelfPaced}
+                                      isCustomRelativeDatesActive={isCustomRelativeDatesActive}
                                       savingStatus={savingStatus}
                                       onOpenPublishModal={openPublishModal}
                                       onOpenDeleteModal={openDeleteModal}
@@ -358,6 +363,8 @@ const CourseOutline = ({ courseId }) => {
                                             unit={unit}
                                             subsection={subsection}
                                             section={section}
+                                            isSelfPaced={statusBarData.isSelfPaced}
+                                            isCustomRelativeDatesActive={isCustomRelativeDatesActive}
                                             index={unitIndex}
                                             canMoveItem={canMoveItem(subsection.childInfo.children)}
                                             savingStatus={savingStatus}

--- a/src/course-outline/CourseOutline.scss
+++ b/src/course-outline/CourseOutline.scss
@@ -9,3 +9,4 @@
 @import "./publish-modal/PublishModal";
 @import "./configure-modal/ConfigureModal";
 @import "./drag-helper/ConditionalSortableElement";
+@import "./xblock-status/XBlockStatus";

--- a/src/course-outline/CourseOutline.scss
+++ b/src/course-outline/CourseOutline.scss
@@ -10,3 +10,4 @@
 @import "./configure-modal/ConfigureModal";
 @import "./drag-helper/ConditionalSortableElement";
 @import "./xblock-status/XBlockStatus";
+@import "./paste-button/PasteButton";

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -17,6 +17,7 @@ import {
   getCourseBlockApiUrl,
   getCourseItemApiUrl,
   getXBlockBaseApiUrl,
+  getClipboardUrl,
 } from './data/api';
 import { RequestStatus } from '../data/constants';
 import {
@@ -43,6 +44,8 @@ import cardHeaderMessages from './card-header/messages';
 import enableHighlightsModalMessages from './enable-highlights-modal/messages';
 import statusBarMessages from './status-bar/messages';
 import configureModalMessages from './configure-modal/messages';
+import pasteButtonMessages from './paste-button/messages';
+import subsectionMessages from './subsection-card/messages';
 
 let axiosMock;
 let store;
@@ -1337,5 +1340,80 @@ describe('<CourseOutline />', () => {
     await waitFor(() => {
       expect(within(sectionElement).queryByText(section.displayName)).toBeInTheDocument();
     });
+  });
+
+  it('check whether unit copy & paste option works correctly', async () => {
+    const { findAllByTestId } = render(<RootWrapper />);
+    // get first section -> first subsection -> first unit element
+    const [section] = courseOutlineIndexMock.courseStructure.childInfo.children;
+    const [sectionElement] = await findAllByTestId('section-card');
+    const [subsection] = section.childInfo.children;
+    let [subsectionElement] = await within(sectionElement).findAllByTestId('subsection-card');
+    const expandBtn = await within(subsectionElement).findByTestId('subsection-card-header__expanded-btn');
+    await act(async () => fireEvent.click(expandBtn));
+    const [unit] = subsection.childInfo.children;
+    const [unitElement] = await within(subsectionElement).findAllByTestId('unit-card');
+
+    const expectedClipboardContent = {
+      content: {
+        blockType: 'vertical',
+        blockTypeDisplay: 'Unit',
+        created: '2024-01-29T07:58:36.844249Z',
+        displayName: unit.displayName,
+        id: 15,
+        olxUrl: 'http://localhost:18010/api/content-staging/v1/staged-content/15/olx',
+        purpose: 'clipboard',
+        status: 'ready',
+        userId: 3,
+      },
+      sourceUsageKey: unit.id,
+      sourceContexttitle: courseOutlineIndexMock.courseStructure.displayName,
+      sourceEditUrl: unit.studioUrl,
+    };
+    // mock api call
+    axiosMock
+      .onPost(getClipboardUrl(), {
+        usage_key: unit.id,
+      }).reply(200, expectedClipboardContent);
+    // check that initialUserClipboard state is empty
+    const { initialUserClipboard } = store.getState().courseOutline;
+    expect(initialUserClipboard).toBeUndefined();
+
+    // find menu button and click on it to open menu
+    const menu = await within(unitElement).findByTestId('unit-card-header__menu-button');
+    await act(async () => fireEvent.click(menu));
+
+    // move first unit back to second position to test move down option
+    const copyButton = await within(unitElement).findByText(cardHeaderMessages.menuCopy.defaultMessage);
+    await act(async () => fireEvent.click(copyButton));
+
+    // check that initialUserClipboard state is updated
+    expect(store.getState().courseOutline.initialUserClipboard).toEqual(expectedClipboardContent);
+
+    [subsectionElement] = await within(sectionElement).findAllByTestId('subsection-card');
+    // find clipboard content label
+    const clipboardLabel = await within(subsectionElement).findByText(
+      pasteButtonMessages.clipboardContentLabel.defaultMessage,
+    );
+    await act(async () => fireEvent.mouseOver(clipboardLabel));
+
+    // find clipboard content popup link
+    expect(
+      subsectionElement.querySelector('#vertical-paste-button-overlay'),
+    ).toHaveAttribute('href', unit.studioUrl);
+
+    // check paste button functionality
+    // mock api call
+    axiosMock
+      .onPost(getXBlockBaseApiUrl(), {
+        parent_locator: subsection.id,
+        staged_content: 'clipboard',
+      }).reply(200, { dummy: 'value' });
+    const pasteBtn = await within(subsectionElement).findByText(subsectionMessages.pasteButton.defaultMessage);
+    await act(async () => fireEvent.click(pasteBtn));
+
+    [subsectionElement] = await within(sectionElement).findAllByTestId('subsection-card');
+    const lastUnitElement = (await within(subsectionElement).findAllByTestId('unit-card')).slice(-1)[0];
+    expect(lastUnitElement).toHaveTextContent(unit.displayName);
   });
 });

--- a/src/course-outline/__mocks__/courseOutlineIndex.js
+++ b/src/course-outline/__mocks__/courseOutlineIndex.js
@@ -261,6 +261,7 @@ module.exports = {
                       ancestorHasStaffLock: true,
                       staffOnlyMessage: false,
                       hasPartitionGroupComponents: false,
+                      enableCopyPasteUnits: true,
                       userPartitionInfo: {
                         selectablePartitions: [
                           {
@@ -292,6 +293,7 @@ module.exports = {
                 ancestorHasStaffLock: true,
                 staffOnlyMessage: false,
                 hasPartitionGroupComponents: false,
+                enableCopyPasteUnits: true,
                 userPartitionInfo: {
                   selectablePartitions: [
                     {
@@ -391,7 +393,7 @@ module.exports = {
                 },
                 ancestor_has_staff_lock: false,
                 staff_only_message: false,
-                enable_copy_paste_units: false,
+                enable_copy_paste_units: true,
                 has_partition_group_components: false,
                 user_partition_info: {
                   selectable_partitions: [

--- a/src/course-outline/card-header/CardHeader.jsx
+++ b/src/course-outline/card-header/CardHeader.jsx
@@ -32,9 +32,12 @@ const CardHeader = ({
   onClickDuplicate,
   onClickMoveUp,
   onClickMoveDown,
+  onClickCopy,
   titleComponent,
   namePrefix,
   actions,
+  enableCopyPasteUnits,
+  isVertical,
 }) => {
   const intl = useIntl();
   const [titleValue, setTitleValue] = useState(title);
@@ -106,6 +109,11 @@ const CardHeader = ({
             >
               {intl.formatMessage(messages.menuConfigure)}
             </Dropdown.Item>
+            {isVertical && enableCopyPasteUnits && (
+              <Dropdown.Item onClick={onClickCopy}>
+                {intl.formatMessage(messages.menuCopy)}
+              </Dropdown.Item>
+            )}
             {actions.duplicable && (
               <Dropdown.Item
                 data-testid={`${namePrefix}-card-header__menu-duplicate-button`}
@@ -148,6 +156,12 @@ const CardHeader = ({
   );
 };
 
+CardHeader.defaultProps = {
+  enableCopyPasteUnits: false,
+  isVertical: false,
+  onClickCopy: null,
+};
+
 CardHeader.propTypes = {
   title: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
@@ -164,6 +178,7 @@ CardHeader.propTypes = {
   onClickDuplicate: PropTypes.func.isRequired,
   onClickMoveUp: PropTypes.func.isRequired,
   onClickMoveDown: PropTypes.func.isRequired,
+  onClickCopy: PropTypes.func,
   titleComponent: PropTypes.node.isRequired,
   namePrefix: PropTypes.string.isRequired,
   actions: PropTypes.shape({
@@ -174,6 +189,8 @@ CardHeader.propTypes = {
     allowMoveUp: PropTypes.bool,
     allowMoveDown: PropTypes.bool,
   }).isRequired,
+  enableCopyPasteUnits: PropTypes.bool,
+  isVertical: PropTypes.bool,
 };
 
 export default CardHeader;

--- a/src/course-outline/card-header/CardHeader.scss
+++ b/src/course-outline/card-header/CardHeader.scss
@@ -1,7 +1,6 @@
 .item-card-header {
   display: flex;
   align-items: center;
-  margin-right: -.5rem;
 
   .item-card-header__title-btn {
     justify-content: flex-start;

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -9,6 +9,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.card.status-badge.live',
     defaultMessage: 'Live',
   },
+  statusBadgeGated: {
+    id: 'course-authoring.course-outline.card.status-badge.gated',
+    defaultMessage: 'Gated',
+  },
   statusBadgePublishedNotLive: {
     id: 'course-authoring.course-outline.card.status-badge.published-not-live',
     defaultMessage: 'Published not live',

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -57,6 +57,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.card.menu.delete',
     defaultMessage: 'Delete',
   },
+  menuCopy: {
+    id: 'course-authoring.course-outline.card.menu.delete',
+    defaultMessage: 'Copy to clipboard',
+  },
 });
 
 export default messages;

--- a/src/course-outline/constants.js
+++ b/src/course-outline/constants.js
@@ -1,5 +1,6 @@
 export const ITEM_BADGE_STATUS = /** @type {const} */ ({
   live: 'live',
+  gated: 'gated',
   publishedNotLive: 'published_not_live',
   unpublishedChanges: 'unpublished_changes',
   staffOnly: 'staff_only',

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -28,6 +28,7 @@ export const getCourseReindexApiUrl = (reindexLink) => `${getApiBaseUrl()}${rein
 export const getXBlockBaseApiUrl = () => `${getApiBaseUrl()}/xblock/`;
 export const getCourseItemApiUrl = (itemId) => `${getXBlockBaseApiUrl()}${itemId}`;
 export const getXBlockApiUrl = (blockId) => `${getXBlockBaseApiUrl()}outline/${blockId}`;
+export const getClipboardUrl = () => `${getApiBaseUrl()}/api/content-staging/v1/clipboard/`;
 
 /**
  * @typedef {Object} courseOutline
@@ -408,6 +409,35 @@ export async function setVideoSharingOption(courseId, videoSharingOption) {
       metadata: {
         video_sharing_options: videoSharingOption,
       },
+    });
+
+  return data;
+}
+
+/**
+ * Copy block to clipboard
+ * @param {string} usageKey
+ * @returns {Promise<Object>}
+*/
+export async function copyBlockToClipboard(usageKey) {
+  const { data } = await getAuthenticatedHttpClient()
+    .post(getClipboardUrl(), {
+      usage_key: usageKey,
+    });
+
+  return camelCaseObject(data);
+}
+
+/**
+ * Paste block to clipboard
+ * @param {string} parentLocator
+ * @returns {Promise<Object>}
+*/
+export async function pasteBlock(parentLocator) {
+  const { data } = await getAuthenticatedHttpClient()
+    .post(getXBlockBaseApiUrl(), {
+      parent_locator: parentLocator,
+      staged_content: 'clipboard',
     });
 
   return data;

--- a/src/course-outline/data/selectors.js
+++ b/src/course-outline/data/selectors.js
@@ -8,3 +8,4 @@ export const getCurrentSection = (state) => state.courseOutline.currentSection;
 export const getCurrentSubsection = (state) => state.courseOutline.currentSubsection;
 export const getCourseActions = (state) => state.courseOutline.actions;
 export const getCustomRelativeDatesActiveFlag = (state) => state.courseOutline.isCustomRelativeDatesActive;
+export const getInitialUserClipboard = (state) => state.courseOutline.initialUserClipboard;

--- a/src/course-outline/data/selectors.js
+++ b/src/course-outline/data/selectors.js
@@ -7,3 +7,4 @@ export const getCurrentItem = (state) => state.courseOutline.currentItem;
 export const getCurrentSection = (state) => state.courseOutline.currentSection;
 export const getCurrentSubsection = (state) => state.courseOutline.currentSubsection;
 export const getCourseActions = (state) => state.courseOutline.actions;
+export const getCustomRelativeDatesActiveFlag = (state) => state.courseOutline.isCustomRelativeDatesActive;

--- a/src/course-outline/data/slice.js
+++ b/src/course-outline/data/slice.js
@@ -28,6 +28,7 @@ const slice = createSlice({
       videoSharingOptions: VIDEO_SHARING_OPTIONS.perVideo,
     },
     sectionsList: [],
+    isCustomRelativeDatesActive: false,
     currentSection: {},
     currentSubsection: {},
     currentItem: {},
@@ -42,6 +43,7 @@ const slice = createSlice({
     fetchOutlineIndexSuccess: (state, { payload }) => {
       state.outlineIndexData = payload;
       state.sectionsList = payload.courseStructure?.childInfo?.children || [];
+      state.isCustomRelativeDatesActive = payload.isCustomRelativeDatesActive;
     },
     updateOutlineIndexLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {

--- a/src/course-outline/data/slice.js
+++ b/src/course-outline/data/slice.js
@@ -38,12 +38,19 @@ const slice = createSlice({
       childAddable: true,
       duplicable: true,
     },
+    initialUserClipboard: {
+      content: {},
+      sourceUsageKey: null,
+      sourceContexttitle: null,
+      sourceEditUrl: null,
+    },
   },
   reducers: {
     fetchOutlineIndexSuccess: (state, { payload }) => {
       state.outlineIndexData = payload;
       state.sectionsList = payload.courseStructure?.childInfo?.children || [];
       state.isCustomRelativeDatesActive = payload.isCustomRelativeDatesActive;
+      state.initialUserClipboard = payload.initialUserClipboard;
     },
     updateOutlineIndexLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {
@@ -68,6 +75,9 @@ const slice = createSlice({
         ...state.statusBarData,
         ...payload,
       };
+    },
+    updateClipboardContent: (state, { payload }) => {
+      state.initialUserClipboard = payload;
     },
     updateCourseActions: (state, { payload }) => {
       state.actions = {
@@ -205,6 +215,7 @@ export const {
   reorderSectionList,
   reorderSubsectionList,
   reorderUnitList,
+  updateClipboardContent,
 } = slice.actions;
 
 export const {

--- a/src/course-outline/data/thunk.js
+++ b/src/course-outline/data/thunk.js
@@ -28,6 +28,8 @@ import {
   setSectionOrderList,
   setVideoSharingOption,
   setCourseItemOrderList,
+  copyBlockToClipboard,
+  pasteBlock,
 } from './api';
 import {
   addSection,
@@ -49,6 +51,7 @@ import {
   reorderSectionList,
   reorderSubsectionList,
   reorderUnitList,
+  updateClipboardContent,
 } from './slice';
 
 export function fetchCourseOutlineIndexQuery(courseId) {
@@ -371,7 +374,7 @@ export function deleteCourseUnitQuery(unitId, subsectionId, sectionId) {
 function duplicateCourseItemQuery(itemId, parentLocator, duplicateFn) {
   return async (dispatch) => {
     dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
-    dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
+    dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.duplicating));
 
     try {
       await duplicateCourseItem(itemId, parentLocator).then(async (result) => {
@@ -555,6 +558,50 @@ export function setUnitOrderListQuery(sectionId, subsectionId, unitListIds, rest
       });
     } catch (error) {
       restoreCallback();
+      dispatch(hideProcessingNotification());
+      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+    }
+  };
+}
+
+export function setClipboardContent(usageKey, broadcastClipboard) {
+  return async (dispatch) => {
+    dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
+    dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.copying));
+
+    try {
+      await copyBlockToClipboard(usageKey).then(async (result) => {
+        const status = result?.content?.status;
+        if (status === 'ready') {
+          dispatch(updateClipboardContent(result));
+          broadcastClipboard(result);
+          dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
+          dispatch(hideProcessingNotification());
+        } else {
+          throw new Error(`Unexpected clipboard status "${status}" in successful API response.`);
+        }
+      });
+    } catch (error) {
+      dispatch(hideProcessingNotification());
+      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+    }
+  };
+}
+
+export function pasteClipboardContent(parentLocator, sectionId) {
+  return async (dispatch) => {
+    dispatch(updateSavingStatus({ status: RequestStatus.PENDING }));
+    dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.pasting));
+
+    try {
+      await pasteBlock(parentLocator).then(async (result) => {
+        if (result) {
+          dispatch(fetchCourseSectionQuery(sectionId, true));
+          dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
+          dispatch(hideProcessingNotification());
+        }
+      });
+    } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
     }

--- a/src/course-outline/drag-helper/ConditionalSortableElement.jsx
+++ b/src/course-outline/drag-helper/ConditionalSortableElement.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row } from '@edx/paragon';
+import { Col, Row } from '@edx/paragon';
 import { SortableItem } from '@edx/frontend-lib-content-components';
 
 const ConditionalSortableElement = ({
@@ -24,9 +24,9 @@ const ConditionalSortableElement = ({
         id={id}
         componentStyle={style}
       >
-        <div className="extend-margin">
+        <Col className="extend-margin px-0">
           {children}
-        </div>
+        </Col>
       </SortableItem>
     );
   }
@@ -36,7 +36,9 @@ const ConditionalSortableElement = ({
       style={style}
       className="mx-0"
     >
-      {children}
+      <Col className="px-0">
+        {children}
+      </Col>
     </Row>
   );
 };

--- a/src/course-outline/drag-helper/ConditionalSortableElement.scss
+++ b/src/course-outline/drag-helper/ConditionalSortableElement.scss
@@ -1,7 +1,4 @@
 .extend-margin {
-  display: flex;
-  flex-grow: 1;
-
   .item-children {
     margin-right: -2.75rem;
   }

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -6,10 +6,12 @@ import { getConfig } from '@edx/frontend-platform';
 
 import { RequestStatus } from '../data/constants';
 import { COURSE_BLOCK_NAMES } from './constants';
+import { useBroadcastChannel } from '../generic/broadcast-channel/hooks';
 import {
   setCurrentItem,
   setCurrentSection,
   updateSavingStatus,
+  updateClipboardContent,
 } from './data/slice';
 import {
   getLoadingStatus,
@@ -48,6 +50,8 @@ import {
   setVideoSharingOptionQuery,
   setSubsectionOrderListQuery,
   setUnitOrderListQuery,
+  setClipboardContent,
+  pasteClipboardContent,
 } from './data/thunk';
 
 const useCourseOutline = ({ courseId }) => {
@@ -74,6 +78,17 @@ const useCourseOutline = ({ courseId }) => {
   const [isPublishModalOpen, openPublishModal, closePublishModal] = useToggle(false);
   const [isConfigureModalOpen, openConfigureModal, closeConfigureModal] = useToggle(false);
   const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
+  const clipboardBroadcastChannel = useBroadcastChannel('studio_clipboard_channel', (message) => {
+    dispatch(updateClipboardContent(message));
+  });
+
+  const handleCopyToClipboardClick = (usageKey) => {
+    dispatch(setClipboardContent(usageKey, clipboardBroadcastChannel.postMessage));
+  };
+
+  const handlePasteClipboardClick = (parentLocator, sectionId) => {
+    dispatch(pasteClipboardContent(parentLocator, sectionId));
+  };
 
   const handleNewSectionSubmit = () => {
     dispatch(addNewSectionQuery(courseStructure.id));
@@ -289,6 +304,8 @@ const useCourseOutline = ({ courseId }) => {
     handleSubsectionDragAndDrop,
     handleVideoSharingOptionChange,
     handleUnitDragAndDrop,
+    handleCopyToClipboardClick,
+    handlePasteClipboardClick,
   };
 };
 

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -21,6 +21,7 @@ import {
   getCurrentItem,
   getCurrentSection,
   getCurrentSubsection,
+  getCustomRelativeDatesActiveFlag,
 } from './data/selectors';
 import {
   addNewSectionQuery,
@@ -62,6 +63,7 @@ const useCourseOutline = ({ courseId }) => {
   const currentItem = useSelector(getCurrentItem);
   const currentSection = useSelector(getCurrentSection);
   const currentSubsection = useSelector(getCurrentSubsection);
+  const isCustomRelativeDatesActive = useSelector(getCustomRelativeDatesActiveFlag);
 
   const [isEnableHighlightsModalOpen, openEnableHighlightsModal, closeEnableHighlightsModal] = useToggle(false);
   const [isSectionsExpanded, setSectionsExpanded] = useState(true);
@@ -242,6 +244,7 @@ const useCourseOutline = ({ courseId }) => {
     courseActions,
     savingStatus,
     sectionsList,
+    isCustomRelativeDatesActive,
     isLoading: outlineIndexLoadingStatus === RequestStatus.IN_PROGRESS,
     isReIndexShow: Boolean(reindexLink),
     showSuccessAlert,

--- a/src/course-outline/paste-button/PasteButton.jsx
+++ b/src/course-outline/paste-button/PasteButton.jsx
@@ -1,0 +1,115 @@
+import { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import {
+  Hyperlink, Icon, Button, OverlayTrigger,
+} from '@edx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  FileCopy as PasteIcon,
+  Question as QuestionIcon,
+} from '@edx/paragon/icons';
+import { getInitialUserClipboard } from '../data/selectors';
+import messages from './messages';
+
+const PasteButton = ({
+  text,
+  blockType,
+  onClick,
+}) => {
+  const intl = useIntl();
+  const initialUserClipboard = useSelector(getInitialUserClipboard);
+  const {
+    content,
+    sourceContextTitle,
+    sourceEditUrl,
+  } = initialUserClipboard || {};
+  // Show button only if clipboard has content
+  const showPasteButton = (
+    content?.status === 'ready'
+    && content?.blockType === blockType
+  );
+
+  const [show, setShow] = useState(false);
+  const handleOnMouseEnter = () => {
+    setShow(true);
+  };
+  const handleOnMouseLeave = () => {
+    setShow(false);
+  };
+  const ref = useRef(null);
+
+  if (!showPasteButton) {
+    return null;
+  }
+
+  const renderBlockLink = (props) => (
+    <Hyperlink
+      id={`${blockType}-paste-button-overlay`}
+      className="d-flex bg-white p-3 text-decoration-none popup-link shadow mb-2 zindex-2"
+      target="_blank"
+      destination={sourceEditUrl}
+      onMouseEnter={handleOnMouseEnter}
+      onMouseLeave={handleOnMouseLeave}
+      onFocus={handleOnMouseEnter}
+      onBlur={handleOnMouseLeave}
+      {...props}
+    >
+      <div className="text-gray mr-5 mw-xs">
+        <h4>
+          {content?.displayName}<br />
+          <span className="micro text-gray-400">
+            {content?.blockTypeDisplay}
+          </span>
+        </h4>
+        <span className="x-small">
+          {intl.formatMessage(messages.clipboardContentFromLabel)}
+          <em>{sourceContextTitle}</em>
+        </span>
+      </div>
+    </Hyperlink>
+  );
+
+  return (
+    <>
+      <Button
+        className="mt-4"
+        variant="outline-primary"
+        iconBefore={PasteIcon}
+        block
+        onClick={onClick}
+      >
+        {text}
+      </Button>
+      <OverlayTrigger
+        key={`${blockType}-paste-button-overlay`}
+        show={show}
+        placement="top"
+        container={ref}
+        overlay={renderBlockLink}
+      >
+        <div
+          className="float-right d-inline-flex align-items-center x-small mt-2 cursor-help"
+          ref={ref}
+          onMouseEnter={handleOnMouseEnter}
+          onMouseLeave={handleOnMouseLeave}
+          onFocus={handleOnMouseEnter}
+          onBlur={handleOnMouseLeave}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex="0"
+        >
+          <Icon className="mr-1" size="sm" src={QuestionIcon} />
+          {intl.formatMessage(messages.clipboardContentLabel)}
+        </div>
+      </OverlayTrigger>
+    </>
+  );
+};
+
+PasteButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  blockType: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default PasteButton;

--- a/src/course-outline/paste-button/PasteButton.scss
+++ b/src/course-outline/paste-button/PasteButton.scss
@@ -1,0 +1,20 @@
+// adds bottom arrow to popup link
+.popup-link {
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    border-top: solid .5rem white;
+    border-left: solid .5rem transparent;
+    border-right: solid .5rem transparent;
+  }
+}
+
+.cursor-help {
+  cursor: help !important;
+}

--- a/src/course-outline/paste-button/messages.js
+++ b/src/course-outline/paste-button/messages.js
@@ -1,0 +1,14 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  clipboardContentFromLabel: {
+    id: 'course-authoring.course-outline.paste-button.whats-in-clipboard.from-label',
+    defaultMessage: 'From: ',
+  },
+  clipboardContentLabel: {
+    id: 'course-authoring.course-outline.paste-button.whats-in-clipboard.label',
+    defaultMessage: 'What\'s in my clipboard?',
+  },
+});
+
+export default messages;

--- a/src/course-outline/section-card/SectionCard.jsx
+++ b/src/course-outline/section-card/SectionCard.jsx
@@ -14,11 +14,14 @@ import CardHeader from '../card-header/CardHeader';
 import BaseTitleWithStatusBadge from '../card-header/BaseTitleWithStatusBadge';
 import ConditionalSortableElement from '../drag-helper/ConditionalSortableElement';
 import TitleButton from '../card-header/TitleButton';
+import XBlockStatus from '../xblock-status/XBlockStatus';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '../utils';
 import messages from './messages';
 
 const SectionCard = ({
   section,
+  isSelfPaced,
+  isCustomRelativeDatesActive,
   children,
   index,
   canMoveItem,
@@ -60,7 +63,6 @@ const SectionCard = ({
     highlights,
     actions: sectionActions,
     isHeaderVisible = true,
-    explanatoryMessage = '',
   } = section;
 
   // re-create actions object for customizations
@@ -174,18 +176,24 @@ const SectionCard = ({
             />
           )}
           <div className="section-card__content" data-testid="section-card__content">
-            {explanatoryMessage && <p className="text-secondary-400 x-small mb-1">{explanatoryMessage}</p>}
-            <div className="outline-section__status">
+            <div className="outline-section__status mb-1">
               <Button
-                className="section-card__highlights"
+                className="p-0 bg-transparent"
                 data-destid="section-card-highlights-button"
                 variant="tertiary"
                 onClick={handleOpenHighlightsModal}
               >
-                <Badge className="highlights-badge">{highlights.length}</Badge>
+                <Badge className="mr-1 d-flex justify-content-center align-items-center highlights-badge">
+                  {highlights.length}
+                </Badge>
                 <p className="m-0 text-black">{messages.sectionHighlightsBadge.defaultMessage}</p>
               </Button>
             </div>
+            <XBlockStatus
+              isSelfPaced={isSelfPaced}
+              isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+              blockData={section}
+            />
           </div>
           {isExpanded && (
             <div
@@ -226,7 +234,6 @@ SectionCard.propTypes = {
     visibilityState: PropTypes.string.isRequired,
     highlights: PropTypes.arrayOf(PropTypes.string).isRequired,
     shouldScroll: PropTypes.bool,
-    explanatoryMessage: PropTypes.string,
     actions: PropTypes.shape({
       deletable: PropTypes.bool.isRequired,
       draggable: PropTypes.bool.isRequired,
@@ -235,6 +242,8 @@ SectionCard.propTypes = {
     }).isRequired,
     isHeaderVisible: PropTypes.bool,
   }).isRequired,
+  isSelfPaced: PropTypes.bool.isRequired,
+  isCustomRelativeDatesActive: PropTypes.bool.isRequired,
   children: PropTypes.node,
   onOpenHighlightsModal: PropTypes.func.isRequired,
   onOpenPublishModal: PropTypes.func.isRequired,

--- a/src/course-outline/section-card/SectionCard.scss
+++ b/src/course-outline/section-card/SectionCard.scss
@@ -13,26 +13,15 @@
     color: $headings-color;
   }
 
-  .section-card__highlights {
-    display: flex;
-    align-items: center;
-    gap: .5rem;
-    padding: 0;
-    background: transparent;
 
-    &::before {
-      display: none;
-    }
+  .highlights-badge {
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 1.375rem;
+    font-size: 1rem;
+  }
 
-    .highlights-badge {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 1.75rem;
-      height: 1.75rem;
-      border-radius: 1.375rem;
-      font-size: 1.125rem;
-      font-weight: 700;
-    }
+  .section-card__content {
+    margin-left: 1.7rem;
   }
 }

--- a/src/course-outline/subsection-card/SubsectionCard.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.jsx
@@ -8,11 +8,13 @@ import classNames from 'classnames';
 
 import { setCurrentItem, setCurrentSection, setCurrentSubsection } from '../data/slice';
 import { RequestStatus } from '../../data/constants';
+import { COURSE_BLOCK_NAMES } from '../constants';
 import CardHeader from '../card-header/CardHeader';
 import BaseTitleWithStatusBadge from '../card-header/BaseTitleWithStatusBadge';
 import ConditionalSortableElement from '../drag-helper/ConditionalSortableElement';
 import TitleButton from '../card-header/TitleButton';
 import XBlockStatus from '../xblock-status/XBlockStatus';
+import PasteButton from '../paste-button/PasteButton';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '../utils';
 import messages from './messages';
 
@@ -32,6 +34,7 @@ const SubsectionCard = ({
   onNewUnitSubmit,
   onOrderChange,
   onOpenConfigureModal,
+  onPasteClick,
 }) => {
   const currentRef = useRef(null);
   const intl = useIntl();
@@ -47,6 +50,7 @@ const SubsectionCard = ({
     visibilityState,
     actions: subsectionActions,
     isHeaderVisible = true,
+    enableCopyPasteUnits = false,
   } = subsection;
 
   // re-create actions object for customizations
@@ -91,6 +95,7 @@ const SubsectionCard = ({
   };
 
   const handleNewButtonClick = () => onNewUnitSubmit(id);
+  const handlePasteButtonClick = () => onPasteClick(id, section.id);
 
   const titleComponent = (
     <TitleButton
@@ -176,16 +181,25 @@ const SubsectionCard = ({
           >
             {children}
             {actions.childAddable && (
-              <Button
-                data-testid="new-unit-button"
-                className="mt-4"
-                variant="outline-primary"
-                iconBefore={IconAdd}
-                block
-                onClick={handleNewButtonClick}
-              >
-                {intl.formatMessage(messages.newUnitButton)}
-              </Button>
+              <>
+                <Button
+                  data-testid="new-unit-button"
+                  className="mt-4"
+                  variant="outline-primary"
+                  iconBefore={IconAdd}
+                  block
+                  onClick={handleNewButtonClick}
+                >
+                  {intl.formatMessage(messages.newUnitButton)}
+                </Button>
+                {enableCopyPasteUnits && (
+                  <PasteButton
+                    text={intl.formatMessage(messages.pasteButton)}
+                    blockType={COURSE_BLOCK_NAMES.vertical.id}
+                    onClick={handlePasteButtonClick}
+                  />
+                )}
+              </>
             )}
           </div>
         )}
@@ -214,6 +228,7 @@ SubsectionCard.propTypes = {
     hasChanges: PropTypes.bool.isRequired,
     visibilityState: PropTypes.string.isRequired,
     shouldScroll: PropTypes.bool,
+    enableCopyPasteUnits: PropTypes.bool,
     actions: PropTypes.shape({
       deletable: PropTypes.bool.isRequired,
       draggable: PropTypes.bool.isRequired,
@@ -235,6 +250,7 @@ SubsectionCard.propTypes = {
   canMoveItem: PropTypes.func.isRequired,
   onOrderChange: PropTypes.func.isRequired,
   onOpenConfigureModal: PropTypes.func.isRequired,
+  onPasteClick: PropTypes.func.isRequired,
 };
 
 export default SubsectionCard;

--- a/src/course-outline/subsection-card/SubsectionCard.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.jsx
@@ -12,12 +12,15 @@ import CardHeader from '../card-header/CardHeader';
 import BaseTitleWithStatusBadge from '../card-header/BaseTitleWithStatusBadge';
 import ConditionalSortableElement from '../drag-helper/ConditionalSortableElement';
 import TitleButton from '../card-header/TitleButton';
+import XBlockStatus from '../xblock-status/XBlockStatus';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '../utils';
 import messages from './messages';
 
 const SubsectionCard = ({
   section,
   subsection,
+  isSelfPaced,
+  isCustomRelativeDatesActive,
   children,
   index,
   canMoveItem,
@@ -136,26 +139,35 @@ const SubsectionCard = ({
     >
       <div className="subsection-card" data-testid="subsection-card" ref={currentRef}>
         {isHeaderVisible && (
-          <CardHeader
-            title={displayName}
-            status={subsectionStatus}
-            hasChanges={hasChanges}
-            onClickMenuButton={handleClickMenuButton}
-            onClickPublish={onOpenPublishModal}
-            onClickEdit={openForm}
-            onClickDelete={onOpenDeleteModal}
-            onClickMoveUp={handleSubsectionMoveUp}
-            onClickMoveDown={handleSubsectionMoveDown}
-            onClickConfigure={onOpenConfigureModal}
-            isFormOpen={isFormOpen}
-            closeForm={closeForm}
-            onEditSubmit={handleEditSubmit}
-            isDisabledEditField={savingStatus === RequestStatus.IN_PROGRESS}
-            onClickDuplicate={onDuplicateSubmit}
-            titleComponent={titleComponent}
-            namePrefix={namePrefix}
-            actions={actions}
-          />
+          <>
+            <CardHeader
+              title={displayName}
+              status={subsectionStatus}
+              hasChanges={hasChanges}
+              onClickMenuButton={handleClickMenuButton}
+              onClickPublish={onOpenPublishModal}
+              onClickEdit={openForm}
+              onClickDelete={onOpenDeleteModal}
+              onClickMoveUp={handleSubsectionMoveUp}
+              onClickMoveDown={handleSubsectionMoveDown}
+              onClickConfigure={onOpenConfigureModal}
+              isFormOpen={isFormOpen}
+              closeForm={closeForm}
+              onEditSubmit={handleEditSubmit}
+              isDisabledEditField={savingStatus === RequestStatus.IN_PROGRESS}
+              onClickDuplicate={onDuplicateSubmit}
+              titleComponent={titleComponent}
+              namePrefix={namePrefix}
+              actions={actions}
+            />
+            <div className="subsection-card__content item-children" data-testid="subsection-card__content">
+              <XBlockStatus
+                isSelfPaced={isSelfPaced}
+                isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+                blockData={subsection}
+              />
+            </div>
+          </>
         )}
         {isExpanded && (
           <div
@@ -211,6 +223,8 @@ SubsectionCard.propTypes = {
     isHeaderVisible: PropTypes.bool,
   }).isRequired,
   children: PropTypes.node,
+  isSelfPaced: PropTypes.bool.isRequired,
+  isCustomRelativeDatesActive: PropTypes.bool.isRequired,
   onOpenPublishModal: PropTypes.func.isRequired,
   onEditSubmit: PropTypes.func.isRequired,
   savingStatus: PropTypes.string.isRequired,

--- a/src/course-outline/subsection-card/SubsectionCard.scss
+++ b/src/course-outline/subsection-card/SubsectionCard.scss
@@ -16,4 +16,8 @@
     line-height: $headings-line-height;
     color: $headings-color;
   }
+
+  .subsection-card__content {
+    margin-left: 1.7rem;
+  }
 }

--- a/src/course-outline/subsection-card/messages.js
+++ b/src/course-outline/subsection-card/messages.js
@@ -5,6 +5,10 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.subsection.button.new-unit',
     defaultMessage: 'New unit',
   },
+  pasteButton: {
+    id: 'course-authoring.course-outline.subsection.button.new-unit',
+    defaultMessage: 'Paste unit',
+  },
 });
 
 export default messages;

--- a/src/course-outline/unit-card/UnitCard.jsx
+++ b/src/course-outline/unit-card/UnitCard.jsx
@@ -28,6 +28,7 @@ const UnitCard = ({
   onDuplicateSubmit,
   getTitleLink,
   onOrderChange,
+  onCopyToClipboardClick,
 }) => {
   const currentRef = useRef(null);
   const dispatch = useDispatch();
@@ -42,6 +43,7 @@ const UnitCard = ({
     visibilityState,
     actions: unitActions,
     isHeaderVisible = true,
+    enableCopyPasteUnits = false,
   } = unit;
 
   // re-create actions object for customizations
@@ -78,6 +80,10 @@ const UnitCard = ({
 
   const handleUnitMoveDown = () => {
     onOrderChange(index, index + 1);
+  };
+
+  const handleCopyClick = () => {
+    onCopyToClipboardClick(unit.id);
   };
 
   const titleComponent = (
@@ -148,6 +154,9 @@ const UnitCard = ({
           titleComponent={titleComponent}
           namePrefix={namePrefix}
           actions={actions}
+          isVertical
+          enableCopyPasteUnits={enableCopyPasteUnits}
+          onClickCopy={handleCopyClick}
         />
         <div className="unit-card__content item-children" data-testid="unit-card__content">
           <XBlockStatus
@@ -176,6 +185,7 @@ UnitCard.propTypes = {
       duplicable: PropTypes.bool.isRequired,
     }).isRequired,
     isHeaderVisible: PropTypes.bool,
+    enableCopyPasteUnits: PropTypes.bool,
   }).isRequired,
   subsection: PropTypes.shape({
     id: PropTypes.string.isRequired,
@@ -205,6 +215,7 @@ UnitCard.propTypes = {
   onOrderChange: PropTypes.func.isRequired,
   isSelfPaced: PropTypes.bool.isRequired,
   isCustomRelativeDatesActive: PropTypes.bool.isRequired,
+  onCopyToClipboardClick: PropTypes.func.isRequired,
 };
 
 export default UnitCard;

--- a/src/course-outline/unit-card/UnitCard.jsx
+++ b/src/course-outline/unit-card/UnitCard.jsx
@@ -9,12 +9,15 @@ import CardHeader from '../card-header/CardHeader';
 import BaseTitleWithStatusBadge from '../card-header/BaseTitleWithStatusBadge';
 import ConditionalSortableElement from '../drag-helper/ConditionalSortableElement';
 import TitleLink from '../card-header/TitleLink';
+import XBlockStatus from '../xblock-status/XBlockStatus';
 import { getItemStatus, getItemStatusBorder, scrollToElement } from '../utils';
 
 const UnitCard = ({
   unit,
   subsection,
   section,
+  isSelfPaced,
+  isCustomRelativeDatesActive,
   index,
   canMoveItem,
   onOpenPublishModal,
@@ -146,6 +149,13 @@ const UnitCard = ({
           namePrefix={namePrefix}
           actions={actions}
         />
+        <div className="unit-card__content item-children" data-testid="unit-card__content">
+          <XBlockStatus
+            isSelfPaced={isSelfPaced}
+            isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+            blockData={unit}
+          />
+        </div>
       </div>
     </ConditionalSortableElement>
   );
@@ -193,6 +203,8 @@ UnitCard.propTypes = {
   index: PropTypes.number.isRequired,
   canMoveItem: PropTypes.func.isRequired,
   onOrderChange: PropTypes.func.isRequired,
+  isSelfPaced: PropTypes.bool.isRequired,
+  isCustomRelativeDatesActive: PropTypes.bool.isRequired,
 };
 
 export default UnitCard;

--- a/src/course-outline/unit-card/UnitCard.scss
+++ b/src/course-outline/unit-card/UnitCard.scss
@@ -1,10 +1,6 @@
 .unit-card {
   flex-grow: 1;
 
-  .unit-card__content {
-    margin: $spacer;
-  }
-
   .item-card-header__badge-status {
     background: $light-100;
   }

--- a/src/course-outline/unit-card/UnitCard.test.jsx
+++ b/src/course-outline/unit-card/UnitCard.test.jsx
@@ -10,6 +10,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import initializeStore from '../../store';
 import UnitCard from './UnitCard';
+import cardMessages from '../card-header/messages';
 
 // eslint-disable-next-line no-unused-vars
 let axiosMock;
@@ -118,5 +119,18 @@ describe('<UnitCard />', () => {
     await act(async () => fireEvent.click(menu));
     expect(within(element).queryByTestId('unit-card-header__menu-duplicate-button')).not.toBeInTheDocument();
     expect(within(element).queryByTestId('unit-card-header__menu-delete-button')).not.toBeInTheDocument();
+  });
+
+  it('shows copy option based on enableCopyPasteUnits flag', async () => {
+    const { findByTestId } = renderComponent({
+      unit: {
+        ...unit,
+        enableCopyPasteUnits: true,
+      },
+    });
+    const element = await findByTestId('unit-card');
+    const menu = await within(element).findByTestId('unit-card-header__menu-button');
+    await act(async () => fireEvent.click(menu));
+    expect(within(element).queryByText(cardMessages.menuCopy.defaultMessage)).toBeInTheDocument();
   });
 });

--- a/src/course-outline/utils.jsx
+++ b/src/course-outline/utils.jsx
@@ -21,6 +21,8 @@ const getItemStatus = ({
   switch (true) {
   case visibilityState === VisibilityTypes.STAFF_ONLY:
     return ITEM_BADGE_STATUS.staffOnly;
+  case visibilityState === VisibilityTypes.GATED:
+    return ITEM_BADGE_STATUS.gated;
   case visibilityState === VisibilityTypes.LIVE:
     return ITEM_BADGE_STATUS.live;
   case published && !hasChanges:
@@ -42,6 +44,11 @@ const getItemStatus = ({
  */
 const getItemStatusBadgeContent = (status, messages, intl) => {
   switch (status) {
+  case ITEM_BADGE_STATUS.gated:
+    return {
+      badgeTitle: intl.formatMessage(messages.statusBadgeGated),
+      badgeIcon: LockIcon,
+    };
   case ITEM_BADGE_STATUS.live:
     return {
       badgeTitle: intl.formatMessage(messages.statusBadgeLive),
@@ -91,6 +98,10 @@ const getItemStatusBorder = (status) => {
   case ITEM_BADGE_STATUS.publishedNotLive:
     return {
       borderLeft: '5px solid #0D7D4D',
+    };
+  case ITEM_BADGE_STATUS.gated:
+    return {
+      borderLeft: '5px solid #000000',
     };
   case ITEM_BADGE_STATUS.staffOnly:
     return {

--- a/src/course-outline/xblock-status/GradingPolicyAlert.jsx
+++ b/src/course-outline/xblock-status/GradingPolicyAlert.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Alert } from '@edx/paragon';
+import {
+  WarningFilled as WarningIcon,
+} from '@edx/paragon/icons';
+
+import messages from './messages';
+
+const GradingPolicyAlert = ({
+  graded,
+  gradingType,
+  courseGraders,
+}) => {
+  const intl = useIntl();
+
+  let gradingPolicyMismatch = false;
+  if (graded) {
+    if (gradingType) {
+      gradingPolicyMismatch = (
+        courseGraders.filter((cg) => cg.toLowerCase() === gradingType.toLowerCase())
+      ).length === 0;
+    }
+  }
+
+  if (gradingPolicyMismatch) {
+    return (
+      <Alert className="mt-2 grading-mismatch-alert" variant="warning" icon={WarningIcon}>
+        {intl.formatMessage(messages.gradingPolicyMismatchText, { gradingType })}
+      </Alert>
+    );
+  }
+  return null;
+};
+
+GradingPolicyAlert.defaultProps = {
+  graded: false,
+  gradingType: '',
+};
+
+GradingPolicyAlert.propTypes = {
+  graded: PropTypes.bool,
+  gradingType: PropTypes.string,
+  courseGraders: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+};
+
+export default GradingPolicyAlert;

--- a/src/course-outline/xblock-status/GradingTypeAndDueDate.jsx
+++ b/src/course-outline/xblock-status/GradingTypeAndDueDate.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import {
+  Check as CheckIcon,
+  CalendarMonth as CalendarIcon,
+} from '@edx/paragon/icons';
+
+import messages from './messages';
+
+const GradingTypeAndDueDate = ({
+  isSelfPaced,
+  isInstructorPaced,
+  isCustomRelativeDatesActive,
+  isTimeLimited,
+  isProctoredExam,
+  isOnboardingExam,
+  isPracticeExam,
+  graded,
+  gradingType,
+  dueDate,
+  relativeWeeksDue,
+}) => {
+  const intl = useIntl();
+  const showRelativeWeeks = isSelfPaced && isCustomRelativeDatesActive && relativeWeeksDue;
+
+  let examValue = '';
+  if (isProctoredExam) {
+    if (isOnboardingExam) {
+      examValue = messages.onboardingExam;
+    } else if (isPracticeExam) {
+      examValue = messages.practiceProctoredExam;
+    } else {
+      examValue = messages.proctoredExam;
+    }
+  } else {
+    examValue = messages.timedExam;
+  }
+
+  const gradingTypeDiv = () => (
+    <div className="d-flex align-items-center mr-1" data-testid="grading-type-div">
+      <span className="sr-only status-grading-label">
+        {intl.formatMessage(messages.gradedAsScreenReaderLabel)}
+      </span>
+      <Icon className="mr-1" size="sm" src={CheckIcon} />
+      <span className="status-grading-value">
+        {gradingType || intl.formatMessage(messages.ungradedText)}
+      </span>
+    </div>
+  );
+
+  const dueDateDiv = () => {
+    if (dueDate && isInstructorPaced) {
+      return (
+        <div className="status-grading-date" data-testid="due-date-div">
+          {intl.formatMessage(messages.dueLabel)} {dueDate}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const selfPacedRelativeDueWeeksDiv = () => (
+    <div className="d-flex align-items-center" data-testid="self-paced-relative-due-weeks-div">
+      <Icon className="mr-1" size="sm" src={CalendarIcon} />
+      <span className="status-custom-grading-date">
+        {intl.formatMessage(messages.customDueDateLabel, { relativeWeeksDue })}
+      </span>
+    </div>
+  );
+
+  if (isTimeLimited) {
+    return (
+      <>
+        <div className="d-flex align-items-center">
+          {gradingTypeDiv()} -
+          <span className="sr-only">{intl.formatMessage(examValue)}</span>
+          <span className="mx-2" data-testid="exam-value-span">
+            {intl.formatMessage(examValue)}
+          </span>
+          {dueDateDiv()}
+        </div>
+        {showRelativeWeeks && (selfPacedRelativeDueWeeksDiv())}
+      </>
+    );
+  } if ((dueDate && !isSelfPaced) || graded) {
+    return (
+      <>
+        <div className="d-flex align-items-center">
+          {gradingTypeDiv()}
+          {dueDateDiv()}
+        </div>
+        {showRelativeWeeks && (selfPacedRelativeDueWeeksDiv())}
+      </>
+    );
+  } if (showRelativeWeeks) {
+    return (
+      <>
+        {gradingTypeDiv()}
+        {selfPacedRelativeDueWeeksDiv()}
+      </>
+    );
+  }
+  return null;
+};
+
+GradingTypeAndDueDate.defaultProps = {
+  isCustomRelativeDatesActive: false,
+  isTimeLimited: false,
+  isProctoredExam: false,
+  isOnboardingExam: false,
+  isPracticeExam: false,
+  graded: false,
+  gradingType: '',
+  dueDate: '',
+  relativeWeeksDue: null,
+};
+
+GradingTypeAndDueDate.propTypes = {
+  isInstructorPaced: PropTypes.bool.isRequired,
+  isSelfPaced: PropTypes.bool.isRequired,
+  isCustomRelativeDatesActive: PropTypes.bool,
+  isTimeLimited: PropTypes.bool,
+  isProctoredExam: PropTypes.bool,
+  isOnboardingExam: PropTypes.bool,
+  isPracticeExam: PropTypes.bool,
+  graded: PropTypes.bool,
+  gradingType: PropTypes.string,
+  dueDate: PropTypes.string,
+  relativeWeeksDue: PropTypes.number,
+};
+
+export default GradingTypeAndDueDate;

--- a/src/course-outline/xblock-status/HideAfterDueMessage.jsx
+++ b/src/course-outline/xblock-status/HideAfterDueMessage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import {
+  VisibilityOff as HideIcon,
+} from '@edx/paragon/icons';
+
+import messages from './messages';
+
+const HideAfterDueMessage = ({ isSelfPaced }) => {
+  const intl = useIntl();
+  return (
+    <div className="d-flex align-items-center" data-testid="hide-after-due-message">
+      <Icon className="mr-1" size="sm" src={HideIcon} />
+      <span className="status-hide-after-due-value">
+        {isSelfPaced
+          ? intl.formatMessage(messages.hiddenAfterEndDate)
+          : intl.formatMessage(messages.hiddenAfterDueDate)}
+      </span>
+    </div>
+  );
+};
+
+HideAfterDueMessage.propTypes = {
+  isSelfPaced: PropTypes.bool.isRequired,
+};
+
+export default HideAfterDueMessage;

--- a/src/course-outline/xblock-status/ReleaseStatus.jsx
+++ b/src/course-outline/xblock-status/ReleaseStatus.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import {
+  AccessTime as ClockIcon,
+} from '@edx/paragon/icons';
+
+import messages from './messages';
+
+const ReleaseStatus = ({
+  isInstructorPaced,
+  explanatoryMessage,
+  releaseDate,
+  releasedToStudents,
+}) => {
+  const intl = useIntl();
+
+  const explanatoryMessageDiv = () => (
+    <span data-testid="explanatory-message-span">
+      {explanatoryMessage}
+    </span>
+  );
+
+  let releaseLabel = messages.unscheduledLabel;
+  if (releasedToStudents) {
+    releaseLabel = messages.releasedLabel;
+  } else if (releaseDate) {
+    releaseLabel = messages.scheduledLabel;
+  }
+
+  const releaseStatusDiv = () => (
+    <div className="d-flex align-items-center" data-testid="release-status-div">
+      <span className="sr-only status-release-label">
+        {intl.formatMessage(messages.releaseStatusScreenReaderTitle)}
+      </span>
+      <Icon className="mr-1" size="sm" src={ClockIcon} />
+      {intl.formatMessage(releaseLabel)}
+      {releaseDate && releaseDate}
+    </div>
+  );
+
+  if (explanatoryMessage) {
+    return explanatoryMessageDiv();
+  }
+
+  if (isInstructorPaced) {
+    return releaseStatusDiv();
+  }
+
+  return null;
+};
+
+ReleaseStatus.defaultProps = {
+  explanatoryMessage: '',
+};
+
+ReleaseStatus.propTypes = {
+  isInstructorPaced: PropTypes.bool.isRequired,
+  explanatoryMessage: PropTypes.string,
+  releaseDate: PropTypes.string.isRequired,
+  releasedToStudents: PropTypes.bool.isRequired,
+};
+
+export default ReleaseStatus;

--- a/src/course-outline/xblock-status/StatusMessages.jsx
+++ b/src/course-outline/xblock-status/StatusMessages.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import {
+  Lock as LockIcon,
+  Groups as GroupsIcon,
+} from '@edx/paragon/icons';
+
+import messages from './messages';
+
+const StatusMessages = ({
+  isVertical,
+  staffOnlyMessage,
+  prereq,
+  prereqs,
+  userPartitionInfo,
+  hasPartitionGroupComponents,
+}) => {
+  const intl = useIntl();
+  const statusMessages = [];
+
+  if (prereq) {
+    let prereqDisplayName = '';
+    prereqs.forEach((block) => {
+      if (block.blockUsageKey === prereq) {
+        prereqDisplayName = block.blockDisplayName;
+      }
+    });
+    statusMessages.push({
+      icon: LockIcon,
+      text: intl.formatMessage(messages.prerequisiteLabel, { prereqDisplayName }),
+    });
+  }
+
+  if (!staffOnlyMessage && isVertical) {
+    const { selectedPartitionIndex, selectedGroupsLabel } = userPartitionInfo;
+    if (selectedPartitionIndex !== -1 && !Number.isNaN(selectedPartitionIndex)) {
+      statusMessages.push({
+        icon: GroupsIcon,
+        text: intl.formatMessage(messages.restrictedUnitAccess, { selectedGroupsLabel }),
+      });
+    } else if (hasPartitionGroupComponents) {
+      statusMessages.push({
+        icon: GroupsIcon,
+        text: intl.formatMessage(messages.restrictedUnitAccessToSomeContent),
+      });
+    }
+  }
+
+  if (statusMessages.length > 0) {
+    return (
+      <div className="border-top border-light mt-2 text-dark" data-testid="status-messages-div">
+        {statusMessages.map(({ icon, text }) => (
+          <div key={text} className="d-flex align-items-center pt-1">
+            <Icon className="mr-1" size="sm" src={icon} />
+            {text}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return null;
+};
+
+StatusMessages.defaultProps = {
+  staffOnlyMessage: false,
+  prereq: '',
+  prereqs: [],
+  userPartitionInfo: {},
+};
+
+StatusMessages.propTypes = {
+  isVertical: PropTypes.bool.isRequired,
+  staffOnlyMessage: PropTypes.bool,
+  prereq: PropTypes.string,
+  prereqs: PropTypes.arrayOf(PropTypes.shape({
+    blockUsageKey: PropTypes.string.isRequired,
+    blockDisplayName: PropTypes.string.isRequired,
+  })),
+  userPartitionInfo: PropTypes.shape({
+    selectedPartitionIndex: PropTypes.number.isRequired,
+    selectedGroupsLabel: PropTypes.string.isRequired,
+  }),
+  hasPartitionGroupComponents: PropTypes.bool.isRequired,
+};
+
+export default StatusMessages;

--- a/src/course-outline/xblock-status/XBlockStatus.jsx
+++ b/src/course-outline/xblock-status/XBlockStatus.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { COURSE_BLOCK_NAMES } from '../constants';
+import ReleaseStatus from './ReleaseStatus';
+import GradingPolicyAlert from './GradingPolicyAlert';
+import GradingTypeAndDueDate from './GradingTypeAndDueDate';
+import StatusMessages from './StatusMessages';
+import HideAfterDueMessage from './HideAfterDueMessage';
+
+const XBlockStatus = ({
+  isSelfPaced,
+  isCustomRelativeDatesActive,
+  blockData,
+}) => {
+  const {
+    category,
+    explanatoryMessage,
+    releasedToStudents,
+    releaseDate,
+    isProctoredExam,
+    isOnboardingExam,
+    isPracticeExam,
+    prereq,
+    prereqs,
+    staffOnlyMessage,
+    userPartitionInfo,
+    hasPartitionGroupComponents,
+    format: gradingType,
+    dueDate,
+    relativeWeeksDue,
+    isTimeLimited,
+    graded,
+    courseGraders,
+    hideAfterDue,
+  } = blockData;
+
+  const isInstructorPaced = !isSelfPaced;
+  const isVertical = category === COURSE_BLOCK_NAMES.vertical.id;
+
+  return (
+    <div className="text-secondary-400 x-small mb-1">
+      {!isVertical && (
+        <ReleaseStatus
+          isInstructorPaced={isInstructorPaced}
+          explanatoryMessage={explanatoryMessage}
+          releaseDate={releaseDate}
+          releasedToStudents={releasedToStudents}
+        />
+      )}
+      {!isVertical && (
+        <GradingTypeAndDueDate
+          isSelfPaced={isSelfPaced}
+          isInstructorPaced={isInstructorPaced}
+          isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+          isTimeLimited={isTimeLimited}
+          isProctoredExam={isProctoredExam}
+          isOnboardingExam={isOnboardingExam}
+          isPracticeExam={isPracticeExam}
+          graded={graded}
+          gradingType={gradingType}
+          dueDate={dueDate}
+          relativeWeeksDue={relativeWeeksDue}
+        />
+      )}
+      {hideAfterDue && (
+        <HideAfterDueMessage isSelfPaced={isSelfPaced} />
+      )}
+      <StatusMessages
+        isVertical={isVertical}
+        staffOnlyMessage={staffOnlyMessage}
+        prereq={prereq}
+        prereqs={prereqs}
+        userPartitionInfo={userPartitionInfo}
+        hasPartitionGroupComponents={hasPartitionGroupComponents}
+      />
+      <GradingPolicyAlert
+        graded={graded}
+        gradingType={gradingType}
+        courseGraders={courseGraders}
+      />
+    </div>
+  );
+};
+
+XBlockStatus.defaultProps = {
+  isCustomRelativeDatesActive: false,
+};
+
+XBlockStatus.propTypes = {
+  isSelfPaced: PropTypes.bool.isRequired,
+  isCustomRelativeDatesActive: PropTypes.bool,
+  blockData: PropTypes.shape({
+    category: PropTypes.string.isRequired,
+    explanatoryMessage: PropTypes.string,
+    releasedToStudents: PropTypes.bool.isRequired,
+    releaseDate: PropTypes.string.isRequired,
+    isProctoredExam: PropTypes.bool,
+    isOnboardingExam: PropTypes.bool,
+    isPracticeExam: PropTypes.bool,
+    prereq: PropTypes.string,
+    prereqs: PropTypes.arrayOf(PropTypes.shape({
+      blockUsageKey: PropTypes.string.isRequired,
+      blockDisplayName: PropTypes.string.isRequired,
+    })),
+    staffOnlyMessage: PropTypes.bool,
+    userPartitionInfo: PropTypes.shape({
+      selectedPartitionIndex: PropTypes.number.isRequired,
+      selectedGroupsLabel: PropTypes.string.isRequired,
+    }),
+    hasPartitionGroupComponents: PropTypes.bool.isRequired,
+    format: PropTypes.string,
+    dueDate: PropTypes.string,
+    relativeWeeksDue: PropTypes.number,
+    isTimeLimited: PropTypes.bool,
+    graded: PropTypes.bool,
+    courseGraders: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    hideAfterDue: PropTypes.bool,
+  }).isRequired,
+};
+
+export default XBlockStatus;

--- a/src/course-outline/xblock-status/XBlockStatus.scss
+++ b/src/course-outline/xblock-status/XBlockStatus.scss
@@ -1,0 +1,4 @@
+.grading-mismatch-alert {
+  font-size: 14px;
+  font-weight: 400;
+}

--- a/src/course-outline/xblock-status/XBlockStatus.test.jsx
+++ b/src/course-outline/xblock-status/XBlockStatus.test.jsx
@@ -1,0 +1,503 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { AppProvider } from '@edx/frontend-platform/react';
+import { initializeMockApp } from '@edx/frontend-platform';
+import MockAdapter from 'axios-mock-adapter';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import initializeStore from '../../store';
+import XBlockStatus from './XBlockStatus';
+import messages from './messages';
+
+// eslint-disable-next-line no-unused-vars
+let axiosMock;
+let store;
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  useIntl: () => ({
+    formatMessage: (message) => message.defaultMessage,
+  }),
+}));
+
+const section = {
+  id: '123',
+  displayName: 'Section Name',
+  published: true,
+  visibilityState: 'live',
+  hasChanges: false,
+  highlights: ['highlight 1', 'highlight 2'],
+  category: 'chapter',
+  explanatoryMessage: '',
+  releasedToStudents: true,
+  releaseDate: 'Feb 05, 2013 at 01:00 UTC',
+  isProctoredExam: false,
+  isOnboardingExam: false,
+  isPracticeExam: false,
+  staffOnlyMessage: false,
+  userPartitionInfo: {
+    selectedPartitionIndex: -1,
+    selectedGroupsLabel: '',
+  },
+  hasPartitionGroupComponents: false,
+  format: 'Homework',
+  dueDate: 'Dec 28, 2023 at 22:00 UTC',
+  isTimeLimited: true,
+  graded: true,
+  courseGraders: ['Homework'],
+  hideAfterDue: true,
+};
+
+const renderComponent = (props) => render(
+  <AppProvider store={store}>
+    <IntlProvider locale="en">
+      <XBlockStatus
+        isSelfPaced={false}
+        isCustomRelativeDatesActive={false}
+        {...props}
+      />
+    </IntlProvider>,
+  </AppProvider>,
+);
+
+describe('<XBlockStatus /> for Instructor paced Section', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  it('render XBlockStatus with explanatoryMessage', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...section,
+        explanatoryMessage: 'some explanatory message',
+      },
+    });
+
+    expect(queryByTestId('explanatory-message-span')).toBeInTheDocument();
+    // when explanatory message is displayed, release date should not be visible
+    expect(queryByTestId('release-status-div')).not.toBeInTheDocument();
+  });
+
+  it('renders XBlockStatus with release status, grading type, due date etc.', () => {
+    const { queryByTestId } = renderComponent({ blockData: section });
+
+    expect(queryByTestId('explanatory-message-span')).not.toBeInTheDocument();
+    // when explanatory message is not displayed, release date should be visible
+    const releaseStatusDiv = queryByTestId('release-status-div');
+    expect(releaseStatusDiv).toBeInTheDocument();
+    expect(releaseStatusDiv).toHaveTextContent(
+      `${messages.releasedLabel.defaultMessage}${section.releaseDate}`,
+    );
+
+    // check grading type
+    const gradingTypeDiv = queryByTestId('grading-type-div');
+    expect(gradingTypeDiv).toBeInTheDocument();
+    expect(gradingTypeDiv).toHaveTextContent(section.format);
+    // check exam value label
+    const examValue = queryByTestId('exam-value-span');
+    expect(examValue).toBeInTheDocument();
+    expect(examValue).toHaveTextContent(messages.timedExam.defaultMessage);
+    // check due date div
+    const dueDateDiv = queryByTestId('due-date-div');
+    expect(dueDateDiv).toBeInTheDocument();
+    expect(dueDateDiv).toHaveTextContent(
+      `${messages.dueLabel.defaultMessage} ${section.dueDate}`,
+    );
+    // self paced weeks should not be visible as
+    // isSelfPaced is false as well as isCustomRelativeDatesActive is false
+    expect(queryByTestId('self-paced-relative-due-weeks-div')).not.toBeInTheDocument();
+
+    // check hide after due date message
+    const hideAfterDueMessage = queryByTestId('hide-after-due-message');
+    expect(hideAfterDueMessage).toBeInTheDocument();
+    expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterDueDate.defaultMessage);
+
+    // check status messages
+    const statusDiv = queryByTestId('status-messages-div');
+    expect(statusDiv).not.toBeInTheDocument();
+  });
+});
+
+describe('<XBlockStatus /> for self paced Section', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  it('renders XBlockStatus with grading type, due weeks etc.', () => {
+    const { queryByTestId } = renderComponent({
+      isSelfPaced: true,
+      isCustomRelativeDatesActive: true,
+      blockData: {
+        ...section,
+        relativeWeeksDue: 2,
+      },
+    });
+
+    // both explanatoryMessage & releaseStatusDiv should not be visible
+    expect(queryByTestId('explanatory-message-span')).not.toBeInTheDocument();
+    expect(queryByTestId('release-status-div')).not.toBeInTheDocument();
+
+    // check grading type
+    const gradingTypeDiv = queryByTestId('grading-type-div');
+    expect(gradingTypeDiv).toBeInTheDocument();
+    expect(gradingTypeDiv).toHaveTextContent(section.format);
+    // due date should not be visible for self paced courses.
+    expect(queryByTestId('due-date-div')).not.toBeInTheDocument();
+    // check selfPacedRelativeDueWeeksDiv
+    const selfPacedRelativeDueWeeksDiv = queryByTestId('self-paced-relative-due-weeks-div');
+    expect(selfPacedRelativeDueWeeksDiv).toBeInTheDocument();
+    expect(selfPacedRelativeDueWeeksDiv).toHaveTextContent(
+      messages.customDueDateLabel.defaultMessage,
+    );
+
+    // check hide after due date message
+    const hideAfterDueMessage = queryByTestId('hide-after-due-message');
+    expect(hideAfterDueMessage).toBeInTheDocument();
+    expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterEndDate.defaultMessage);
+
+    // check status messages
+    expect(queryByTestId('status-messages-div')).not.toBeInTheDocument();
+  });
+
+  it('renders XBlockStatus with grading mismatch alert', () => {
+    const { queryByText } = renderComponent({
+      blockData: {
+        ...section,
+        format: 'Fun',
+      },
+    });
+
+    // check alert
+    const alert = queryByText(messages.gradingPolicyMismatchText.defaultMessage);
+    expect(alert).toBeInTheDocument();
+  });
+});
+
+const subsection = {
+  id: '123',
+  displayName: 'Subsection Name',
+  published: true,
+  visibilityState: 'live',
+  hasChanges: false,
+  highlights: ['highlight 1', 'highlight 2'],
+  category: 'sequential',
+  explanatoryMessage: '',
+  releasedToStudents: false,
+  releaseDate: 'Feb 05, 2025 at 01:00 UTC',
+  isProctoredExam: false,
+  isOnboardingExam: false,
+  isPracticeExam: false,
+  prereq: 'block-v1:edX+DemoX+Demo_Course+type@sequential+block@dbe8fc0',
+  prereqs: [
+    {
+      blockDisplayName: 'Find your study buddy',
+      blockUsageKey: 'block-v1:edX+DemoX+Demo_Course+type@sequential+block@dbe8fc0',
+    },
+    {
+      blockDisplayName: 'Something else',
+      blockUsageKey: 'block-v1:edX+DemoX+Demo_Course+type@sequential+block@sdafyrb',
+    },
+  ],
+  staffOnlyMessage: false,
+  userPartitionInfo: {
+    selectedPartitionIndex: -1,
+    selectedGroupsLabel: '',
+  },
+  hasPartitionGroupComponents: false,
+  format: 'Homework',
+  dueDate: 'Dec 28, 2023 at 22:00 UTC',
+  isTimeLimited: true,
+  graded: true,
+  courseGraders: ['Homework'],
+  hideAfterDue: true,
+};
+
+describe('<XBlockStatus /> for Instructor paced Subsection', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  it('renders XBlockStatus with release status, grading type, due date etc.', () => {
+    const { queryByTestId } = renderComponent({ blockData: subsection });
+
+    expect(queryByTestId('explanatory-message-span')).not.toBeInTheDocument();
+    // when explanatory message is not displayed, release date should be visible
+    const releaseStatusDiv = queryByTestId('release-status-div');
+    expect(releaseStatusDiv).toBeInTheDocument();
+    expect(releaseStatusDiv).toHaveTextContent(
+      `${messages.scheduledLabel.defaultMessage}${subsection.releaseDate}`,
+    );
+
+    // check grading type
+    const gradingTypeDiv = queryByTestId('grading-type-div');
+    expect(gradingTypeDiv).toBeInTheDocument();
+    expect(gradingTypeDiv).toHaveTextContent(subsection.format);
+    // check exam value label
+    const examValue = queryByTestId('exam-value-span');
+    expect(examValue).toBeInTheDocument();
+    expect(examValue).toHaveTextContent(messages.timedExam.defaultMessage);
+    // check due date div
+    const dueDateDiv = queryByTestId('due-date-div');
+    expect(dueDateDiv).toBeInTheDocument();
+    expect(dueDateDiv).toHaveTextContent(
+      `${messages.dueLabel.defaultMessage} ${subsection.dueDate}`,
+    );
+    // self paced weeks should not be visible as
+    // isSelfPaced is false as well as isCustomRelativeDatesActive is false
+    expect(queryByTestId('self-paced-relative-due-weeks-div')).not.toBeInTheDocument();
+
+    // check hide after due date message
+    const hideAfterDueMessage = queryByTestId('hide-after-due-message');
+    expect(hideAfterDueMessage).toBeInTheDocument();
+    expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterDueDate.defaultMessage);
+
+    // check status messages
+    const statusDiv = queryByTestId('status-messages-div');
+    expect(statusDiv).toBeInTheDocument();
+    expect(statusDiv).toHaveTextContent(messages.prerequisiteLabel.defaultMessage);
+  });
+
+  it('renders XBlockStatus with proctored exam info', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...subsection,
+        isProctoredExam: true,
+        isOnboardingExam: false,
+        isPracticeExam: false,
+      },
+    });
+
+    // check exam value label
+    const examValue = queryByTestId('exam-value-span');
+    expect(examValue).toBeInTheDocument();
+    expect(examValue).toHaveTextContent(messages.proctoredExam.defaultMessage);
+  });
+
+  it('renders XBlockStatus with practice proctored exam info', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...subsection,
+        isProctoredExam: true,
+        isOnboardingExam: false,
+        isPracticeExam: true,
+      },
+    });
+
+    // check exam value label
+    const examValue = queryByTestId('exam-value-span');
+    expect(examValue).toBeInTheDocument();
+    expect(examValue).toHaveTextContent(messages.practiceProctoredExam.defaultMessage);
+  });
+
+  it('renders XBlockStatus with onboarding exam info', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...subsection,
+        isProctoredExam: true,
+        isOnboardingExam: true,
+        isPracticeExam: false,
+      },
+    });
+
+    // check exam value label
+    const examValue = queryByTestId('exam-value-span');
+    expect(examValue).toBeInTheDocument();
+    expect(examValue).toHaveTextContent(messages.onboardingExam.defaultMessage);
+  });
+
+  it('renders XBlockStatus correctly for graded but not time limited subsection', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...subsection,
+        isTimeLimited: false,
+        graded: true,
+      },
+    });
+
+    // check grading type
+    const gradingTypeDiv = queryByTestId('grading-type-div');
+    expect(gradingTypeDiv).toBeInTheDocument();
+    expect(gradingTypeDiv).toHaveTextContent(subsection.format);
+    // exam value label should not be visible
+    expect(queryByTestId('exam-value-span')).not.toBeInTheDocument();
+    // check due date div
+    const dueDateDiv = queryByTestId('due-date-div');
+    expect(dueDateDiv).toBeInTheDocument();
+    expect(dueDateDiv).toHaveTextContent(
+      `${messages.dueLabel.defaultMessage} ${subsection.dueDate}`,
+    );
+    // self paced weeks should not be visible as
+    // isSelfPaced is false as well as isCustomRelativeDatesActive is false
+    expect(queryByTestId('self-paced-relative-due-weeks-div')).not.toBeInTheDocument();
+  });
+});
+
+describe('<XBlockStatus /> for self paced Subsection', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  it('renders XBlockStatus with grading type, due weeks etc.', () => {
+    const { queryByTestId } = renderComponent({
+      isSelfPaced: true,
+      isCustomRelativeDatesActive: true,
+      blockData: {
+        ...subsection,
+        relativeWeeksDue: 2,
+      },
+    });
+
+    // both explanatoryMessage & releaseStatusDiv should not be visible
+    expect(queryByTestId('explanatory-message-span')).not.toBeInTheDocument();
+    expect(queryByTestId('release-status-div')).not.toBeInTheDocument();
+
+    // check grading type
+    const gradingTypeDiv = queryByTestId('grading-type-div');
+    expect(gradingTypeDiv).toBeInTheDocument();
+    expect(gradingTypeDiv).toHaveTextContent(subsection.format);
+    // due date should not be visible for self paced courses.
+    expect(queryByTestId('due-date-div')).not.toBeInTheDocument();
+    // check selfPacedRelativeDueWeeksDiv
+    const selfPacedRelativeDueWeeksDiv = queryByTestId('self-paced-relative-due-weeks-div');
+    expect(selfPacedRelativeDueWeeksDiv).toBeInTheDocument();
+    expect(selfPacedRelativeDueWeeksDiv).toHaveTextContent(
+      messages.customDueDateLabel.defaultMessage,
+    );
+
+    // check hide after due date message
+    const hideAfterDueMessage = queryByTestId('hide-after-due-message');
+    expect(hideAfterDueMessage).toBeInTheDocument();
+    expect(hideAfterDueMessage).toHaveTextContent(messages.hiddenAfterEndDate.defaultMessage);
+
+    // check status messages
+    const statusDiv = queryByTestId('status-messages-div');
+    expect(statusDiv).toBeInTheDocument();
+    expect(statusDiv).toHaveTextContent(messages.prerequisiteLabel.defaultMessage);
+  });
+});
+
+const unit = {
+  id: '123',
+  displayName: 'Unit Name',
+  published: true,
+  visibilityState: 'live',
+  hasChanges: false,
+  highlights: ['highlight 1', 'highlight 2'],
+  category: 'vertical',
+  explanatoryMessage: '',
+  releasedToStudents: true,
+  releaseDate: 'Feb 05, 2013 at 01:00 UTC',
+  isProctoredExam: false,
+  isOnboardingExam: false,
+  isPracticeExam: false,
+  staffOnlyMessage: false,
+  userPartitionInfo: {
+    selectedPartitionIndex: 1,
+    selectedGroupsLabel: 'Some label',
+  },
+  hasPartitionGroupComponents: false,
+  format: 'Homework',
+  dueDate: 'Dec 28, 2023 at 22:00 UTC',
+  isTimeLimited: true,
+  graded: true,
+  courseGraders: ['Homework'],
+};
+
+describe('<XBlockStatus /> for unit', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    store = initializeStore();
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  it('renders XBlockStatus with status messages', () => {
+    const { queryByTestId } = renderComponent({ blockData: unit });
+
+    expect(queryByTestId('explanatory-message-span')).not.toBeInTheDocument();
+    expect(queryByTestId('release-status-div')).not.toBeInTheDocument();
+
+    // grading type should not be visible
+    expect(queryByTestId('grading-type-div')).not.toBeInTheDocument();
+    // due date should not be visible
+    expect(queryByTestId('due-date-div')).not.toBeInTheDocument();
+
+    // self paced weeks should not be visible for units
+    expect(queryByTestId('self-paced-relative-due-weeks-div')).not.toBeInTheDocument();
+
+    // check hide after due date message
+    // hide after due date message should not be visible as the flag is set to false
+    expect(queryByTestId('hide-after-due-message')).not.toBeInTheDocument();
+
+    // check status messages for partition info
+    const statusDiv = queryByTestId('status-messages-div');
+    expect(statusDiv).toBeInTheDocument();
+    expect(statusDiv).toHaveTextContent(messages.restrictedUnitAccess.defaultMessage);
+  });
+
+  it('renders XBlockStatus with status messages', () => {
+    const { queryByTestId } = renderComponent({
+      blockData: {
+        ...unit,
+        hasPartitionGroupComponents: true,
+        userPartitionInfo: {
+          selectedPartitionIndex: -1,
+          selectedGroupsLabel: '',
+        },
+      },
+    });
+
+    // check status messages for partition info
+    const statusDiv = queryByTestId('status-messages-div');
+    expect(statusDiv).toBeInTheDocument();
+    expect(statusDiv).toHaveTextContent(messages.restrictedUnitAccessToSomeContent.defaultMessage);
+  });
+});

--- a/src/course-outline/xblock-status/messages.js
+++ b/src/course-outline/xblock-status/messages.js
@@ -1,0 +1,78 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  unscheduledLabel: {
+    id: 'course-authoring.course-outline.xblock-status.unscheduled.label',
+    defaultMessage: 'Unscheduled',
+  },
+  releasedLabel: {
+    id: 'course-authoring.course-outline.xblock-status.released.label',
+    defaultMessage: 'Released: ',
+  },
+  scheduledLabel: {
+    id: 'course-authoring.course-outline.xblock-status.scheduled.label',
+    defaultMessage: 'Scheduled: ',
+  },
+  onboardingExam: {
+    id: 'course-authoring.course-outline.xblock-status.onboardingExam.value',
+    defaultMessage: 'Onboarding Exam',
+  },
+  practiceProctoredExam: {
+    id: 'course-authoring.course-outline.xblock-status.practiceProctoredExam.value',
+    defaultMessage: 'Practice proctored Exam',
+  },
+  proctoredExam: {
+    id: 'course-authoring.course-outline.xblock-status.proctoredExam.value',
+    defaultMessage: 'Proctored Exam',
+  },
+  timedExam: {
+    id: 'course-authoring.course-outline.xblock-status.timedExam.value',
+    defaultMessage: 'Timed Exam',
+  },
+  releaseStatusScreenReaderTitle: {
+    id: 'course-authoring.course-outline.xblock-status.releaseStatusScreenReader.title',
+    defaultMessage: 'Release Status: ',
+  },
+  gradedAsScreenReaderLabel: {
+    id: 'course-authoring.course-outline.xblock-status.gradedAsScreenReader.label',
+    defaultMessage: 'Graded as: ',
+  },
+  ungradedText: {
+    id: 'course-authoring.course-outline.xblock-status.ungraded.text',
+    defaultMessage: 'Ungraded',
+  },
+  dueLabel: {
+    id: 'course-authoring.course-outline.xblock-status.due.label',
+    defaultMessage: 'Due:',
+  },
+  customDueDateLabel: {
+    id: 'course-authoring.course-outline.xblock-status.custom-due-date.label',
+    defaultMessage: 'Custom due date: {relativeWeeksDue, plural, one {# week} other {# weeks}} from enrollment',
+  },
+  prerequisiteLabel: {
+    id: 'course-authoring.course-outline.xblock-status.prerequisite.label',
+    defaultMessage: 'Prerequisite: {prereqDisplayName}',
+  },
+  restrictedUnitAccess: {
+    id: 'course-authoring.course-outline.xblock-status.restrictedUnitAccess.text',
+    defaultMessage: 'Access to this unit is restricted to: {selectedGroupsLabel}',
+  },
+  restrictedUnitAccessToSomeContent: {
+    id: 'course-authoring.course-outline.xblock-status.restrictedUnitAccessToSomeContent.text',
+    defaultMessage: 'Access to some content in this unit is restricted to specific groups of learners',
+  },
+  gradingPolicyMismatchText: {
+    id: 'course-authoring.course-outline.xblock-status.gradingPolicyMismatch.text',
+    defaultMessage: 'This subsection is configured as "{gradingType}", which doesn\'t exist in the current grading policy.',
+  },
+  hiddenAfterEndDate: {
+    id: 'course-authoring.course-outline.xblock-status.hiddenAfterEndDate.text',
+    defaultMessage: 'Subsection is hidden after course end date',
+  },
+  hiddenAfterDueDate: {
+    id: 'course-authoring.course-outline.xblock-status.hiddenAfterDueDate.text',
+    defaultMessage: 'Subsection is hidden after due date',
+  },
+});
+
+export default messages;

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -45,6 +45,7 @@ export const DivisionSchemes = /** @type {const} */ ({
 });
 
 export const VisibilityTypes = /** @type {const} */ ({
+  GATED: 'gated',
   LIVE: 'live',
   STAFF_ONLY: 'staff_only',
   HIDE_AFTER_DUE: 'hide_after_due',

--- a/src/generic/broadcast-channel/hooks.js
+++ b/src/generic/broadcast-channel/hooks.js
@@ -1,0 +1,46 @@
+import {
+  useCallback, useEffect, useMemo, useRef,
+} from 'react';
+import { BroadcastChannel } from 'broadcast-channel';
+
+const channelInstances = {};
+
+export const getSingletonChannel = (name) => {
+  if (!channelInstances[name]) {
+    channelInstances[name] = new BroadcastChannel(name);
+  }
+  return channelInstances[name];
+};
+
+export const useBroadcastChannel = (channelName, onMessageReceived) => {
+  const channel = useMemo(() => getSingletonChannel(channelName), [channelName]);
+  const isSubscribed = useRef(false);
+
+  useEffect(() => {
+    if (!isSubscribed.current || process.env.NODE_ENV !== 'development') {
+      // BroadcastChannel api from npm has minor difference from native BroadcastChannel
+      // Native BroadcastChannel passes event to onmessage callback and to
+      // access data we need to use `event.data`, but npm BroadcastChannel
+      // directly passes data as seen below
+      channel.onmessage = (data) => onMessageReceived(data);
+    }
+    return () => {
+      if (isSubscribed.current || process.env.NODE_ENV !== 'development') {
+        channel.close();
+        isSubscribed.current = true;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const postMessage = useCallback(
+    (message) => {
+      channel?.postMessage(message);
+    },
+    [channel],
+  );
+
+  return {
+    postMessage,
+  };
+};


### PR DESCRIPTION
**Description:**

Adds status text under each item in the outline. Screenshot from legacy UI for reference:
![image](https://github.com/open-craft/frontend-app-course-authoring/assets/10894099/8b31c505-7762-431f-a5a7-f0dc1b439875)

The reference logic for displaying this text can be found in https://github.com/openedx/edx-platform/blob/master/cms/templates/js/course-outline.underscore.

**Also combines** https://github.com/open-craft/frontend-app-course-authoring/pull/29

<details>
  <summary>MFE Screenshot:</summary>
 

![image](https://github.com/open-craft/frontend-app-course-authoring/assets/10894099/390b9185-18dd-497f-88ee-eee983772089)


</details> 

**Test instructions:**

* Get devstack up and running using `make {lms,cms}-up`.
* Start npm devserver in this repo using `npm start`.
* Goto http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/
* Different types of status text should be visible based on the item configuration.
* You can enable proctoring exam via advanced settings page.

**Depends on:** https://github.com/openedx/edx-platform/pull/34058