### PR TITLE
docs: fix incorrect waffle flag stated.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ Requirements
 
 * ``edx-platform`` Waffle flags:
 
-  * ``contentstore.new_studio_mfe.use_tagging_taxonomy_list_page``: this feature flag must be enabled.
+  * ``new_studio_mfe.use_tagging_taxonomy_list_page``: this feature flag must be enabled.
 
 Configuration
 -------------

--- a/src/taxonomy/TaxonomyListPage.jsx
+++ b/src/taxonomy/TaxonomyListPage.jsx
@@ -154,13 +154,9 @@ const TaxonomyListPage = () => {
     isSuccess: isOrganizationListLoaded,
   } = useOrganizationListData();
 
-  const useTaxonomyListData = () => {
-    const taxonomyListData = useTaxonomyListDataResponse(selectedOrgFilter);
-    const isLoaded = useIsTaxonomyListDataLoaded(selectedOrgFilter);
-    return { taxonomyListData, isLoaded };
-  };
-  const { taxonomyListData, isLoaded } = useTaxonomyListData();
-  const canAddTaxonomy = isLoaded ? taxonomyListData.canAddTaxonomy : false;
+  const taxonomyListData = useTaxonomyListDataResponse(selectedOrgFilter);
+  const isLoaded = useIsTaxonomyListDataLoaded(selectedOrgFilter);
+  const canAddTaxonomy = taxonomyListData?.canAddTaxonomy ?? false;
 
   const getOrgSelect = () => (
     // Initialize organization select component


### PR DESCRIPTION
The README states the wrong waffle flag. Although this is inconsistent with the others, this is the actual waffle flag that edx-platform currently checks.

Ref: 

https://github.com/openedx/edx-platform/blob/4b7ef2697e84bae269983dfce63f1af60bb247df/cms/djangoapps/contentstore/toggles.py#L550