### PR TITLE
feat: Add export ID on Taxonomy details and import new Taxonomy

### DIFF
--- a/src/taxonomy/TaxonomyListPage.jsx
+++ b/src/taxonomy/TaxonomyListPage.jsx
@@ -160,7 +160,7 @@ const TaxonomyListPage = () => {
     return { taxonomyListData, isLoaded };
   };
   const { taxonomyListData, isLoaded } = useTaxonomyListData();
-  const canAddTaxonomy = isLoaded ? taxonomyListData.canAddTaxonomy : false;
+  const canAddTaxonomy = isLoaded ? (taxonomyListData?.canAddTaxonomy || false) : false;
 
   const getOrgSelect = () => (
     // Initialize organization select component

--- a/src/taxonomy/data/types.mjs
+++ b/src/taxonomy/data/types.mjs
@@ -5,6 +5,7 @@
  * @property {number} id
  * @property {string} name
  * @property {string} description
+ * @property {string} exportId
  * @property {boolean} enabled
  * @property {boolean} allowMultiple
  * @property {boolean} allowFreeText

--- a/src/taxonomy/import-tags/__mocks__/taxonomyImportMock.js
+++ b/src/taxonomy/import-tags/__mocks__/taxonomyImportMock.js
@@ -1,4 +1,5 @@
 export default {
   name: 'Taxonomy name',
+  exportId: 'taxonomy_export_id',
   description: 'Taxonomy description',
 };

--- a/src/taxonomy/import-tags/data/api.js
+++ b/src/taxonomy/import-tags/data/api.js
@@ -35,10 +35,11 @@ export const getTagsPlanImportApiUrl = (taxonomyId) => new URL(
  * @param {File} file
  * @returns {Promise<import('../../data/types.mjs').TaxonomyData>}
  */
-export async function importNewTaxonomy(taxonomyName, taxonomyDescription, file) {
+export async function importNewTaxonomy(taxonomyName, taxonomyExportId, taxonomyDescription, file) {
   // ToDo: transform this to use react-query like useImportTags
   const formData = new FormData();
   formData.append('taxonomy_name', taxonomyName);
+  formData.append('taxonomy_export_id', taxonomyExportId);
   formData.append('taxonomy_description', taxonomyDescription);
   formData.append('file', file);
 

--- a/src/taxonomy/import-tags/data/api.test.jsx
+++ b/src/taxonomy/import-tags/data/api.test.jsx
@@ -51,7 +51,7 @@ describe('import taxonomy api calls', () => {
 
   it('should call import new taxonomy', async () => {
     axiosMock.onPost(getTaxonomyImportNewApiUrl()).reply(201, taxonomyImportMock);
-    const result = await importNewTaxonomy('Taxonomy name', 'Taxonomy description');
+    const result = await importNewTaxonomy('Taxonomy name', 'taxonomy_export_id', 'Taxonomy description');
 
     expect(axiosMock.history.post[0].url).toEqual(getTaxonomyImportNewApiUrl());
     expect(result).toEqual(taxonomyImportMock);

--- a/src/taxonomy/import-tags/data/utils.js
+++ b/src/taxonomy/import-tags/data/utils.js
@@ -76,8 +76,7 @@ export const importTaxonomy = async (intl) => { // eslint-disable-line import/pr
 
       if (!taxonomyExportId) {
         alert(intl.formatMessage(messages.promptTaxonomyExportIdRequired));
-      }
-      else if (!validationRegex.test(taxonomyExportId)) {
+      } else if (!validationRegex.test(taxonomyExportId)) {
         alert(intl.formatMessage(messages.promptTaxonomyExportIdInvalid));
         taxonomyExportId = null;
       }

--- a/src/taxonomy/import-tags/data/utils.js
+++ b/src/taxonomy/import-tags/data/utils.js
@@ -77,7 +77,7 @@ export const importTaxonomy = async (intl) => { // eslint-disable-line import/pr
       if (!taxonomyExportId) {
         alert(intl.formatMessage(messages.promptTaxonomyExportIdRequired));
       }
-      if (!validationRegex.test(taxonomyExportId)) {
+      else if (!validationRegex.test(taxonomyExportId)) {
         alert(intl.formatMessage(messages.promptTaxonomyExportIdInvalid));
         taxonomyExportId = null;
       }

--- a/src/taxonomy/import-tags/data/utils.js
+++ b/src/taxonomy/import-tags/data/utils.js
@@ -64,6 +64,27 @@ export const importTaxonomy = async (intl) => { // eslint-disable-line import/pr
     return taxonomyName;
   };
 
+  const getTaxonomyExportId = () => {
+    let taxonomyExportId = null;
+    const validationRegex = /^[\p{L}\w\-.]+$/u;
+    while (!taxonomyExportId) {
+      taxonomyExportId = prompt(intl.formatMessage(messages.promptTaxonomyExportId));
+
+      if (taxonomyExportId == null) {
+        break;
+      }
+
+      if (!taxonomyExportId) {
+        alert(intl.formatMessage(messages.promptTaxonomyExportIdRequired));
+      }
+      if (!validationRegex.test(taxonomyExportId)) {
+        alert(intl.formatMessage(messages.promptTaxonomyExportIdInvalid));
+        taxonomyExportId = null;
+      }
+    }
+    return taxonomyExportId;
+  };
+
   const getTaxonomyDescription = () => prompt(intl.formatMessage(messages.promptTaxonomyDescription));
 
   const file = await selectFile();
@@ -77,12 +98,17 @@ export const importTaxonomy = async (intl) => { // eslint-disable-line import/pr
     return;
   }
 
+  const taxonomyExportId = getTaxonomyExportId();
+  if (taxonomyExportId == null) {
+    return;
+  }
+
   const taxonomyDescription = getTaxonomyDescription();
   if (taxonomyDescription == null) {
     return;
   }
 
-  importNewTaxonomy(taxonomyName, taxonomyDescription, file)
+  importNewTaxonomy(taxonomyName, taxonomyExportId, taxonomyDescription, file)
     .then(() => {
       alert(intl.formatMessage(messages.importTaxonomySuccess));
     })

--- a/src/taxonomy/import-tags/messages.js
+++ b/src/taxonomy/import-tags/messages.js
@@ -92,6 +92,18 @@ const messages = defineMessages({
     id: 'course-authoring.import-tags.prompt.taxonomy-name.required',
     defaultMessage: 'You must enter a name for the new taxonomy',
   },
+  promptTaxonomyExportId: {
+    id: 'course-authoring.import-tags.prompt.taxonomy-export-id',
+    defaultMessage: "Enter a Export ID for the new taxonomy. Should only contain alphanumeric characters or '_' '-' '.'",
+  },
+  promptTaxonomyExportIdRequired: {
+    id: 'course-authoring.import-tags.prompt.taxonomy-export-id.required',
+    defaultMessage: 'You must enter an Export ID for the new taxonomy.',
+  },
+  promptTaxonomyExportIdInvalid: {
+    id: 'course-authoring.import-tags.prompt.taxonomy-export-id.invalid',
+    defaultMessage: "Invalid Export ID. Should only contain alphanumeric characters or '_' '-' '.'",
+  },
   promptTaxonomyDescription: {
     id: 'course-authoring.import-tags.prompt.taxonomy-description',
     defaultMessage: 'Enter a description for the new taxonomy',

--- a/src/taxonomy/taxonomy-detail/TaxonomyDetailSideCard.jsx
+++ b/src/taxonomy/taxonomy-detail/TaxonomyDetailSideCard.jsx
@@ -18,6 +18,9 @@ const TaxonomyDetailSideCard = ({ taxonomy }) => {
       <Card.Section title={intl.formatMessage(messages.taxonomyDetailsDescription)}>
         {taxonomy.description}
       </Card.Section>
+      <Card.Section title={intl.formatMessage(messages.taxonomyDetailsExportID)}>
+        {taxonomy.exportId}
+      </Card.Section>
     </Card>
   );
 };
@@ -25,6 +28,7 @@ const TaxonomyDetailSideCard = ({ taxonomy }) => {
 TaxonomyDetailSideCard.propTypes = {
   taxonomy: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    exportId: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/taxonomy/taxonomy-detail/messages.js
+++ b/src/taxonomy/taxonomy-detail/messages.js
@@ -14,6 +14,10 @@ const messages = defineMessages({
     id: 'course-authoring.taxonomy-detail.side-card.description',
     defaultMessage: 'Description',
   },
+  taxonomyDetailsExportID: {
+    id: 'course-authoring.taxonomy-detail.side-card.exportID',
+    defaultMessage: 'Export ID',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
**Description**

- Adds a new propmt on the import new taxonomy workflow to enter the `export_id`.
- Adds the `export_id` on the Taxonomy page details.

**Supporting information**

- Github issue: https://github.com/openedx/modular-learning/issues/183
- Internal Ticket: [FAL-3620](https://tasks.opencraft.com/browse/FAL-3620)
- openedx-learning related PR: https://github.com/openedx/openedx-learning/pull/145
- edx-platform related PR: https://github.com/openedx/edx-platform/pull/34143

**Screenshots**

![image](https://github.com/openedx/frontend-app-course-authoring/assets/11827305/39c92489-c55f-4127-874a-fe214c0ddf26)
![image](https://github.com/openedx/frontend-app-course-authoring/assets/11827305/c31ba6b4-1322-4f55-a3f7-c43ccfae6fec)

**Testing instructions**

- First, follow the testing instructions in https://github.com/openedx/edx-platform/pull/34143
- Go to the [taxonomy list page](http://localhost:2001/taxonomies).
- Import a new taxonomy. 
    - Enter an empty `export_id`. Verify the alert.
    - Enter an invalid `export_id`. Verify the alert.
    - Enter a valid `export_id`.
- Click on any Taxonomy to go to details page.
- Verify that the `export_id` is present on the page.