### PR TITLE
fix: model update for usage locations

### DIFF
--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -31,20 +31,19 @@ export async function getVideos(courseId) {
   };
 }
 
-export async function getAllUsagePaths({ courseId, videos }) {
-  const apiPromises = videos.map(video => getAuthenticatedHttpClient()
-    .get(`${getVideosUrl(courseId)}/${video.id}/usage`, { videoId: video.id }));
-  const results = await Promise.allSettled(apiPromises);
+export async function getAllUsagePaths({ courseId, videoIds }) {
+  const apiPromises = videoIds.map(id => getAuthenticatedHttpClient()
+    .get(`${getVideosUrl(courseId)}/${id}/usage`, { videoId: id }));
   const updatedUsageLocations = [];
+  const results = await Promise.allSettled(apiPromises);
+
   results.forEach(result => {
-    const data = camelCaseObject(result.value.data);
-    const activeStatus = data?.usageLocations?.length > 0 ? 'active' : 'inactive';
-    const { videoId } = result.value.config;
-    if (data) {
-      const { usageLocations } = data;
+    const value = camelCaseObject(result.value);
+    if (value) {
+      const { usageLocations } = value.data;
+      const activeStatus = usageLocations?.length > 0 ? 'active' : 'inactive';
+      const { videoId } = value.config;
       updatedUsageLocations.push({ id: videoId, usageLocations, activeStatus });
-    } else {
-      updatedUsageLocations.push({ id: videoId, usageLocations: [], activeStatus });
     }
   });
   return updatedUsageLocations;

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -5,6 +5,7 @@ import {
   addModels,
   removeModel,
   updateModel,
+  updateModels,
 } from '../../../generic/model-store';
 import {
   addThumbnail,
@@ -70,11 +71,12 @@ export function fetchVideos(courseId) {
           videoIds: parsedVideos.map(video => video.id),
         }));
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.PARTIAL }));
-        await getAllUsagePaths({
+        const allUsageLocations = await getAllUsagePaths({
           courseId,
           videos: parsedVideos,
           updateModel: (apiData, videoId) => updateUsageLocation(videoId, dispatch, apiData.usageLocations),
         });
+        dispatch(updateModels({ modelType: 'videos', models: allUsageLocations }));
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
       }
     } catch (error) {

--- a/src/files-and-videos/videos-page/data/thunks.js
+++ b/src/files-and-videos/videos-page/data/thunks.js
@@ -39,19 +39,6 @@ import {
 
 import { updateFileValues } from './utils';
 
-function updateUsageLocation(videoId, dispatch, usageLocations) {
-  const activeStatus = usageLocations?.length > 0 ? 'active' : 'inactive';
-
-  dispatch(updateModel({
-    modelType: 'videos',
-    model: {
-      id: videoId,
-      usageLocations,
-      activeStatus,
-    },
-  }));
-}
-
 export function fetchVideos(courseId) {
   return async (dispatch) => {
     dispatch(updateLoadingStatus({ courseId, status: RequestStatus.IN_PROGRESS }));
@@ -66,16 +53,11 @@ export function fetchVideos(courseId) {
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
       } else {
         const parsedVideos = updateFileValues(previousUploads);
+        const videoIds = parsedVideos.map(video => video.id);
         dispatch(addModels({ modelType: 'videos', models: parsedVideos }));
-        dispatch(setVideoIds({
-          videoIds: parsedVideos.map(video => video.id),
-        }));
+        dispatch(setVideoIds({ videoIds }));
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.PARTIAL }));
-        const allUsageLocations = await getAllUsagePaths({
-          courseId,
-          videos: parsedVideos,
-          updateModel: (apiData, videoId) => updateUsageLocation(videoId, dispatch, apiData.usageLocations),
-        });
+        const allUsageLocations = await getAllUsagePaths({ courseId, videoIds });
         dispatch(updateModels({ modelType: 'videos', models: allUsageLocations }));
         dispatch(updateLoadingStatus({ courseId, status: RequestStatus.SUCCESSFUL }));
       }


### PR DESCRIPTION
This PR fixes the page crashing by updating the videos model at one time rather then for each video.

Testing

1. Open a course with at least 50 videos
2. Wait for card skeletons to disappear
3. Try clicking around on the page
    - Select videos
    - open the info modal
    - search for videos
    The page should have expected response times
5. Check that the Active column for the videos is correct