### PR TITLE
fix: revert code due to wrong merge conflict resolution

### DIFF
--- a/src/content-tags-drawer/data/api.js
+++ b/src/content-tags-drawer/data/api.js
@@ -75,8 +75,8 @@ export async function getContentData(contentId) {
  * @returns {Promise<import("./types.mjs").ContentTaxonomyTagsData>}
  */
 export async function updateContentTaxonomyTags(contentId, taxonomyId, tags) {
-  let url = getContentTaxonomyTagsApiUrl(contentId);
-  url = `${url}&taxonomy=${taxonomyId}`;
-  const { data } = await getAuthenticatedHttpClient().put(url, { tags });
+  const url = getContentTaxonomyTagsApiUrl(contentId);
+  const params = { taxonomy: taxonomyId };
+  const { data } = await getAuthenticatedHttpClient().put(url, { tags }, { params });
   return camelCaseObject(data[contentId]);
 }

--- a/src/content-tags-drawer/data/api.test.js
+++ b/src/content-tags-drawer/data/api.test.js
@@ -110,10 +110,10 @@ describe('content tags drawer api calls', () => {
     const contentId = 'block-v1:SampleTaxonomyOrg1+STC1+2023_1+type@vertical+block@aaf8b8eb86b54281aeeab12499d2cb0b';
     const taxonomyId = 3;
     const tags = ['flat taxonomy tag 100', 'flat taxonomy tag 3856'];
-    axiosMock.onPut(`${getContentTaxonomyTagsApiUrl(contentId)}&taxonomy=${taxonomyId}`).reply(200, updateContentTaxonomyTagsMock);
+    axiosMock.onPut(`${getContentTaxonomyTagsApiUrl(contentId)}`).reply(200, updateContentTaxonomyTagsMock);
     const result = await updateContentTaxonomyTags(contentId, taxonomyId, tags);
 
-    expect(axiosMock.history.put[0].url).toEqual(`${getContentTaxonomyTagsApiUrl(contentId)}&taxonomy=${taxonomyId}`);
+    expect(axiosMock.history.put[0].url).toEqual(`${getContentTaxonomyTagsApiUrl(contentId)}`);
     expect(result).toEqual(updateContentTaxonomyTagsMock[contentId]);
   });
 });


### PR DESCRIPTION
## Description

The #799 PR inadvertently reverted the code change from #815. This PR adds the code from #815 again.

## Testing instructions

### Setup:
1. Create test taxonomies, tags, orgs, and courses with https://github.com/open-craft/taxonomy-sample-data/
1. Run this PR's branch for course authoring.

### Testing Tag Drawer:

1. Login to Studio as a non-superuser with course authoring permissions.
1. Visit the Sample Taxonomy Course course-v1:SampleTaxonomyOrg1+STC1+2023_1
1. Navigate to a Unit
1. Click "Manage Tags", either from the sidebar or the unit's menu
1. Add a bunch of tags at various hierarchy levels, and ensure they add as expected.
1. Delete some tags and ensure they delete as expected.
