### PR TITLE
Add permissions checks for group_configuration, grading, outline

### DIFF
--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -43,6 +43,9 @@ import ConfigureModal from './configure-modal/ConfigureModal';
 import DeleteModal from './delete-modal/DeleteModal';
 import { useCourseOutline } from './hooks';
 import messages from './messages';
+import { useUserPermissions } from '../generic/hooks';
+import { getUserPermissionsEnabled } from '../generic/data/selectors';
+import PermissionDeniedAlert from '../generic/PermissionDeniedAlert';
 
 const CourseOutline = ({ courseId }) => {
   const intl = useIntl();
@@ -100,6 +103,12 @@ const CourseOutline = ({ courseId }) => {
   } = useCourseOutline({ courseId });
 
   const [sections, setSections] = useState(sectionsList);
+  
+  const { checkPermission } = useUserPermissions();
+  const userPermissionsEnabled = useSelector(getUserPermissionsEnabled);
+  const hasOutlinePermissions = !userPermissionsEnabled || (
+    userPermissionsEnabled && (checkPermission('manage_libraries') || checkPermission('manage_content'))
+  );
 
   let initialSections = [...sectionsList];
 
@@ -233,6 +242,12 @@ const CourseOutline = ({ courseId }) => {
   useEffect(() => {
     setSections(sectionsList);
   }, [sectionsList]);
+
+  if (!hasOutlinePermissions) {
+    return (
+      <PermissionDeniedAlert />
+    );
+  }
 
   if (isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -103,7 +103,7 @@ const CourseOutline = ({ courseId }) => {
   } = useCourseOutline({ courseId });
 
   const [sections, setSections] = useState(sectionsList);
-  
+
   const { checkPermission } = useUserPermissions();
   const userPermissionsEnabled = useSelector(getUserPermissionsEnabled);
   const hasOutlinePermissions = !userPermissionsEnabled || (

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -54,7 +54,7 @@ let store;
 const mockPathname = '/foo-bar';
 const courseId = '123';
 const userId = 3;
-let userPermissionsData = { permissions: [] };
+const userPermissionsData = { permissions: [] };
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 

--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -30,6 +30,9 @@ import CreditSection from './credit-section';
 import DeadlineSection from './deadline-section';
 import { useConvertGradeCutoffs, useUpdateGradingData } from './hooks';
 import getPageHeadTitle from '../generic/utils';
+import { useUserPermissions } from '../generic/hooks';
+import { getUserPermissionsEnabled } from '../generic/data/selectors';
+import PermissionDeniedAlert from '../generic/PermissionDeniedAlert';
 
 const GradingSettings = ({ intl, courseId }) => {
   const gradingSettingsData = useSelector(getGradingSettings);
@@ -43,6 +46,14 @@ const GradingSettings = ({ intl, courseId }) => {
   const [isQueryPending, setIsQueryPending] = useState(false);
   const [showOverrideInternetConnectionAlert, setOverrideInternetConnectionAlert] = useState(false);
   const [eligibleGrade, setEligibleGrade] = useState(null);
+  const { checkPermission } = useUserPermissions();
+  const userPermissionsEnabled = useSelector(getUserPermissionsEnabled);
+  const hasGradingPermissions = !userPermissionsEnabled || (
+    userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings'))
+  );
+  // const viewOnly = !userPermissionsEnabled || (
+  //   userPermissionsEnabled && checkPermission('view_course_settings') && !checkPermission('manage_course_settings')
+  // );
 
   const courseDetails = useModel('courseDetails', courseId);
   document.title = getPageHeadTitle(courseDetails?.name, intl.formatMessage(messages.headingTitle));
@@ -82,6 +93,12 @@ const GradingSettings = ({ intl, courseId }) => {
     dispatch(fetchGradingSettings(courseId));
     dispatch(fetchCourseSettingsQuery(courseId));
   }, [courseId]);
+
+  if (!hasGradingPermissions) {
+    return (
+      <PermissionDeniedAlert />
+    );
+  }
 
   if (isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/grading-settings/GradingSettings.jsx
+++ b/src/grading-settings/GradingSettings.jsx
@@ -51,9 +51,9 @@ const GradingSettings = ({ intl, courseId }) => {
   const hasGradingPermissions = !userPermissionsEnabled || (
     userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings'))
   );
-  // const viewOnly = !userPermissionsEnabled || (
-  //   userPermissionsEnabled && checkPermission('view_course_settings') && !checkPermission('manage_course_settings')
-  // );
+  const viewOnly = !userPermissionsEnabled || (
+    userPermissionsEnabled && checkPermission('view_course_settings') && !checkPermission('manage_course_settings')
+  );
 
   const courseDetails = useModel('courseDetails', courseId);
   document.title = getPageHeadTitle(courseDetails?.name, intl.formatMessage(messages.headingTitle));
@@ -173,6 +173,7 @@ const GradingSettings = ({ intl, courseId }) => {
                       resetDataRef={resetDataRef}
                       setOverrideInternetConnectionAlert={setOverrideInternetConnectionAlert}
                       setEligibleGrade={setEligibleGrade}
+                      viewOnly={viewOnly}
                     />
                   </section>
                   {courseSettingsData.creditEligibilityEnabled && courseSettingsData.isCreditCourse && (
@@ -187,6 +188,7 @@ const GradingSettings = ({ intl, courseId }) => {
                         minimumGradeCredit={minimumGradeCredit}
                         setGradingData={setGradingData}
                         setShowSuccessAlert={setShowSuccessAlert}
+                        viewOnly={viewOnly}
                       />
                     </section>
                   )}
@@ -200,6 +202,7 @@ const GradingSettings = ({ intl, courseId }) => {
                       gracePeriod={gracePeriod}
                       setGradingData={setGradingData}
                       setShowSuccessAlert={setShowSuccessAlert}
+                      viewOnly={viewOnly}
                     />
                   </section>
                   <section>
@@ -218,11 +221,13 @@ const GradingSettings = ({ intl, courseId }) => {
                       setGradingData={setGradingData}
                       courseAssignmentLists={courseAssignmentLists}
                       setShowSuccessAlert={setShowSuccessAlert}
+                      viewOnly={viewOnly}
                     />
                     <Button
                       variant="primary"
                       iconBefore={IconAdd}
                       onClick={handleAddAssignment}
+                      disabled={viewOnly}
                     >
                       {intl.formatMessage(messages.addNewAssignmentTypeBtn)}
                     </Button>

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -20,7 +20,7 @@ const courseId = '123';
 const userId = 3;
 let axiosMock;
 let store;
-let userPermissionsData = { permissions: [] };
+const userPermissionsData = { permissions: [] };
 
 const RootWrapper = () => (
   <AppProvider store={store}>
@@ -56,6 +56,17 @@ describe('<GradingSettings />', () => {
     executeThunk(fetchUserPermissionsEnabledFlag(), store.dispatch);
   });
 
+  afterEach(() => {
+    axiosMock
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: false });
+    axiosMock
+      .onGet(getUserPermissionsUrl(courseId, userId))
+      .reply(200, userPermissionsData);
+    executeThunk(fetchUserPermissionsQuery(courseId), store.dispatch);
+    executeThunk(fetchUserPermissionsEnabledFlag(), store.dispatch);
+  });
+
   it('should render without errors', async () => {
     const { getByText, getAllByText } = render(<RootWrapper />);
     await waitFor(() => {
@@ -66,6 +77,32 @@ describe('<GradingSettings />', () => {
       expect(getByText(messages.policy.defaultMessage)).toBeInTheDocument();
       expect(getByText(messages.policiesDescription.defaultMessage)).toBeInTheDocument();
     });
+  });
+
+  it('should render without errors if access controlled by permissions', async () => {
+    const { getByText, getAllByText, getAllByTestId } = render(<RootWrapper />);
+    axiosMock
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: true });
+    const permissionsData = { permissions: ['manage_course_settings'] }
+    axiosMock
+      .onGet(getUserPermissionsUrl(courseId, userId))
+      .reply(200, permissionsData);
+    await executeThunk(fetchUserPermissionsQuery(courseId), store.dispatch);
+    await executeThunk(fetchUserPermissionsEnabledFlag(), store.dispatch);
+    await waitFor(() => {
+      const gradingElements = getAllByText(messages.headingTitle.defaultMessage);
+      const gradingTitle = gradingElements[0];
+      const segmentButton = getAllByTestId('grading-scale-btn-add-segment');
+      expect(getByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
+      expect(gradingTitle).toBeInTheDocument();
+      expect(getByText(messages.policy.defaultMessage)).toBeInTheDocument();
+      expect(getByText(messages.policiesDescription.defaultMessage)).toBeInTheDocument();
+      expect(segmentButton.length).toEqual(1);
+      expect(segmentButton[0]).toBeInTheDocument();
+      expect(segmentButton[0].disabled).toEqual(false);
+    });
+
   });
 
   it('should render permissionDenied if incorrect permissions', async () => {
@@ -108,6 +145,25 @@ describe('<GradingSettings />', () => {
       expect(saveBtn).toBeInTheDocument();
       fireEvent.click(saveBtn);
       expect(getByText(messages.buttonSavingText.defaultMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('should show disabled button to update segments', async () => {
+    const { getAllByTestId } = render(<RootWrapper />);
+    axiosMock
+      .onGet(getUserPermissionsEnabledFlagUrl)
+      .reply(200, { enabled: true });
+    const permissionsData = { permissions: ['view_course_settings'] }
+    axiosMock
+      .onGet(getUserPermissionsUrl(courseId, userId))
+      .reply(200, permissionsData);
+    await executeThunk(fetchUserPermissionsQuery(courseId), store.dispatch);
+    await executeThunk(fetchUserPermissionsEnabledFlag(), store.dispatch);
+    await waitFor(() => {
+      const segmentButton = getAllByTestId('grading-scale-btn-add-segment');
+      expect(segmentButton.length).toEqual(1);
+      expect(segmentButton[0]).toBeInTheDocument();
+      expect(segmentButton[0].disabled).toEqual(true);
     });
   });
 });

--- a/src/grading-settings/GradingSettings.test.jsx
+++ b/src/grading-settings/GradingSettings.test.jsx
@@ -84,7 +84,7 @@ describe('<GradingSettings />', () => {
     axiosMock
       .onGet(getUserPermissionsEnabledFlagUrl)
       .reply(200, { enabled: true });
-    const permissionsData = { permissions: ['manage_course_settings'] }
+    const permissionsData = { permissions: ['manage_course_settings'] };
     axiosMock
       .onGet(getUserPermissionsUrl(courseId, userId))
       .reply(200, permissionsData);
@@ -102,7 +102,6 @@ describe('<GradingSettings />', () => {
       expect(segmentButton[0]).toBeInTheDocument();
       expect(segmentButton[0].disabled).toEqual(false);
     });
-
   });
 
   it('should render permissionDenied if incorrect permissions', async () => {
@@ -153,7 +152,7 @@ describe('<GradingSettings />', () => {
     axiosMock
       .onGet(getUserPermissionsEnabledFlagUrl)
       .reply(200, { enabled: true });
-    const permissionsData = { permissions: ['view_course_settings'] }
+    const permissionsData = { permissions: ['view_course_settings'] };
     axiosMock
       .onGet(getUserPermissionsUrl(courseId, userId))
       .reply(200, permissionsData);

--- a/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
@@ -20,7 +20,7 @@ const AssignmentItem = ({
   secondErrorMsg,
   gradeField,
   trailingElement,
-  viewOnly
+  viewOnly,
 }) => (
   <li className={className}>
     <Form.Group className={classNames('form-group-custom', {

--- a/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentItem.jsx
@@ -20,6 +20,7 @@ const AssignmentItem = ({
   secondErrorMsg,
   gradeField,
   trailingElement,
+  viewOnly
 }) => (
   <li className={className}>
     <Form.Group className={classNames('form-group-custom', {
@@ -37,6 +38,7 @@ const AssignmentItem = ({
         value={value}
         isInvalid={errorEffort}
         trailingElement={trailingElement}
+        disabled={viewOnly}
       />
       <Form.Control.Feedback className="grading-description">
         {descriptions}
@@ -81,6 +83,7 @@ AssignmentItem.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   gradeField: PropTypes.shape(defaultAssignmentsPropTypes),
   trailingElement: PropTypes.string,
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default AssignmentItem;

--- a/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
@@ -8,7 +8,7 @@ import { ASSIGNMENT_TYPES, DUPLICATE_ASSIGNMENT_NAME } from '../utils/enum';
 import messages from '../messages';
 
 const AssignmentTypeName = ({
-  intl, value, errorEffort, onChange, viewOnly
+  intl, value, errorEffort, onChange, viewOnly,
 }) => {
   const initialAssignmentName = useRef(value);
 

--- a/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
+++ b/src/grading-settings/assignment-section/assignments/AssignmentTypeName.jsx
@@ -8,7 +8,7 @@ import { ASSIGNMENT_TYPES, DUPLICATE_ASSIGNMENT_NAME } from '../utils/enum';
 import messages from '../messages';
 
 const AssignmentTypeName = ({
-  intl, value, errorEffort, onChange,
+  intl, value, errorEffort, onChange, viewOnly
 }) => {
   const initialAssignmentName = useRef(value);
 
@@ -28,6 +28,7 @@ const AssignmentTypeName = ({
           onChange={onChange}
           value={value}
           isInvalid={Boolean(errorEffort)}
+          disabled={viewOnly}
         />
         <Form.Control.Feedback className="grading-description">
           {intl.formatMessage(messages.assignmentTypeNameDescription)}
@@ -64,6 +65,7 @@ AssignmentTypeName.propTypes = {
   onChange: PropTypes.func.isRequired,
   errorEffort: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default injectIntl(AssignmentTypeName);

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -22,6 +22,7 @@ const AssignmentSection = ({
   setGradingData,
   courseAssignmentLists,
   setShowSuccessAlert,
+  viewOnly
 }) => {
   const [errorList, setErrorList] = useState({});
   const {
@@ -83,6 +84,7 @@ const AssignmentSection = ({
                 value={gradeField.type}
                 errorEffort={errorList[`${type}-${gradeField.id}`]}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
+                viewOnly={viewOnly}
               />
               <AssignmentItem
                 className="course-grading-assignment-abbreviation"
@@ -92,6 +94,7 @@ const AssignmentSection = ({
                 name="shortLabel"
                 value={gradeField.shortLabel}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
+                viewOnly={viewOnly}
               />
               <AssignmentItem
                 className="course-grading-assignment-total-grade"
@@ -106,6 +109,7 @@ const AssignmentSection = ({
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
                 errorEffort={errorList[`${weight}-${gradeField.id}`]}
                 trailingElement="%"
+                viewOnly={viewOnly}
               />
               <AssignmentItem
                 className="course-grading-assignment-total-number"
@@ -118,6 +122,7 @@ const AssignmentSection = ({
                 value={gradeField.minCount}
                 onChange={(e) => handleAssignmentChange(e, gradeField.id)}
                 errorEffort={errorList[`${minCount}-${gradeField.id}`]}
+                viewOnly={viewOnly}
               />
               <AssignmentItem
                 className="course-grading-assignment-number-droppable"
@@ -134,6 +139,7 @@ const AssignmentSection = ({
                   type: gradeField.type,
                 })}
                 errorEffort={errorList[`${dropCount}-${gradeField.id}`]}
+                viewOnly={viewOnly}
               />
             </ol>
             {showDefinedCaseAlert && (
@@ -185,6 +191,7 @@ const AssignmentSection = ({
               variant="outline-primary"
               size="sm"
               onClick={() => handleRemoveAssignment(gradeField.id)}
+              disabled={viewOnly}
             >
               {intl.formatMessage(messages.assignmentDeleteButton)}
             </Button>
@@ -210,6 +217,7 @@ AssignmentSection.propTypes = {
   graders: PropTypes.arrayOf(
     PropTypes.shape(defaultAssignmentsPropTypes),
   ),
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default injectIntl(AssignmentSection);

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -22,7 +22,7 @@ const AssignmentSection = ({
   setGradingData,
   courseAssignmentLists,
   setShowSuccessAlert,
-  viewOnly
+  viewOnly,
 }) => {
   const [errorList, setErrorList] = useState({});
   const {

--- a/src/grading-settings/credit-section/CreditSection.test.jsx
+++ b/src/grading-settings/credit-section/CreditSection.test.jsx
@@ -18,6 +18,7 @@ const RootWrapper = (props = {}) => (
       minimumGradeCredit={0.1}
       setGradingData={jest.fn()}
       setShowSuccessAlert={jest.fn()}
+      viewOnly={false}
       {...props}
     />
   </IntlProvider>
@@ -38,6 +39,14 @@ describe('<CreditSection />', () => {
       expect(inputElement.value).toBe('10');
       fireEvent.change(inputElement, { target: { value: '2' } });
       expect(testObj.minimumGradeCredit).toBe(0.02);
+      expect(inputElement.disabled).toBe(false);
     });
   });
+  it('should disable the fields if viewOnly', async () => {
+    const { getByTestId } = render(<RootWrapper viewOnly={true} />);
+    await waitFor(() => {
+      const inputElement = getByTestId('minimum-grade-credit-input');
+      expect(inputElement.disabled).toBe(true);
+    });
+  })
 });

--- a/src/grading-settings/credit-section/CreditSection.test.jsx
+++ b/src/grading-settings/credit-section/CreditSection.test.jsx
@@ -43,10 +43,10 @@ describe('<CreditSection />', () => {
     });
   });
   it('should disable the fields if viewOnly', async () => {
-    const { getByTestId } = render(<RootWrapper viewOnly={true} />);
+    const { getByTestId } = render(<RootWrapper viewOnly />);
     await waitFor(() => {
       const inputElement = getByTestId('minimum-grade-credit-input');
       expect(inputElement.disabled).toBe(true);
     });
-  })
+  });
 });

--- a/src/grading-settings/credit-section/index.jsx
+++ b/src/grading-settings/credit-section/index.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
 const CreditSection = ({
-  intl, eligibleGrade, setShowSavePrompt, minimumGradeCredit, setGradingData, setShowSuccessAlert, viewOnly
+  intl, eligibleGrade, setShowSavePrompt, minimumGradeCredit, setGradingData, setShowSuccessAlert, viewOnly,
 }) => {
   const [errorEffort, setErrorEffort] = useState(false);
 

--- a/src/grading-settings/credit-section/index.jsx
+++ b/src/grading-settings/credit-section/index.jsx
@@ -7,7 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
 const CreditSection = ({
-  intl, eligibleGrade, setShowSavePrompt, minimumGradeCredit, setGradingData, setShowSuccessAlert,
+  intl, eligibleGrade, setShowSavePrompt, minimumGradeCredit, setGradingData, setShowSuccessAlert, viewOnly
 }) => {
   const [errorEffort, setErrorEffort] = useState(false);
 
@@ -46,6 +46,7 @@ const CreditSection = ({
         value={Math.round(parseFloat(minimumGradeCredit) * 100) || ''}
         name="minimum_grade_credit"
         onChange={handleCreditChange}
+        disabled={viewOnly}
       />
       <Form.Control.Feedback className="grading-description">
         {intl.formatMessage(messages.creditEligibilityDescription)}
@@ -66,6 +67,7 @@ CreditSection.propTypes = {
   setGradingData: PropTypes.func.isRequired,
   setShowSuccessAlert: PropTypes.func.isRequired,
   minimumGradeCredit: PropTypes.number.isRequired,
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default injectIntl(CreditSection);

--- a/src/grading-settings/deadline-section/DeadlineSection.test.jsx
+++ b/src/grading-settings/deadline-section/DeadlineSection.test.jsx
@@ -22,6 +22,7 @@ const RootWrapper = (props = {}) => (
       setShowSavePrompt={jest.fn()}
       setGradingData={jest.fn()}
       setShowSuccessAlert={jest.fn()}
+      viewOnly={false}
       {...props}
     />
   </IntlProvider>
@@ -46,6 +47,7 @@ describe('<DeadlineSection />', () => {
       fireEvent.change(inputElement, { target: { value: '13:13' } });
       expect(testObj.gracePeriod.hours).toBe(13);
       expect(testObj.gracePeriod.minutes).toBe(13);
+      expect(inputElement.disabled).toEqual(false);
     });
   });
   it('checking deadline input value if grace Period equal null', async () => {
@@ -76,6 +78,13 @@ describe('<DeadlineSection />', () => {
       const inputElement = getByPlaceholderText(TIME_FORMAT.toUpperCase());
       fireEvent.change(inputElement, { target: { value: '32:70' } });
       expect(getByText(`Grace period must be specified in ${TIME_FORMAT.toUpperCase()} format.`)).toBeInTheDocument();
+    });
+  });
+  it('checking deadline input is disabled if viewOnly', async () => {
+    const { getByTestId } = render(<RootWrapper viewOnly={true} />);
+    await waitFor(() => {
+      const inputElement = getByTestId('deadline-period-input');
+      expect(inputElement.disabled).toEqual(true);
     });
   });
 });

--- a/src/grading-settings/deadline-section/DeadlineSection.test.jsx
+++ b/src/grading-settings/deadline-section/DeadlineSection.test.jsx
@@ -81,7 +81,7 @@ describe('<DeadlineSection />', () => {
     });
   });
   it('checking deadline input is disabled if viewOnly', async () => {
-    const { getByTestId } = render(<RootWrapper viewOnly={true} />);
+    const { getByTestId } = render(<RootWrapper viewOnly />);
     await waitFor(() => {
       const inputElement = getByTestId('deadline-period-input');
       expect(inputElement.disabled).toEqual(true);

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -9,7 +9,7 @@ import { formatTime, timerValidation } from './utils';
 import messages from './messages';
 
 const DeadlineSection = ({
-  intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert, viewOnly
+  intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert, viewOnly,
 }) => {
   const timeStampValue = gracePeriod
     ? gracePeriod.hours && `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -9,7 +9,7 @@ import { formatTime, timerValidation } from './utils';
 import messages from './messages';
 
 const DeadlineSection = ({
-  intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert,
+  intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert, viewOnly
 }) => {
   const timeStampValue = gracePeriod
     ? gracePeriod.hours && `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`
@@ -52,6 +52,7 @@ const DeadlineSection = ({
         value={newDeadlineValue}
         onChange={handleDeadlineChange}
         placeholder={TIME_FORMAT.toUpperCase()}
+        disabled={viewOnly}
       />
       <Form.Control.Feedback className="grading-description">
         {intl.formatMessage(messages.gracePeriodOnDeadlineDescription)}
@@ -78,6 +79,7 @@ DeadlineSection.propTypes = {
     hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     minutes: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }),
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default injectIntl(DeadlineSection);

--- a/src/grading-settings/grading-scale/GradingScale.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.jsx
@@ -23,7 +23,7 @@ const GradingScale = ({
   sortedGrades,
   setOverrideInternetConnectionAlert,
   setEligibleGrade,
-  viewOnly
+  viewOnly,
 }) => {
   const [gradingSegments, setGradingSegments] = useState(sortedGrades);
   const [letters, setLetters] = useState(gradeLetters);

--- a/src/grading-settings/grading-scale/GradingScale.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.jsx
@@ -23,6 +23,7 @@ const GradingScale = ({
   sortedGrades,
   setOverrideInternetConnectionAlert,
   setEligibleGrade,
+  viewOnly
 }) => {
   const [gradingSegments, setGradingSegments] = useState(sortedGrades);
   const [letters, setLetters] = useState(gradeLetters);
@@ -191,7 +192,7 @@ const GradingScale = ({
       <IconButtonWithTooltip
         tooltipPlacement="top"
         tooltipContent={intl.formatMessage(messages.addNewSegmentButtonAltText)}
-        disabled={gradingSegments.length >= 5}
+        disabled={gradingSegments.length >= 5 || viewOnly}
         data-testid="grading-scale-btn-add-segment"
         className="mr-3"
         src={IconAdd}
@@ -245,6 +246,7 @@ GradingScale.propTypes = {
     }),
   ).isRequired,
   setEligibleGrade: PropTypes.func.isRequired,
+  viewOnly: PropTypes.bool.isRequired,
 };
 
 export default injectIntl(GradingScale);

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -76,7 +76,7 @@ describe('<GradingScale />', () => {
   });
 
   it('should not disable new grading segment button when viewOnly=false', async () => {
-    const { getAllByTestId } = render(<RootWrapper viewOnly={ false } />);
+    const { getAllByTestId } = render(<RootWrapper viewOnly={false} />);
     await waitFor(() => {
       const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
       expect(addNewSegmentBtn).toHaveLength(1);
@@ -86,7 +86,7 @@ describe('<GradingScale />', () => {
   });
 
   it('should disable new grading segment button when viewOnly', async () => {
-    const { getAllByTestId } = render(<RootWrapper viewOnly={ true } />);
+    const { getAllByTestId } = render(<RootWrapper viewOnly />);
     await waitFor(() => {
       const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
       expect(addNewSegmentBtn).toHaveLength(1);

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -16,7 +16,7 @@ const sortedGrades = [
   { current: 20, previous: 0 },
 ];
 
-const RootWrapper = () => (
+const RootWrapper = (props = {}) => (
   <IntlProvider locale="en" messages={{}}>
     <GradingScale
       intl={injectIntl}
@@ -29,6 +29,8 @@ const RootWrapper = () => (
       setGradingData={jest.fn()}
       setOverrideInternetConnectionAlert={jest.fn()}
       setEligibleGrade={jest.fn()}
+      viewOnly={false}
+      {...props}
     />
   </IntlProvider>
 );
@@ -70,6 +72,26 @@ describe('<GradingScale />', () => {
       const segments = getAllByTestId('grading-scale-segment');
       expect(segments).toHaveLength(6);
       debug(addNewSegmentBtn);
+    });
+  });
+
+  it('should not disable new grading segment button when viewOnly=false', async () => {
+    const { getAllByTestId } = render(<RootWrapper viewOnly={ false } />);
+    await waitFor(() => {
+      const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
+      expect(addNewSegmentBtn).toHaveLength(1);
+      expect(addNewSegmentBtn[0]).toBeInTheDocument();
+      expect(addNewSegmentBtn[0].disabled).toBe(false);
+    });
+  });
+
+  it('should disable new grading segment button when viewOnly', async () => {
+    const { getAllByTestId } = render(<RootWrapper viewOnly={ true } />);
+    await waitFor(() => {
+      const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
+      expect(addNewSegmentBtn).toHaveLength(1);
+      expect(addNewSegmentBtn[0]).toBeInTheDocument();
+      expect(addNewSegmentBtn[0].disabled).toBe(true);
     });
   });
 

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -16,7 +16,7 @@ const sortedGrades = [
   { current: 20, previous: 0 },
 ];
 
-const RootWrapper = (viewOnly = { viewOnly: false}) => (
+const RootWrapper = (viewOnly = { viewOnly: false }) => (
   <IntlProvider locale="en" messages={{}}>
     <GradingScale
       intl={injectIntl}

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -16,7 +16,7 @@ const sortedGrades = [
   { current: 20, previous: 0 },
 ];
 
-const RootWrapper = (props = {}) => (
+const RootWrapper = (viewOnly = { viewOnly: false}) => (
   <IntlProvider locale="en" messages={{}}>
     <GradingScale
       intl={injectIntl}
@@ -29,8 +29,7 @@ const RootWrapper = (props = {}) => (
       setGradingData={jest.fn()}
       setOverrideInternetConnectionAlert={jest.fn()}
       setEligibleGrade={jest.fn()}
-      viewOnly={false}
-      {...props}
+      {...viewOnly}
     />
   </IntlProvider>
 );
@@ -76,7 +75,7 @@ describe('<GradingScale />', () => {
   });
 
   it('should not disable new grading segment button when viewOnly=false', async () => {
-    const { getAllByTestId } = render(<RootWrapper viewOnly={false} />);
+    const { getAllByTestId } = render(<RootWrapper />);
     await waitFor(() => {
       const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
       expect(addNewSegmentBtn).toHaveLength(1);

--- a/src/header/Header.jsx
+++ b/src/header/Header.jsx
@@ -29,8 +29,8 @@ const Header = ({
   const hasAdvancedSettingsAccess = !userPermissionsEnabled
     || (userPermissionsEnabled && (checkPermission('manage_advanced_settings') || checkPermission('view_course_settings')));
   const hasSettingsPermissions = !userPermissionsEnabled
-  || (userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings')));
-    const hasToolsPermissions = !userPermissionsEnabled
+    || (userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings')));
+  const hasToolsPermissions = !userPermissionsEnabled
     || (userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings')));
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const contentMenu = getContentMenuItems({

--- a/src/header/Header.jsx
+++ b/src/header/Header.jsx
@@ -25,9 +25,12 @@ const Header = ({
   const userPermissions = useSelector(getUserPermissions);
   const userPermissionsEnabled = useSelector(getUserPermissionsEnabled);
   const hasContentPermissions = !userPermissionsEnabled || (userPermissionsEnabled && checkPermission('manage_content'));
-  const hasSettingsPermissions = !userPermissionsEnabled
+  const hasOutlinePermissions = !userPermissionsEnabled || (userPermissionsEnabled && (checkPermission('manage_content') || checkPermission('manage_libraries')));
+  const hasAdvancedSettingsAccess = !userPermissionsEnabled
     || (userPermissionsEnabled && (checkPermission('manage_advanced_settings') || checkPermission('view_course_settings')));
-  const hasToolsPermissions = !userPermissionsEnabled
+  const hasSettingsPermissions = !userPermissionsEnabled
+  || (userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings')));
+    const hasToolsPermissions = !userPermissionsEnabled
     || (userPermissionsEnabled && (checkPermission('manage_course_settings') || checkPermission('view_course_settings')));
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const contentMenu = getContentMenuItems({
@@ -35,6 +38,7 @@ const Header = ({
     courseId,
     intl,
     hasContentPermissions,
+    hasOutlinePermissions,
   });
   const mainMenuDropdowns = [];
   const toolsMenu = getToolsMenuItems({
@@ -69,6 +73,7 @@ const Header = ({
         courseId,
         intl,
         hasSettingsPermissions,
+        hasAdvancedSettingsAccess,
       }),
     },
   );

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -63,10 +63,10 @@ export const getSettingMenuItems = ({
   );
   if (hasSettingsPermissions) {
     items.push(
-    {
-      href: `${studioBaseUrl}/settings/grading/${courseId}`,
-      title: intl.formatMessage(messages['header.links.grading']),
-    },
+      {
+        href: `${studioBaseUrl}/settings/grading/${courseId}`,
+        title: intl.formatMessage(messages['header.links.grading']),
+      },
     );
   }
   items.push(

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -7,15 +7,20 @@ export const getContentMenuItems = ({
   courseId,
   intl,
   hasContentPermissions,
+  hasOutlinePermissions,
 }) => {
   const items = [];
 
-  if (hasContentPermissions) {
+  if (hasOutlinePermissions) {
     items.push(
       {
         href: `${studioBaseUrl}/course/${courseId}`,
         title: intl.formatMessage(messages['header.links.outline']),
       },
+    );
+  }
+  if (hasContentPermissions) {
+    items.push(
       {
         href: `${studioBaseUrl}/course_info/${courseId}`,
         title: intl.formatMessage(messages['header.links.updates']),
@@ -45,6 +50,7 @@ export const getSettingMenuItems = ({
   studioBaseUrl,
   courseId,
   intl,
+  hasAdvancedSettingsAccess,
   hasSettingsPermissions,
 }) => {
   const items = [];
@@ -54,20 +60,30 @@ export const getSettingMenuItems = ({
       href: `${studioBaseUrl}/settings/details/${courseId}`,
       title: intl.formatMessage(messages['header.links.scheduleAndDetails']),
     },
+  );
+  if (hasSettingsPermissions) {
+    items.push(
     {
       href: `${studioBaseUrl}/settings/grading/${courseId}`,
       title: intl.formatMessage(messages['header.links.grading']),
     },
+    );
+  }
+  items.push(
     {
       href: `${studioBaseUrl}/course_team/${courseId}`,
       title: intl.formatMessage(messages['header.links.courseTeam']),
     },
-    {
-      href: `${studioBaseUrl}/group_configurations/course-v1:${courseId}`,
-      title: intl.formatMessage(messages['header.links.groupConfigurations']),
-    },
   );
   if (hasSettingsPermissions) {
+    items.push(
+      {
+        href: `${studioBaseUrl}/group_configurations/course-v1:${courseId}`,
+        title: intl.formatMessage(messages['header.links.groupConfigurations']),
+      },
+    );
+  }
+  if (hasAdvancedSettingsAccess) {
     items.push(
       {
         href: `${studioBaseUrl}/settings/advanced/${courseId}`,

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -36,11 +36,12 @@ export const getContentMenuItems = ({
     );
   }
   if (getConfig().ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN === 'true') {
-    items.push({
-      href: `${studioBaseUrl}/videos/${courseId}`,
-      title: intl.formatMessage(messages['header.links.videoUploads']),
-    }
-  );
+    items.push(
+      {
+        href: `${studioBaseUrl}/videos/${courseId}`,
+        title: intl.formatMessage(messages['header.links.videoUploads']),
+      },
+    );
   }
 
   return items;

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -43,7 +43,10 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(1);
     });
     it('should include Outline if outline permissions', () => {
-      process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
+      setConfig({
+        ...getConfig(),
+        ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'false',
+      });
       const actualItems = getContentMenuItems({
         ...baseProps,
         hasContentPermissions: false,
@@ -52,7 +55,10 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(1);
     });
     it('should include content sections if content permissions', () => {
-      process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
+      setConfig({
+        ...getConfig(),
+        ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'false',
+      });
       const actualItems = getContentMenuItems({
         ...baseProps,
         hasContentPermissions: true,

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -35,17 +35,29 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'true',
       });
-      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: false, hasOutlinePermissions: false });
+      const actualItems = getContentMenuItems({
+        ...baseProps,
+        hasContentPermissions: false,
+        hasOutlinePermissions: false,
+      });
       expect(actualItems).toHaveLength(1);
     });
     it('should include Outline if outline permissions', () => {
       process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
-      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: false, hasOutlinePermissions: true });
+      const actualItems = getContentMenuItems({
+        ...baseProps,
+        hasContentPermissions: false,
+        hasOutlinePermissions: true,
+      });
       expect(actualItems).toHaveLength(1);
     });
     it('should include content sections if content permissions', () => {
       process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
-      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: true, hasOutlinePermissions: false });
+      const actualItems = getContentMenuItems({
+        ...baseProps,
+        hasContentPermissions: true,
+        hasOutlinePermissions: false,
+      });
       expect(actualItems).toHaveLength(3);
     });
   });
@@ -55,15 +67,27 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(6);
     });
     it('should include Advanced Settings option, but not settings options', () => {
-      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: false, hasAdvancedSettingsAccess: true });
+      const actualItems = getSettingMenuItems({
+        ...baseProps,
+        hasSettingsPermissions: false,
+        hasAdvancedSettingsAccess: true,
+      });
       expect(actualItems).toHaveLength(4);
     });
     it('should include settings, but not advanced settings', () => {
-      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: true, hasAdvancedSettingsAccess: false });
+      const actualItems = getSettingMenuItems({
+        ...baseProps,
+        hasSettingsPermissions: true,
+        hasAdvancedSettingsAccess: false,
+      });
       expect(actualItems).toHaveLength(5);
     });
     it('should only include default options', () => {
-      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: false, hasAdvancedSettingsAccess: false });
+      const actualItems = getSettingMenuItems({
+        ...baseProps,
+        hasSettingsPermissions: false,
+        hasAdvancedSettingsAccess: false,
+      });
       expect(actualItems).toHaveLength(3);
     });
   });

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -8,8 +8,8 @@ const baseProps = {
     formatMessage: jest.fn(),
   },
 };
-const contentProps = { ...baseProps, hasContentPermissions: true };
-const settingProps = { ...baseProps, hasSettingsPermissions: true };
+const contentProps = { ...baseProps, hasContentPermissions: true, hasOutlinePermissions: true };
+const settingProps = { ...baseProps, hasAdvancedSettingsAccess: true, hasSettingsPermissions: true };
 const toolsProps = { ...baseProps, hasToolsPermissions: true };
 
 describe('header utils', () => {
@@ -35,8 +35,18 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'true',
       });
-      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: false });
+      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: false, hasOutlinePermissions: false });
       expect(actualItems).toHaveLength(1);
+    });
+    it('should include Outline if outline permissions', () => {
+      process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
+      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: false, hasOutlinePermissions: true });
+      expect(actualItems).toHaveLength(1);
+    });
+    it('should include content sections if content permissions', () => {
+      process.env.ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN = 'false';
+      const actualItems = getContentMenuItems({ ...baseProps, hasContentPermissions: true, hasOutlinePermissions: false });
+      expect(actualItems).toHaveLength(3);
     });
   });
   describe('getSettingMenuItems', async () => {
@@ -44,9 +54,17 @@ describe('header utils', () => {
       const actualItems = getSettingMenuItems(settingProps);
       expect(actualItems).toHaveLength(6);
     });
-    it('should not include Advanced Settings option', () => {
-      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: false });
+    it('should include Advanced Settings option, but not settings options', () => {
+      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: false, hasAdvancedSettingsAccess: true });
+      expect(actualItems).toHaveLength(4);
+    });
+    it('should include settings, but not advanced settings', () => {
+      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: true, hasAdvancedSettingsAccess: false });
       expect(actualItems).toHaveLength(5);
+    });
+    it('should only include default options', () => {
+      const actualItems = getSettingMenuItems({ ...baseProps, hasSettingsPermissions: false, hasAdvancedSettingsAccess: false });
+      expect(actualItems).toHaveLength(3);
     });
   });
   describe('getToolsMenuItems', async () => {


### PR DESCRIPTION
### Description

This PR adds updates the header to check access for the group_configuration and grading sections. It also adds permissions checks for the outline and grading components and creates a view only option for grading.

This is a PR to a [feature branch](https://github.com/openedx/frontend-app-course-authoring/tree/CourseRoles).