### PR TITLE
feat: add export course tags menu

### DIFF
--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -93,6 +93,11 @@ const messages = defineMessages({
   },
   'header.links.export': {
     id: 'header.links.export',
+    defaultMessage: 'Export',
+    description: 'Link to Studio Export page',
+  },
+  'header.links.exportCourse': {
+    id: 'header.links.exportCourse',
     defaultMessage: 'Export Course',
     description: 'Link to Studio Export page',
   },

--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -93,8 +93,13 @@ const messages = defineMessages({
   },
   'header.links.export': {
     id: 'header.links.export',
-    defaultMessage: 'Export',
+    defaultMessage: 'Export Course',
     description: 'Link to Studio Export page',
+  },
+  'header.links.exportTags': {
+    id: 'header.links.exportTags',
+    defaultMessage: 'Export Tags',
+    description: 'Download course content tags as CSV',
   },
   'header.links.checklists': {
     id: 'header.links.checklists',

--- a/src/header/messages.js
+++ b/src/header/messages.js
@@ -91,11 +91,6 @@ const messages = defineMessages({
     defaultMessage: 'Import',
     description: 'Link to Studio Import page',
   },
-  'header.links.export': {
-    id: 'header.links.export',
-    defaultMessage: 'Export',
-    description: 'Link to Studio Export page',
-  },
   'header.links.exportCourse': {
     id: 'header.links.exportCourse',
     defaultMessage: 'Export Course',

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -68,7 +68,7 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
     title: intl.formatMessage(
       getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
         ? messages['header.links.exportCourse']
-        : messages['header.links.export']
+        : messages['header.links.export'],
     ),
   },
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -64,7 +64,7 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
     title: intl.formatMessage(messages['header.links.import']),
   },
   {
-    href: `${studioBaseUrl}/import/${courseId}`,
+    href: `${studioBaseUrl}/export/${courseId}`,
     title: intl.formatMessage(messages['header.links.exportCourse']),
   },
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -65,11 +65,7 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
   },
   {
     href: `${studioBaseUrl}/import/${courseId}`,
-    title: intl.formatMessage(
-      getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
-        ? messages['header.links.exportCourse']
-        : messages['header.links.export'],
-    ),
+    title: intl.formatMessage(messages['header.links.exportCourse']),
   },
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
     ? [{

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -64,13 +64,19 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
     title: intl.formatMessage(messages['header.links.import']),
   },
   {
-    href: `${studioBaseUrl}/export/${courseId}`,
-    title: intl.formatMessage(messages['header.links.export']),
+    href: `${studioBaseUrl}/import/${courseId}`,
+    title: intl.formatMessage(
+      getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
+        ? messages['header.links.exportCourse']
+        : messages['header.links.export']
+    ),
   },
-  {
-    href: `${studioBaseUrl}/api/content_tagging/v1/object_tags/${courseId}/export/`,
-    title: intl.formatMessage(messages['header.links.exportTags']),
-  },
+  ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
+    ? [{
+      href: `${studioBaseUrl}/api/content_tagging/v1/object_tags/${courseId}/export/`,
+      title: intl.formatMessage(messages['header.links.exportTags']),
+    }] : []
+  ),
   {
     href: `${studioBaseUrl}/checklists/${courseId}`,
     title: intl.formatMessage(messages['header.links.checklists']),

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -66,7 +66,12 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
   {
     href: `${studioBaseUrl}/export/${courseId}`,
     title: intl.formatMessage(messages['header.links.export']),
-  }, {
+  },
+  {
+    href: `${studioBaseUrl}/api/content_tagging/v1/object_tags/${courseId}/export/`,
+    title: intl.formatMessage(messages['header.links.exportTags']),
+  },
+  {
     href: `${studioBaseUrl}/checklists/${courseId}`,
     title: intl.formatMessage(messages['header.links.checklists']),
   },

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -5,7 +5,7 @@ const props = {
   studioBaseUrl: 'UrLSTuiO',
   courseId: '123',
   intl: {
-    formatMessage: jest.fn(),
+    formatMessage: jest.fn(message => message.defaultMessage),
   },
 };
 
@@ -28,22 +28,32 @@ describe('header utils', () => {
       expect(actualItems).toHaveLength(4);
     });
   });
+
   describe('getToolsMenuItems', () => {
     it('should include export tags option', () => {
       setConfig({
         ...getConfig(),
         ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
       });
-      const actualItems = getToolsMenuItems(props);
-      expect(actualItems).toHaveLength(4);
+      const actualItemsTitle = getToolsMenuItems(props).map((item) => item.title);
+      expect(actualItemsTitle).toEqual([
+        'Import',
+        'Export Course',
+        'Export Tags',
+        'Checklists',
+      ]);
     });
     it('should not include export tags option', () => {
       setConfig({
         ...getConfig(),
         ENABLE_TAGGING_TAXONOMY_PAGES: 'false',
       });
-      const actualItems = getToolsMenuItems(props);
-      expect(actualItems).toHaveLength(3);
+      const actualItemsTitle = getToolsMenuItems(props).map((item) => item.title);
+      expect(actualItemsTitle).toEqual([
+        'Import',
+        'Export',
+        'Checklists',
+      ]);
     });
   });
 });

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -1,5 +1,5 @@
 import { getConfig, setConfig } from '@edx/frontend-platform';
-import { getContentMenuItems } from './utils';
+import { getContentMenuItems, getToolsMenuItems } from './utils';
 
 const props = {
   studioBaseUrl: 'UrLSTuiO',
@@ -26,6 +26,24 @@ describe('header utils', () => {
       });
       const actualItems = getContentMenuItems(props);
       expect(actualItems).toHaveLength(4);
+    });
+  });
+  describe('getToolsMenuItems', () => {
+    it('should include export tags option', () => {
+      setConfig({
+        ...getConfig(),
+        ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
+      });
+      const actualItems = getToolsMenuItems(props);
+      expect(actualItems).toHaveLength(4);
+    });
+    it('should not include export tags option', () => {
+      setConfig({
+        ...getConfig(),
+        ENABLE_TAGGING_TAXONOMY_PAGES: 'false',
+      });
+      const actualItems = getToolsMenuItems(props);
+      expect(actualItems).toHaveLength(3);
     });
   });
 });

--- a/src/header/utils.test.js
+++ b/src/header/utils.test.js
@@ -51,7 +51,7 @@ describe('header utils', () => {
       const actualItemsTitle = getToolsMenuItems(props).map((item) => item.title);
       expect(actualItemsTitle).toEqual([
         'Import',
-        'Export',
+        'Export Course',
         'Checklists',
       ]);
     });


### PR DESCRIPTION
## Description
This PR adds an item in the `Tools` menu to allow a call of the function that exports the course tags to a CSV file.

![image](https://github.com/openedx/frontend-app-course-authoring/assets/849463/8ca60b88-5208-49e0-bc13-7097ad93e656)

## Supporting Information
* Closes:
  * https://github.com/openedx/modular-learning/issues/172
* Depends on:
  * https://github.com/openedx/edx-platform/pull/34091

## Testing instructions
1. Use https://github.com/open-craft/taxonomy-sample-data/ to create some taxonomies.
1. Go to the course page in Studio and add some tags to the units in the course using the `Manage Tags` option:
![image](https://github.com/openedx/frontend-app-course-authoring/assets/849463/f61e459c-5c72-45a9-b96f-9ec1c725742c)
1. Go to the course authoring MFE (i.e http://apps.local.edly.io:2001/course-authoring/course/course-v1:edX+DemoX+Demo_Course using tutor)
1. Click on the `Export Tags` menu from an existing taxonomy card
1. Check if a CSV file is downloaded with the Course structure and the tags applied to its blocks.

---
Private-ref:
 - [FAL-3610](https://tasks.opencraft.com/browse/FAL-3610)