### PR TITLE
[FC-0036] Refined taxonomy details page

### DIFF
--- a/src/taxonomy/index.scss
+++ b/src/taxonomy/index.scss
@@ -3,3 +3,4 @@
 @import "taxonomy/delete-dialog/DeleteDialog";
 @import "taxonomy/system-defined-badge/SystemDefinedBadge";
 @import "taxonomy/export-modal/ExportModal";
+@import "taxonomy/tag-list/TagListTable";

--- a/src/taxonomy/tag-list/TagListTable.jsx
+++ b/src/taxonomy/tag-list/TagListTable.jsx
@@ -93,23 +93,22 @@ const TagListTable = ({ taxonomyId }) => {
         renderRowSubComponent={({ row }) => (
           <SubTagsExpanded taxonomyId={taxonomyId} parentTagValue={row.original.value} />
         )}
-        additionalColumns={[
+        columns={[
+          {
+            Header: intl.formatMessage(messages.tagListColumnValueHeader),
+            Cell: TagValue,
+          },
           {
             id: 'expander',
             Header: DataTable.ExpandAll,
             Cell: OptionalExpandLink,
           },
         ]}
-        columns={[
-          {
-            Header: intl.formatMessage(messages.tagListColumnValueHeader),
-            Cell: TagValue,
-          },
-        ]}
       >
         <DataTable.Table />
         <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFoundMessage)} />
-        <DataTable.TableFooter />
+        {tagList?.numPages !== undefined && tagList?.numPages > 1
+          && <DataTable.TableFooter />}
       </DataTable>
     </div>
   );

--- a/src/taxonomy/tag-list/TagListTable.jsx
+++ b/src/taxonomy/tag-list/TagListTable.jsx
@@ -39,7 +39,9 @@ SubTagsExpanded.propTypes = {
 /**
  * An "Expand" toggle to show/hide subtags, but one which is hidden if the given tag row has no subtags.
  */
-const OptionalExpandLink = ({ row }) => (row.original.childCount > 0 ? <DataTable.ExpandRow row={row} /> : null);
+const OptionalExpandLink = ({ row }) => (
+  row.original.childCount > 0 ? <div className="tag-table-expand-row"><DataTable.ExpandRow row={row} /></div> : null
+);
 OptionalExpandLink.propTypes = DataTable.ExpandRow.propTypes;
 
 /**
@@ -75,38 +77,41 @@ const TagListTable = ({ taxonomyId }) => {
   };
 
   return (
-    <DataTable
-      isLoading={isLoading}
-      isPaginated
-      manualPagination
-      fetchData={fetchData}
-      data={tagList?.results || []}
-      itemCount={tagList?.count || 0}
-      pageCount={tagList?.numPages || 0}
-      initialState={options}
-      isExpandable
-      // This is a temporary "bare bones" solution for brute-force loading all the child tags. In future we'll match
-      // the Figma design and do something more sophisticated.
-      renderRowSubComponent={({ row }) => (
-        <SubTagsExpanded taxonomyId={taxonomyId} parentTagValue={row.original.value} />
-      )}
-      columns={[
-        {
-          Header: intl.formatMessage(messages.tagListColumnValueHeader),
-          Cell: TagValue,
-        },
-        {
-          id: 'expander',
-          Header: DataTable.ExpandAll,
-          Cell: OptionalExpandLink,
-        },
-      ]}
-    >
-      <DataTable.TableControlBar />
-      <DataTable.Table />
-      <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFoundMessage)} />
-      <DataTable.TableFooter />
-    </DataTable>
+    <div className="tag-list-table">
+      <DataTable
+        isLoading={isLoading}
+        isPaginated
+        manualPagination
+        fetchData={fetchData}
+        data={tagList?.results || []}
+        itemCount={tagList?.count || 0}
+        pageCount={tagList?.numPages || 0}
+        initialState={options}
+        isExpandable
+        // This is a temporary "bare bones" solution for brute-force loading all the child tags. In future we'll match
+        // the Figma design and do something more sophisticated.
+        renderRowSubComponent={({ row }) => (
+          <SubTagsExpanded taxonomyId={taxonomyId} parentTagValue={row.original.value} />
+        )}
+        additionalColumns={[
+          {
+            id: 'expander',
+            Header: DataTable.ExpandAll,
+            Cell: OptionalExpandLink,
+          },
+        ]}
+        columns={[
+          {
+            Header: intl.formatMessage(messages.tagListColumnValueHeader),
+            Cell: TagValue,
+          },
+        ]}
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFoundMessage)} />
+        <DataTable.TableFooter />
+      </DataTable>
+    </div>
   );
 };
 

--- a/src/taxonomy/tag-list/TagListTable.jsx
+++ b/src/taxonomy/tag-list/TagListTable.jsx
@@ -40,7 +40,7 @@ SubTagsExpanded.propTypes = {
  * An "Expand" toggle to show/hide subtags, but one which is hidden if the given tag row has no subtags.
  */
 const OptionalExpandLink = ({ row }) => (
-  row.original.childCount > 0 ? <div className="tag-table-expand-row"><DataTable.ExpandRow row={row} /></div> : null
+  row.original.childCount > 0 ? <div className="d-flex justify-content-end"><DataTable.ExpandRow row={row} /></div> : null
 );
 OptionalExpandLink.propTypes = DataTable.ExpandRow.propTypes;
 

--- a/src/taxonomy/tag-list/TagListTable.jsx
+++ b/src/taxonomy/tag-list/TagListTable.jsx
@@ -66,6 +66,7 @@ const TagListTable = ({ taxonomyId }) => {
   const intl = useIntl();
   const [options, setOptions] = useState({
     pageIndex: 0,
+    pageSize: 100,
   });
   const { isLoading } = useTagListDataStatus(taxonomyId, options);
   const tagList = useTagListDataResponse(taxonomyId, options);

--- a/src/taxonomy/tag-list/TagListTable.scss
+++ b/src/taxonomy/tag-list/TagListTable.scss
@@ -1,8 +1,4 @@
 .tag-list-table {
-  .tag-table-expand-row {
-    float: right;
-  }
-
   table tr:first-child > th:nth-child(2) > span {
     // Used to move "Expand all" button to the right.
     // Find the first <span> of the second <th> of the first <tr> of the <table>.
@@ -10,6 +6,7 @@
     // The approach of the expand buttons cannot be applied here since the
     // table headers are rendered differently and at the component level
     // there is no control of this style.
-    float: right;
+    display: flex;
+    justify-content: flex-end;
   }
 }

--- a/src/taxonomy/tag-list/TagListTable.scss
+++ b/src/taxonomy/tag-list/TagListTable.scss
@@ -1,0 +1,15 @@
+.tag-list-table {
+  .tag-table-expand-row {
+    float: right;
+  }
+
+  table tr:first-child > th:nth-child(2) > span {
+    // Used to move "Expand all" button to the right.
+    // Find the first <span> of the second <th> of the first <tr> of the <table>.
+    //
+    // The approach of the expand buttons cannot be applied here since the
+    // table headers are rendered differently and at the component level
+    // there is no control of this style.
+    float: right;
+  }
+}

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -3,7 +3,9 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
-import { render, waitFor, screen, within } from '@testing-library/react';
+import {
+  render, waitFor, screen, within,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -124,7 +126,7 @@ describe('<TagListTable />', () => {
     render(<RootWrapper />);
     const tag = await screen.findByText('root tag 1');
     expect(tag).toBeInTheDocument();
-    
+
     const rows = screen.getAllByRole('row');
     expect(rows.length).toBe(3 + 1); // 3 items plus header
     expect(within(rows[0]).getAllByRole('columnheader')[0].textContent).toEqual('Tag name');

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -56,7 +56,16 @@ const mockTagsResponse = {
     },
   ],
 };
-const rootTagsListUrl = 'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/?page=1';
+const mockTagsPaginationResponse = {
+  next: null,
+  previous: null,
+  count: 103,
+  num_pages: 2,
+  current_page: 1,
+  start: 0,
+  results: [],
+};
+const rootTagsListUrl = 'http://localhost:18010/api/content_tagging/v1/taxonomies/1/tags/?page=1&page_size=100';
 const subTagsResponse = {
   next: null,
   previous: null,
@@ -126,6 +135,22 @@ describe('<TagListTable />', () => {
     expandButton.click();
     await waitFor(() => {
       expect(result.getByText('the child tag')).toBeInTheDocument();
+    });
+  });
+
+  it('should not render pagination footer', async () => {
+    axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsResponse);
+    const result = render(<RootWrapper />);
+    await waitFor(() => {
+      expect(result.queryByTestId('table-footer')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render pagination footer', async () => {
+    axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsPaginationResponse);
+    const result = render(<RootWrapper />);
+    await waitFor(() => {
+      expect(result.getByTestId('table-footer')).toBeInTheDocument();
     });
   });
 });

--- a/src/taxonomy/tag-list/TagListTable.test.jsx
+++ b/src/taxonomy/tag-list/TagListTable.test.jsx
@@ -3,7 +3,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -108,49 +108,50 @@ describe('<TagListTable />', () => {
     let resolveResponse;
     const promise = new Promise(resolve => { resolveResponse = resolve; });
     axiosMock.onGet(rootTagsListUrl).reply(() => promise);
-    const result = render(<RootWrapper />);
-    const spinner = result.getByRole('status');
+    render(<RootWrapper />);
+    const spinner = screen.getByRole('status');
     expect(spinner.textContent).toEqual('loading');
     resolveResponse([200, {}]);
-    await waitFor(() => {
-      expect(result.getByText('No results found')).toBeInTheDocument();
-    });
+    const noFoundComponent = await screen.findByText('No results found');
+    expect(noFoundComponent).toBeInTheDocument();
   });
 
   it('should render page correctly', async () => {
     axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsResponse);
-    const result = render(<RootWrapper />);
-    await waitFor(() => {
-      expect(result.getByText('two level tag 1')).toBeInTheDocument();
-    });
-    const rows = result.getAllByRole('row');
+    render(<RootWrapper />);
+    const tag = await screen.findByText('two level tag 1');
+    expect(tag).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('row');
     expect(rows.length).toBe(3 + 1); // 3 items plus header
   });
 
   it('should render page correctly with subtags', async () => {
     axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsResponse);
     axiosMock.onGet(subTagsUrl).reply(200, subTagsResponse);
-    const result = render(<RootWrapper />);
-    const expandButton = result.getAllByLabelText('Expand row')[0];
+    render(<RootWrapper />);
+    const expandButton = screen.getAllByLabelText('Expand row')[0];
     expandButton.click();
-    await waitFor(() => {
-      expect(result.getByText('the child tag')).toBeInTheDocument();
-    });
+    const childTag = await screen.findByText('the child tag');
+    expect(childTag).toBeInTheDocument();
   });
 
   it('should not render pagination footer', async () => {
     axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsResponse);
-    const result = render(<RootWrapper />);
+    render(<RootWrapper />);
     await waitFor(() => {
-      expect(result.queryByTestId('table-footer')).not.toBeInTheDocument();
+      expect(screen.queryByRole('navigation', {
+        name: /table pagination/i,
+      })).not.toBeInTheDocument();
     });
   });
 
   it('should render pagination footer', async () => {
     axiosMock.onGet(rootTagsListUrl).reply(200, mockTagsPaginationResponse);
-    const result = render(<RootWrapper />);
-    await waitFor(() => {
-      expect(result.getByTestId('table-footer')).toBeInTheDocument();
+    render(<RootWrapper />);
+    const tableFooter = await screen.findByRole('navigation', {
+      name: /table pagination/i,
     });
+    expect(tableFooter).toBeInTheDocument();
   });
 });

--- a/src/taxonomy/tag-list/data/api.js
+++ b/src/taxonomy/tag-list/data/api.js
@@ -9,10 +9,12 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-const getTagListApiUrl = (taxonomyId, page, pageSize) => new URL(
-  `api/content_tagging/v1/taxonomies/${taxonomyId}/tags/?page=${page + 1}&page_size=${pageSize}`,
-  getApiBaseUrl(),
-).href;
+const getTagListApiUrl = (taxonomyId, page, pageSize) => {
+  const url = new URL(`api/content_tagging/v1/taxonomies/${taxonomyId}/tags/`, getApiBaseUrl());
+  url.searchParams.append('page', page + 1);
+  url.searchParams.append('page_size', pageSize);
+  return url.href;
+};
 
 /**
  * @param {number} taxonomyId

--- a/src/taxonomy/tag-list/data/api.js
+++ b/src/taxonomy/tag-list/data/api.js
@@ -20,8 +20,7 @@ const getTagListApiUrl = (taxonomyId, page, pageSize) => new URL(
  * @returns {import('@tanstack/react-query').UseQueryResult<import('./types.mjs').TagListData>}
  */
 export const useTagListData = (taxonomyId, options) => {
-  const { pageIndex } = options;
-  const pageSize = 100;
+  const { pageIndex, pageSize } = options;
   return useQuery({
     queryKey: ['tagList', taxonomyId, pageIndex],
     queryFn: async () => {

--- a/src/taxonomy/tag-list/data/api.js
+++ b/src/taxonomy/tag-list/data/api.js
@@ -9,8 +9,8 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const getApiBaseUrl = () => getConfig().STUDIO_BASE_URL;
-const getTagListApiUrl = (taxonomyId, page) => new URL(
-  `api/content_tagging/v1/taxonomies/${taxonomyId}/tags/?page=${page + 1}`,
+const getTagListApiUrl = (taxonomyId, page, pageSize) => new URL(
+  `api/content_tagging/v1/taxonomies/${taxonomyId}/tags/?page=${page + 1}&page_size=${pageSize}`,
   getApiBaseUrl(),
 ).href;
 
@@ -21,10 +21,11 @@ const getTagListApiUrl = (taxonomyId, page) => new URL(
  */
 export const useTagListData = (taxonomyId, options) => {
   const { pageIndex } = options;
+  const pageSize = 100;
   return useQuery({
     queryKey: ['tagList', taxonomyId, pageIndex],
     queryFn: async () => {
-      const { data } = await getAuthenticatedHttpClient().get(getTagListApiUrl(taxonomyId, pageIndex));
+      const { data } = await getAuthenticatedHttpClient().get(getTagListApiUrl(taxonomyId, pageIndex, pageSize));
       return camelCaseObject(data);
     },
   });

--- a/src/taxonomy/tag-list/data/types.mjs
+++ b/src/taxonomy/tag-list/data/types.mjs
@@ -7,6 +7,7 @@
 /**
  * @typedef {Object} QueryOptions
  * @property {number} pageIndex
+ * @property {number} pageSize
  */
 
 /**


### PR DESCRIPTION
## Description

This PR fixes the issues listed in https://github.com/openedx/modular-learning/issues/186

## Screenshots

![image](https://github.com/openedx/frontend-app-course-authoring/assets/11827305/e9883a9a-82c6-4ee1-8612-a314c9d64479)

## Testing instructions

- Run the [taxonomy-sample-data](https://github.com/open-craft/taxonomy-sample-data) script.
- Go to [taxonomy list](http://localhost:2001/taxonomies/) and click on a taxonomy to see the taxonomy details page.

**1. The table header has been removed (so "Showing 7 of 7" no longer appears).**
- Verify that the header has been removed

**2. The table displays up to 100 parent tags at a time. Pagination is only required if there are more than 100 parent tags.**
- Check `Flat Taxonomy` and verify that the table shows 100 parent tags and there is pagination footer.
- Check `TwoLevelTaxonomy` and verify that there is not pagination footer.

**The "expand all" link and the up/down arrows have been moved to the far right of the table.**
- Verify this style.

## Support information

- Github issue: https://github.com/openedx/modular-learning/issues/186
- Internal ticket: [FAL-3641](https://tasks.opencraft.com/browse/FAL-3641)

