### PR TITLE
[FC-0036] feat: New "Add Tags" widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-responsive": "9.0.2",
         "react-router": "6.16.0",
         "react-router-dom": "6.16.0",
+        "react-select": "^5.8.0",
         "react-textarea-autosize": "^8.4.1",
         "react-transition-group": "4.4.5",
         "redux": "4.0.5",
@@ -3012,6 +3013,117 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz",
+      "integrity": "sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
+      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3115,6 +3227,28 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@formatjs/cli": {
       "version": "6.2.7",
@@ -7106,6 +7240,35 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
@@ -10528,8 +10691,7 @@
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -14686,6 +14848,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/memory-fs": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
@@ -17518,6 +17685,26 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-select": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
@@ -19906,6 +20093,11 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/superagent": {
       "version": "3.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22106,6 +22106,7 @@
       "version": "0.1.0",
       "peerDependencies": {
         "@edx/frontend-app-course-authoring": "*",
+        "@edx/frontend-lib-content-components": "*",
         "@edx/frontend-platform": "*",
         "@openedx/paragon": "*",
         "@reduxjs/toolkit": "*",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-responsive": "9.0.2",
     "react-router": "6.16.0",
     "react-router-dom": "6.16.0",
+    "react-select": "^5.8.0",
     "react-textarea-autosize": "^8.4.1",
     "react-transition-group": "4.4.5",
     "redux": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-responsive": "9.0.2",
     "react-router": "6.16.0",
     "react-router-dom": "6.16.0",
-    "react-select": "^5.8.0",
+    "react-select": "5.8.0",
     "react-textarea-autosize": "^8.4.1",
     "react-transition-group": "4.4.5",
     "redux": "4.0.5",

--- a/src/content-tags-drawer/ContentTagsCollapsible.d.ts
+++ b/src/content-tags-drawer/ContentTagsCollapsible.d.ts
@@ -35,3 +35,5 @@ declare module 'react-select/base' {
   > extends TaxonomySelectProps {
   }
 }
+
+export default ContentTagsCollapsible;

--- a/src/content-tags-drawer/ContentTagsCollapsible.d.ts
+++ b/src/content-tags-drawer/ContentTagsCollapsible.d.ts
@@ -6,6 +6,8 @@ import type {} from 'react-select/base';
 export interface TagTreeEntry {
     explicit: boolean;
     children: Record<string, TagTreeEntry>;
+    canChangeObjecttag: boolean;
+    canDeleteObjecttag: boolean;
 }
 
 export interface TaxonomySelectProps {

--- a/src/content-tags-drawer/ContentTagsCollapsible.d.ts
+++ b/src/content-tags-drawer/ContentTagsCollapsible.d.ts
@@ -1,0 +1,35 @@
+import type {} from 'react-select/base';
+// This import is necessary for module augmentation.
+// It allows us to extend the 'Props' interface in the 'react-select/base' module
+// and add our custom property 'myCustomProp' to it.
+
+export interface TagTreeEntry {
+    explicit: boolean;
+    children: Record<string, TagTreeEntry>;
+}
+
+export interface TaxonomySelectProps {
+    taxonomyId: number;
+    searchTerm: string;
+    appliedContentTagsTree: Record<string, TagTreeEntry>;
+    stagedContentTagsTree: Record<string, TagTreeEntry>;
+    checkedTags: string[];
+    handleCommitStagedTags: () => void;
+    handleCancelStagedTags: () => void;
+    handleSelectableBoxChange: React.ChangeEventHandler;
+}
+
+// Unfortunately the only way to specify the custom props we pass into React Select
+// is with this global type augmentation.
+// https://react-select.com/typescript#custom-select-props
+// If in the future other parts of this MFE need to use React Select for different things,
+// we should change to using a 'react context' to share this data within <ContentTagsCollapsible>,
+// rather than using the custom <Select> Props (selectProps).
+declare module 'react-select/base' {
+  export interface Props<
+    Option,
+    IsMulti extends boolean,
+    Group extends GroupBase<Option>
+  > extends TaxonomySelectProps {
+  }
+}

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -228,7 +228,8 @@ const ContentTagsCollapsible = ({
           {canTagObject && (
             <Select
               isMulti
-              name="colors"
+              name="tags-select"
+              placeholder={intl.formatMessage(messages.collapsibleAddTagsPlaceholderText)}
               isSearchable
               className="d-flex flex-column flex-fill"
               classNamePrefix="react-select"

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -129,13 +129,17 @@ const CustomMenu = (props) => {
  * @param {string} props.contentId - Id of the content object
  * @param {TaxonomyData & {contentTags: ContentTagData[]}} props.taxonomyAndTagsData - Taxonomy metadata & applied tags
  */
-const ContentTagsCollapsible = ({ contentId, taxonomyAndTagsData }) => {
+const ContentTagsCollapsible = ({
+  contentId, taxonomyAndTagsData, stagedContentTags, addStagedContentTag, removeStagedContentTag,
+}) => {
   const intl = useIntl();
   const { id: taxonomyId, name, canTagObject } = taxonomyAndTagsData;
 
   const {
     tagChangeHandler, tagsTree, contentTagsCount, checkedTags,
-  } = useContentTagsCollapsibleHelper(contentId, taxonomyAndTagsData);
+  } = useContentTagsCollapsibleHelper(
+    contentId, taxonomyAndTagsData, addStagedContentTag, removeStagedContentTag,
+  );
 
   const [searchTerm, setSearchTerm] = React.useState('');
 
@@ -174,6 +178,7 @@ const ContentTagsCollapsible = ({ contentId, taxonomyAndTagsData }) => {
               className="d-flex flex-column flex-fill"
               classNamePrefix="react-select"
               onInputChange={handleSearchChange}
+              onChange={(e) => console.log('onChange', e)}
               components={{ Menu: CustomMenu }}
               closeMenuOnSelect={false}
               blurInputOnSelect={false}
@@ -183,6 +188,7 @@ const ContentTagsCollapsible = ({ contentId, taxonomyAndTagsData }) => {
               taxonomyId={taxonomyId}
               tagsTree={tagsTree}
               searchTerm={searchTerm}
+              value={stagedContentTags}
               // value={[
               //   { value: 'Administration,Administrative%20Support,Administrative%20Functions', label: 'Administrative Functions' },
               //   { value: 'Administration,Administrative%20Support,Memos', label: 'Memos' },
@@ -218,6 +224,12 @@ ContentTagsCollapsible.propTypes = {
     })),
     canTagObject: PropTypes.bool.isRequired,
   }).isRequired,
+  stagedContentTags: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string,
+    label: PropTypes.string,
+  })).isRequired,
+  addStagedContentTag: PropTypes.func.isRequired,
+  removeStagedContentTag: PropTypes.func.isRequired,
 };
 
 export default ContentTagsCollapsible;

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -33,6 +33,7 @@ const CustomMenu = (props) => {
     appliedContentTagsTree,
     stagedContentTagsTree,
     searchTerm,
+    value,
   } = props.selectProps;
   return (
     <components.Menu {...props}>
@@ -56,6 +57,23 @@ const CustomMenu = (props) => {
             searchTerm={searchTerm}
           />
         </SelectableBox.Set>
+        <div className="d-flex flex-row justify-content-end">
+          <div className="d-inline">
+            <Button
+              variant="tertiary"
+              onClick={() => { /* TODO: Implement this */ }}
+            >
+              { intl.formatMessage(messages.collapsibleCancelStagedTagsButtonText) }
+            </Button>
+            <Button
+              variant="tertiary"
+              disabled={!(value && value.length)}
+              onClick={() => { /* TODO: Implement this */ }}
+            >
+              { intl.formatMessage(messages.collapsibleAddStagedTagsButtonText) }
+            </Button>
+          </div>
+        </div>
       </div>
     </components.Menu>
   );

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -13,7 +13,6 @@ import { SelectableBox } from '@edx/frontend-lib-content-components';
 import { useIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { debounce } from 'lodash';
 import messages from './messages';
-import './ContentTagsCollapsible.scss';
 
 import ContentTagsDropDownSelector from './ContentTagsDropDownSelector';
 
@@ -57,16 +56,19 @@ const CustomMenu = (props) => {
             searchTerm={searchTerm}
           />
         </SelectableBox.Set>
+        <hr className="mt-0 mb-0" />
         <div className="d-flex flex-row justify-content-end">
           <div className="d-inline">
             <Button
               variant="tertiary"
+              className="cancel-add-tags-button"
               onClick={() => { handleStagedTagsMenuChange([]); selectRef.current?.blur(); }}
             >
               { intl.formatMessage(messages.collapsibleCancelStagedTagsButtonText) }
             </Button>
             <Button
               variant="tertiary"
+              className="text-info-500 add-tags-button"
               disabled={!(value && value.length)}
               onClick={() => { commitStagedTags(); handleStagedTagsMenuChange([]); selectRef.current?.blur(); }}
             >

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -248,7 +248,7 @@ const ContentTagsCollapsible = ({
 }) => {
   const intl = useIntl();
   const { id: taxonomyId, name, canTagObject } = taxonomyAndTagsData;
-  const selectRef = React.useRef(null);
+  const selectRef = React.useRef(/** @type {HTMLSelectElement | null} */(null));
 
   const {
     tagChangeHandler,
@@ -335,7 +335,7 @@ const ContentTagsCollapsible = ({
 
           {canTagObject && (
             <Select
-              ref={selectRef}
+              ref={/** @type {React.RefObject} */(selectRef)}
               isMulti
               isLoading={updateTags.isLoading}
               isDisabled={updateTags.isLoading}

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -278,7 +278,11 @@ const ContentTagsCollapsible = ({
   }, 500); // Perform search after 500ms
 
   const handleSearchChange = React.useCallback((value, { action }) => {
-    if (action === 'input-change') {
+    if (action === 'input-blur') {
+      // Cancel/clear search if focused away from select input
+      handleSearch.cancel();
+      setSearchTerm('');
+    } else if (action === 'input-change') {
       if (value === '') {
         // No need to debounce when search term cleared. Clear debounce function
         handleSearch.cancel();
@@ -311,12 +315,14 @@ const ContentTagsCollapsible = ({
     commitStagedTags();
     handleStagedTagsMenuChange([]);
     selectRef.current?.blur();
-  }, [commitStagedTags, handleStagedTagsMenuChange, selectRef]);
+    setSearchTerm('');
+  }, [commitStagedTags, handleStagedTagsMenuChange, selectRef, setSearchTerm]);
 
   const handleCancelStagedTags = React.useCallback(() => {
     handleStagedTagsMenuChange([]);
     selectRef.current?.blur();
-  }, [handleStagedTagsMenuChange, selectRef]);
+    setSearchTerm('');
+  }, [handleStagedTagsMenuChange, selectRef, setSearchTerm]);
 
   return (
     <div className="d-flex">
@@ -337,7 +343,7 @@ const ContentTagsCollapsible = ({
               placeholder={intl.formatMessage(messages.collapsibleAddTagsPlaceholderText)}
               isSearchable
               className="d-flex flex-column flex-fill"
-              classNamePrefix="react-select"
+              classNamePrefix="react-select-add-tags"
               onInputChange={handleSearchChange}
               onChange={handleStagedTagsMenuChange}
               components={{

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -141,7 +141,7 @@ const ContentTagsCollapsible = ({ contentId, taxonomyAndTagsData }) => {
 
   const handleSelectableBoxChange = React.useCallback((e) => {
     tagChangeHandler(e.target.value, e.target.checked);
-  }, []);
+  }, [tagChangeHandler]);
 
   const handleSearch = debounce((term) => {
     setSearchTerm(term.trim());

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -22,8 +22,8 @@ import ContentTagsTree from './ContentTagsTree';
 
 import useContentTagsCollapsibleHelper from './ContentTagsCollapsibleHelper';
 
-/** @typedef {import("./ContentTagsCollapsible.d.ts").TagTreeEntry} TagTreeEntry */
-/** @typedef {import("./ContentTagsCollapsible.d.ts").TaxonomySelectProps} TaxonomySelectProps */
+/** @typedef {import("./ContentTagsCollapsible").TagTreeEntry} TagTreeEntry */
+/** @typedef {import("./ContentTagsCollapsible").TaxonomySelectProps} TaxonomySelectProps */
 /** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
 /** @typedef {import("./data/types.mjs").Tag} ContentTagData */
 

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -92,7 +92,7 @@ const CustomMenu = (props) => {
 };
 
 const CustomLoadingIndicator = () => {
-  const { intl } = useIntl();
+  const intl = useIntl();
   return (
     <Spinner
       animation="border"

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -127,6 +127,7 @@ CustomLoadingIndicator.propTypes = {
 
 const CustomIndicatorsContainer = (props) => {
   const {
+    intl,
     value,
     handleCommitStagedTags,
   } = props.selectProps;
@@ -141,7 +142,7 @@ const CustomIndicatorsContainer = (props) => {
             onClick={handleCommitStagedTags}
             onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
           >
-            Add
+            { intl.formatMessage(messages.collapsibleInlineAddStagedTagsButtonText) }
           </Button>
         )) || null
       }
@@ -152,6 +153,7 @@ const CustomIndicatorsContainer = (props) => {
 
 CustomIndicatorsContainer.propTypes = {
   selectProps: PropTypes.shape({
+    intl: intlShape.isRequired,
     value: PropTypes.arrayOf(PropTypes.shape({
       value: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -1,6 +1,6 @@
 // @ts-check
 import React from 'react';
-import Select, { components, MenuProps } from 'react-select';
+import Select, { components } from 'react-select';
 import {
   Badge,
   Collapsible,
@@ -12,8 +12,7 @@ import {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { SelectableBox } from '@edx/frontend-lib-content-components';
-import { cloneDeep } from 'lodash';
-import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { debounce } from 'lodash';
 import messages from './messages';
 import './ContentTagsCollapsible.scss';
@@ -32,6 +31,8 @@ const CustomMenu = (props) => {
     taxonomyId,
     appliedContentTagsTree,
     stagedContentTagsTree,
+    handleStagedTagsMenuChange,
+    selectRef,
     searchTerm,
     value,
   } = props.selectProps;
@@ -61,7 +62,7 @@ const CustomMenu = (props) => {
           <div className="d-inline">
             <Button
               variant="tertiary"
-              onClick={() => { /* TODO: Implement this */ }}
+              onClick={() => { handleStagedTagsMenuChange([]); selectRef.current?.blur(); }}
             >
               { intl.formatMessage(messages.collapsibleCancelStagedTagsButtonText) }
             </Button>
@@ -79,7 +80,34 @@ const CustomMenu = (props) => {
   );
 };
 
-// TODO: Add props validation for CustomMenu
+CustomMenu.propTypes = {
+  selectProps: PropTypes.shape({
+    intl: intlShape.isRequired,
+    handleSelectableBoxChange: PropTypes.func.isRequired,
+    checkedTags: PropTypes.arrayOf(PropTypes.string).isRequired,
+    taxonomyId: PropTypes.number.isRequired,
+    appliedContentTagsTree: PropTypes.objectOf(
+      PropTypes.shape({
+        explicit: PropTypes.bool.isRequired,
+        children: PropTypes.shape({}).isRequired,
+      }).isRequired,
+    ).isRequired,
+    stagedContentTagsTree: PropTypes.objectOf(
+      PropTypes.shape({
+        explicit: PropTypes.bool.isRequired,
+        children: PropTypes.shape({}).isRequired,
+      }).isRequired,
+    ).isRequired,
+    handleStagedTagsMenuChange: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    selectRef: PropTypes.shape({ current: PropTypes.object }),
+    searchTerm: PropTypes.string.isRequired,
+    value: PropTypes.arrayOf(PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })).isRequired,
+  }).isRequired,
+};
 
 /** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
 /** @typedef {import("./data/types.mjs").Tag} ContentTagData */
@@ -168,6 +196,7 @@ const ContentTagsCollapsible = ({
 }) => {
   const intl = useIntl();
   const { id: taxonomyId, name, canTagObject } = taxonomyAndTagsData;
+  const selectRef = React.useRef(null);
 
   const {
     tagChangeHandler, appliedContentTagsTree, stagedContentTagsTree, contentTagsCount, checkedTags,
@@ -227,6 +256,7 @@ const ContentTagsCollapsible = ({
 
           {canTagObject && (
             <Select
+              ref={selectRef}
               isMulti
               name="tags-select"
               placeholder={intl.formatMessage(messages.collapsibleAddTagsPlaceholderText)}
@@ -244,6 +274,8 @@ const ContentTagsCollapsible = ({
               taxonomyId={taxonomyId}
               appliedContentTagsTree={appliedContentTagsTree}
               stagedContentTagsTree={stagedContentTagsTree}
+              handleStagedTagsMenuChange={handleStagedTagsMenuChange}
+              selectRef={selectRef}
               searchTerm={searchTerm}
               value={stagedContentTags}
             />

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -203,12 +203,9 @@ const ContentTagsCollapsible = ({
   // The remaining staged tags are passed in as the parameter, so we set the state
   // to the passed in tags
   const handleStagedTagsMenuChange = React.useCallback((stagedTags) => {
-    const prevStagedContentTags = cloneDeep(stagedContentTags);
-    setStagedTags(taxonomyId, stagedTags);
-
     // Get tags that were unstaged to remove them from checkbox selector
-    const unstagedTags = prevStagedContentTags.filter(
-      t1 => !stagedTags.some(t2 => t1.value === t2.value && t1.label === t2.label),
+    const unstagedTags = stagedContentTags.filter(
+      t1 => !stagedTags.some(t2 => t1.value === t2.value),
     );
 
     // Call the `tagChangeHandler` with the unstaged tags to unselect them from the selectbox
@@ -216,6 +213,7 @@ const ContentTagsCollapsible = ({
     // only called when a change occurs in the react-select menu component we know that tags can only be
     // removed from there, hence the tagChangeHandler is always called with `checked=false`.
     unstagedTags.forEach(unstagedTag => tagChangeHandler(unstagedTag.value, false));
+    setStagedTags(taxonomyId, stagedTags);
   }, [taxonomyId, setStagedTags, stagedContentTags, tagChangeHandler]);
 
   return (

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -1,4 +1,7 @@
 // @ts-check
+// disable prop-types since we're using TypeScript to define the prop types,
+// but the linter can't detect that in a .jsx file.
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Select, { components } from 'react-select';
 import {
@@ -7,10 +10,9 @@ import {
   Button,
   Spinner,
 } from '@openedx/paragon';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { SelectableBox } from '@edx/frontend-lib-content-components';
-import { useIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { debounce } from 'lodash';
 import messages from './messages';
 
@@ -20,9 +22,17 @@ import ContentTagsTree from './ContentTagsTree';
 
 import useContentTagsCollapsibleHelper from './ContentTagsCollapsibleHelper';
 
+/** @typedef {import("./ContentTagsCollapsible.d.ts").TagTreeEntry} TagTreeEntry */
+/** @typedef {import("./ContentTagsCollapsible.d.ts").TaxonomySelectProps} TaxonomySelectProps */
+/** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
+/** @typedef {import("./data/types.mjs").Tag} ContentTagData */
+
+/**
+ * Custom Menu component for our Select box
+ * @param {import("react-select").MenuProps&{selectProps: TaxonomySelectProps}} props
+ */
 const CustomMenu = (props) => {
   const {
-    intl,
     handleSelectableBoxChange,
     checkedTags,
     taxonomyId,
@@ -33,6 +43,7 @@ const CustomMenu = (props) => {
     searchTerm,
     value,
   } = props.selectProps;
+  const intl = useIntl();
   return (
     <components.Menu {...props}>
       <div className="bg-white p-3 shadow">
@@ -80,36 +91,8 @@ const CustomMenu = (props) => {
   );
 };
 
-CustomMenu.propTypes = {
-  selectProps: PropTypes.shape({
-    intl: intlShape.isRequired,
-    handleSelectableBoxChange: PropTypes.func.isRequired,
-    checkedTags: PropTypes.arrayOf(PropTypes.string).isRequired,
-    taxonomyId: PropTypes.number.isRequired,
-    appliedContentTagsTree: PropTypes.objectOf(
-      PropTypes.shape({
-        explicit: PropTypes.bool.isRequired,
-        children: PropTypes.shape({}).isRequired,
-      }).isRequired,
-    ).isRequired,
-    stagedContentTagsTree: PropTypes.objectOf(
-      PropTypes.shape({
-        explicit: PropTypes.bool.isRequired,
-        children: PropTypes.shape({}).isRequired,
-      }).isRequired,
-    ).isRequired,
-    handleCommitStagedTags: PropTypes.func.isRequired,
-    handleCancelStagedTags: PropTypes.func.isRequired,
-    searchTerm: PropTypes.string.isRequired,
-    value: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    })).isRequired,
-  }).isRequired,
-};
-
-const CustomLoadingIndicator = (props) => {
-  const { intl } = props.selectProps;
+const CustomLoadingIndicator = () => {
+  const { intl } = useIntl();
   return (
     <Spinner
       animation="border"
@@ -119,18 +102,16 @@ const CustomLoadingIndicator = (props) => {
   );
 };
 
-CustomLoadingIndicator.propTypes = {
-  selectProps: PropTypes.shape({
-    intl: intlShape.isRequired,
-  }).isRequired,
-};
-
+/**
+ * Custom IndicatorsContainer component for our Select box
+ * @param {import("react-select").IndicatorsContainerProps&{selectProps: TaxonomySelectProps}} props
+ */
 const CustomIndicatorsContainer = (props) => {
   const {
-    intl,
     value,
     handleCommitStagedTags,
   } = props.selectProps;
+  const intl = useIntl();
   return (
     <components.IndicatorsContainer {...props}>
       {
@@ -150,21 +131,6 @@ const CustomIndicatorsContainer = (props) => {
     </components.IndicatorsContainer>
   );
 };
-
-CustomIndicatorsContainer.propTypes = {
-  selectProps: PropTypes.shape({
-    intl: intlShape.isRequired,
-    value: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    })).isRequired,
-    handleCommitStagedTags: PropTypes.func.isRequired,
-  }).isRequired,
-  children: PropTypes.node.isRequired,
-};
-
-/** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
-/** @typedef {import("./data/types.mjs").Tag} ContentTagData */
 
 /**
  * Collapsible component that holds a Taxonomy along with Tags that belong to it.
@@ -239,9 +205,12 @@ CustomIndicatorsContainer.propTypes = {
  *
  * @param {Object} props - The component props.
  * @param {string} props.contentId - Id of the content object
- * @param {Array<Object>} props.stagedContentTags - Array of staged tags represented objects with value/label
- * @param {Function} props.addStagedContentTag - Callback function to add a staged tag for a taxonomy
- * @param {Function} props.removeStagedContentTag - Callback function to remove a staged tag from a taxonomy
+ * @param {{value: string, label: string}[]} props.stagedContentTags
+ *        - Array of staged tags represented as objects with value/label
+ * @param {(taxonomyId: number, tag: {value: string, label: string}) => void} props.addStagedContentTag
+ *        - Callback function to add a staged tag for a taxonomy
+ * @param {(taxonomyId: number, tagValue: string) => void} props.removeStagedContentTag
+ *        - Callback function to remove a staged tag from a taxonomy
  * @param {Function} props.setStagedTags - Callback function to set staged tags for a taxonomy to provided tags list
  * @param {TaxonomyData & {contentTags: ContentTagData[]}} props.taxonomyAndTagsData - Taxonomy metadata & applied tags
  */
@@ -349,16 +318,12 @@ const ContentTagsCollapsible = ({
               onInputChange={handleSearchChange}
               onChange={handleStagedTagsMenuChange}
               components={{
-                // @ts-ignore TODO: Properly fix this
                 Menu: CustomMenu,
-                // @ts-ignore TODO: Properly fix this
                 LoadingIndicator: CustomLoadingIndicator,
-                // @ts-ignore TODO: Properly fix this
                 IndicatorsContainer: CustomIndicatorsContainer,
               }}
               closeMenuOnSelect={false}
               blurInputOnSelect={false}
-              intl={intl}
               handleSelectableBoxChange={handleSelectableBoxChange}
               checkedTags={checkedTags}
               taxonomyId={taxonomyId}
@@ -385,26 +350,6 @@ const ContentTagsCollapsible = ({
       </div>
     </div>
   );
-};
-
-ContentTagsCollapsible.propTypes = {
-  contentId: PropTypes.string.isRequired,
-  taxonomyAndTagsData: PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-    contentTags: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string,
-      lineage: PropTypes.arrayOf(PropTypes.string),
-    })),
-    canTagObject: PropTypes.bool.isRequired,
-  }).isRequired,
-  stagedContentTags: PropTypes.arrayOf(PropTypes.shape({
-    value: PropTypes.string,
-    label: PropTypes.string,
-  })).isRequired,
-  addStagedContentTag: PropTypes.func.isRequired,
-  removeStagedContentTag: PropTypes.func.isRequired,
-  setStagedTags: PropTypes.func.isRequired,
 };
 
 export default ContentTagsCollapsible;

--- a/src/content-tags-drawer/ContentTagsCollapsible.scss
+++ b/src/content-tags-drawer/ContentTagsCollapsible.scss
@@ -37,3 +37,23 @@
   background-color: transparent;
   color: $gray-300 !important;
 }
+
+.react-select-add-tags__control {
+  border-radius: 0 !important;
+}
+
+.react-select-add-tags__control--is-focused {
+  border-color: black !important;
+  box-shadow: 0 0 0 1px black !important;
+}
+
+.react-select-add-tags__multi-value__remove {
+  padding-right: 7px !important;
+  padding-left: 7px !important;
+  border-radius: 0 3px 3px 0;
+
+  &:hover {
+    background-color: black !important;
+    color: white !important;
+  }
+}

--- a/src/content-tags-drawer/ContentTagsCollapsible.scss
+++ b/src/content-tags-drawer/ContentTagsCollapsible.scss
@@ -27,3 +27,13 @@
 .pgn__modal-popup__arrow {
   visibility: hidden;
 }
+
+.add-tags-button:not([disabled]):hover {
+  background-color: transparent;
+  color: $info-900 !important;
+}
+
+.cancel-add-tags-button:hover {
+  background-color: transparent;
+  color: $gray-300 !important;
+}

--- a/src/content-tags-drawer/ContentTagsCollapsible.test.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.test.jsx
@@ -167,8 +167,9 @@ describe('<ContentTagsCollapsible />', () => {
 
     // Click on "Add a tag" button to open dropdown to select new tags
     const addTagsButton = getByText(messages.collapsibleAddTagsPlaceholderText.defaultMessage);
-    // Use `mouseDown` instead of `click` since the react-select didn't respond to `click`
+    // Use `mouseDown/mouseUp` instead of `click` since the react-select didn't respond to `click`
     fireEvent.mouseDown(addTagsButton);
+    fireEvent.mouseUp(addTagsButton);
 
     // Wait for the dropdown selector for tags to open,
     // Tag 3 should only appear there, (i.e. the dropdown is open, since Tag 3 is not applied)
@@ -176,7 +177,6 @@ describe('<ContentTagsCollapsible />', () => {
 
     // Click to check Tag 3 and check the `addStagedContentTag` was called with the correct params
     const tag3 = getByText('Tag 3');
-    fireEvent.click(tag3); // Need to call click first time to get focus in tests
     fireEvent.click(tag3);
 
     const taxonomyId = 123;
@@ -199,8 +199,9 @@ describe('<ContentTagsCollapsible />', () => {
 
     // Click on "Add a tag" button to open dropdown to select new tags
     const addTagsButton = getByText(messages.collapsibleAddTagsPlaceholderText.defaultMessage);
-    // Use `mouseDown` instead of `click` since the react-select didn't respond to `click`
+    // Use `mouseDown/mouseup` instead of `click` since the react-select didn't respond to `click`
     fireEvent.mouseDown(addTagsButton);
+    fireEvent.mouseUp(addTagsButton);
 
     // Wait for the dropdown selector for tags to open,
     // Tag 3 should only appear there, (i.e. the dropdown is open, since Tag 3 is not applied)
@@ -208,7 +209,6 @@ describe('<ContentTagsCollapsible />', () => {
 
     // Click to check Tag 3
     const tag3 = getByText('Tag 3');
-    fireEvent.click(tag3); // Need to call click first time to get focus in tests
     fireEvent.click(tag3);
 
     // Click to uncheck Tag 3 and check the `removeStagedContentTag` was called with the correct params

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -210,7 +210,7 @@ const useContentTagsCollapsibleHelper = (contentId, taxonomyAndTagsData) => {
 
     setAddedContentTags(addedTree);
     // setUpdatingTags(true);
-  }, []);
+  }, [addedContentTags, setAddedContentTags, addTags, removeTags, remove]);
 
   return {
     tagChangeHandler, tagsTree, contentTagsCount, checkedTags,

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -91,17 +91,23 @@ const useContentTagsCollapsibleHelper = (contentId, taxonomyAndTagsData) => {
   // To handle checking/unchecking tags in the SelectableBox
   const [checkedTags, { add, remove, clear }] = useCheckboxSetValues();
 
-  // Handles making requests to the update endpoint whenever the checked tags change
-  React.useEffect(() => {
-    // We have this check because this hook is fired when the component first loads
-    // and reloads (on refocus). We only want to make a request to the update endpoint when
-    // the user is updating the tags.
-    if (updatingTags) {
-      setUpdatingTags(false);
-      const tags = checkedTags.map(t => decodeURIComponent(t.split(',').slice(-1)));
-      updateTags.mutate({ tags });
-    }
-  }, [contentId, id, canTagObject, checkedTags]);
+  // =================================================================
+
+  // TODO: Properly implement this based on feature/requirements
+
+  // // Handles making requests to the update endpoint whenever the checked tags change
+  // React.useEffect(() => {
+  //   // We have this check because this hook is fired when the component first loads
+  //   // and reloads (on refocus). We only want to make a request to the update endpoint when
+  //   // the user is updating the tags.
+  //   if (updatingTags) {
+  //     setUpdatingTags(false);
+  //     const tags = checkedTags.map(t => decodeURIComponent(t.split(',').slice(-1)));
+  //     updateTags.mutate({ tags });
+  //   }
+  // }, [contentId, id, canTagObject, checkedTags]);
+
+  // ==================================================================
 
   // This converts the contentTags prop to the tree structure mentioned above
   const appliedContentTags = React.useMemo(() => {
@@ -203,7 +209,7 @@ const useContentTagsCollapsibleHelper = (contentId, taxonomyAndTagsData) => {
     }
 
     setAddedContentTags(addedTree);
-    setUpdatingTags(true);
+    // setUpdatingTags(true);
   }, []);
 
   return {

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -6,6 +6,25 @@ import { cloneDeep } from 'lodash';
 import { useContentTaxonomyTagsUpdater } from './data/apiHooks';
 
 /**
+ * Util function that sorts the keys of a tree in alphabetical order.
+ *
+ * @param {object} tree - tree that needs it's keys sorted
+ * @returns {object} merged tree containing both tree1 and tree2
+ */
+const sortKeysAlphabetically = (tree) => {
+  const sortedObj = {};
+  Object.keys(tree)
+    .sort()
+    .forEach((key) => {
+      sortedObj[key] = tree[key];
+      if (tree[key] && typeof tree[key] === 'object') {
+        sortedObj[key].children = sortKeysAlphabetically(tree[key].children);
+      }
+    });
+  return sortedObj;
+};
+
+/**
  * Util function that consolidates two tag trees into one, sorting the keys in
  * alphabetical order.
  *
@@ -15,19 +34,6 @@ import { useContentTaxonomyTagsUpdater } from './data/apiHooks';
  */
 const mergeTrees = (tree1, tree2) => {
   const mergedTree = cloneDeep(tree1);
-
-  const sortKeysAlphabetically = (obj) => {
-    const sortedObj = {};
-    Object.keys(obj)
-      .sort()
-      .forEach((key) => {
-        sortedObj[key] = obj[key];
-        if (obj[key] && typeof obj[key] === 'object') {
-          sortedObj[key].children = sortKeysAlphabetically(obj[key].children);
-        }
-      });
-    return sortedObj;
-  };
 
   const mergeRecursively = (destination, source) => {
     Object.entries(source).forEach(([key, sourceValue]) => {
@@ -91,7 +97,7 @@ const useContentTagsCollapsibleHelper = (
 
   // Keeps track of the tree structure for tags that are add by selecting/unselecting
   // tags in the dropdowns.
-  const [addedContentTags, setAddedContentTags] = React.useState({});
+  const [stagedContentTagsTree, setStagedContentTagsTree] = React.useState({});
 
   // To handle checking/unchecking tags in the SelectableBox
   const [checkedTags, { add, remove, clear }] = useCheckboxSetValues();
@@ -115,12 +121,12 @@ const useContentTagsCollapsibleHelper = (
   // ==================================================================
 
   // This converts the contentTags prop to the tree structure mentioned above
-  const appliedContentTags = React.useMemo(() => {
+  const appliedContentTagsTree = React.useMemo(() => {
     let contentTagsCounter = 0;
 
     // Clear all the tags that have not been commited and the checked boxes when
     // fresh contentTags passed in so the latest state from the backend is rendered
-    setAddedContentTags({});
+    setStagedContentTagsTree({});
     clear();
 
     // When an error occurs while updating, the contentTags query is invalidated,
@@ -158,17 +164,9 @@ const useContentTagsCollapsibleHelper = (
     return resultTree;
   }, [contentTags, updateTags.isError]);
 
-  // This is the source of truth that represents the current state of tags in
-  // this Taxonomy as a tree. Whenever either the `appliedContentTags` (i.e. tags passed in
-  // the prop from the backed) change, or when the `addedContentTags` (i.e. tags added by
-  // selecting/unselecting them in the dropdown) change, the tree is recomputed.
-  const tagsTree = React.useMemo(() => (
-    mergeTrees(appliedContentTags, addedContentTags)
-  ), [appliedContentTags, addedContentTags]);
-
   // Add tag to the tree, and while traversing remove any selected ancestor tags
   // as they should become implicit
-  const addTags = (tree, tagLineage, selectedTag, taxonomyId) => {
+  const addTags = (tree, tagLineage, selectedTag) => {
     const value = [];
     let traversal = tree;
     tagLineage.forEach(tag => {
@@ -184,7 +182,7 @@ const useContentTagsCollapsibleHelper = (
       } else {
         traversal[tag].explicit = isExplicit;
         if (!isExplicit) {
-          removeStagedContentTag(taxonomyId, tag);
+          removeStagedContentTag(id, tag);
         }
       }
 
@@ -202,12 +200,15 @@ const useContentTagsCollapsibleHelper = (
     const tagLineage = tagSelectableBoxValue.split(',').map(t => decodeURIComponent(t));
     const selectedTag = tagLineage.slice(-1)[0];
 
-    const addedTree = { ...addedContentTags };
     if (checked) {
+      const stagedTree = cloneDeep(stagedContentTagsTree);
       // We "add" the tag to the SelectableBox.Set inside the addTags method
-      addTags(addedTree, tagLineage, selectedTag, id);
+      addTags(stagedTree, tagLineage, selectedTag);
 
-      // Add content tag to taxonomy's staged tags
+      // Update the staged content tags tree
+      setStagedContentTagsTree(stagedTree);
+
+      // Add content tag to taxonomy's staged tags select menu
       addStagedContentTag(
         id,
         {
@@ -219,24 +220,30 @@ const useContentTagsCollapsibleHelper = (
       // Remove tag from the SelectableBox.Set
       remove(tagSelectableBoxValue);
 
-      // We remove them from both incase we are unselecting from an
-      // existing applied Tag or a newly added one
-      removeTags(addedTree, tagLineage);
-      removeTags(appliedContentTags, tagLineage);
+      // Remove tag along with it's from ancestors if it's the only child tag
+      // from the staged tags tree and update the staged content tags tree
+      setStagedContentTagsTree(prevStagedContentTagsTree => {
+        const updatedStagedContentTagsTree = cloneDeep(prevStagedContentTagsTree);
+        removeTags(updatedStagedContentTagsTree, tagLineage);
+        return updatedStagedContentTagsTree;
+      });
 
-      // Remove content tag from taxonomy's staged tags
+      // Remove content tag from taxonomy's staged tags select menu
       removeStagedContentTag(id, selectedTag);
     }
 
-    setAddedContentTags(addedTree);
     // setUpdatingTags(true);
   }, [
-    addedContentTags, setAddedContentTags, addTags, removeTags, remove,
+    stagedContentTagsTree, setStagedContentTagsTree, addTags, removeTags, removeTags,
     id, addStagedContentTag, removeStagedContentTag,
   ]);
 
   return {
-    tagChangeHandler, tagsTree, contentTagsCount, checkedTags,
+    tagChangeHandler,
+    appliedContentTagsTree: sortKeysAlphabetically(appliedContentTagsTree),
+    stagedContentTagsTree: sortKeysAlphabetically(stagedContentTagsTree),
+    contentTagsCount,
+    checkedTags,
   };
 };
 

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -162,8 +162,12 @@ const useContentTagsCollapsibleHelper = (
 
           // Populating the SelectableBox with "selected" (explicit) tags
           const value = item.lineage.map(l => encodeURIComponent(l)).join(',');
-          // eslint-disable-next-line no-unused-expressions
-          isExplicit ? add(value) : remove(value);
+          // Clear all the existing applied tags
+          remove(value);
+          // Add only the explicitly applied tags
+          if (isExplicit) {
+            add(value);
+          }
           contentTagsCounter += 1;
         }
 

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -181,16 +181,18 @@ const useContentTagsCollapsibleHelper = (
         };
       } else {
         traversal[tag].explicit = isExplicit;
-        if (!isExplicit) {
-          removeStagedContentTag(id, tag);
-        }
       }
 
       // Clear out the ancestor tags leading to newly selected tag
       // as they automatically become implicit
       value.push(encodeURIComponent(tag));
-      // eslint-disable-next-line no-unused-expressions
-      isExplicit ? add(value.join(',')) : remove(value.join(','));
+
+      if (isExplicit) {
+        add(value.join(','));
+      } else {
+        removeStagedContentTag(id, value.join(','));
+        remove(value.join(','));
+      }
 
       traversal = traversal[tag].children;
     });
@@ -229,7 +231,7 @@ const useContentTagsCollapsibleHelper = (
       });
 
       // Remove content tag from taxonomy's staged tags select menu
-      removeStagedContentTag(id, selectedTag);
+      removeStagedContentTag(id, tagSelectableBoxValue);
     }
 
     // setUpdatingTags(true);

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -7,7 +7,7 @@ import { useContentTaxonomyTagsUpdater } from './data/apiHooks';
 
 /** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
 /** @typedef {import("./data/types.mjs").Tag} ContentTagData */
-/** @typedef {import("./ContentTagsCollapsible.d.ts").TagTreeEntry} TagTreeEntry */
+/** @typedef {import("./ContentTagsCollapsible").TagTreeEntry} TagTreeEntry */
 
 /**
  * Util function that sorts the keys of a tree in alphabetical order.

--- a/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsibleHelper.jsx
@@ -5,6 +5,10 @@ import { cloneDeep } from 'lodash';
 
 import { useContentTaxonomyTagsUpdater } from './data/apiHooks';
 
+/** @typedef {import("../taxonomy/data/types.mjs").TaxonomyData} TaxonomyData */
+/** @typedef {import("./data/types.mjs").Tag} ContentTagData */
+/** @typedef {import("./ContentTagsCollapsible.d.ts").TagTreeEntry} TagTreeEntry */
+
 /**
  * Util function that sorts the keys of a tree in alphabetical order.
  *
@@ -49,8 +53,23 @@ const getLeafTags = (tree) => {
   return leafKeys;
 };
 
-/*
+/**
  * Handles all the underlying logic for the ContentTagsCollapsible component
+ * @param {string} contentId The ID of the content we're tagging (e.g. usage key)
+ * @param {TaxonomyData & {contentTags: ContentTagData[]}} taxonomyAndTagsData
+ * @param {(taxonomyId: number, tag: {value: string, label: string}) => void} addStagedContentTag
+ * @param {(taxonomyId: number, tagValue: string) => void} removeStagedContentTag
+ * @param {{value: string, label: string}[]} stagedContentTags
+ * @returns {{
+ *      tagChangeHandler: (tagSelectableBoxValue: string, checked: boolean) => void,
+ *      removeAppliedTagHandler: (tagSelectableBoxValue: string) => void,
+ *      appliedContentTagsTree: Record<string, TagTreeEntry>,
+ *      stagedContentTagsTree: Record<string, TagTreeEntry>,
+ *      contentTagsCount: number,
+ *      checkedTags: any,
+ *      commitStagedTags: () => void,
+ *      updateTags: import('@tanstack/react-query').UseMutationResult<any, unknown, { tags: string[]; }, unknown>
+ * }}
  */
 const useContentTagsCollapsibleHelper = (
   contentId,

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -13,7 +13,6 @@ import {
 } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useParams } from 'react-router-dom';
-import { cloneDeep } from 'lodash';
 import messages from './messages';
 import ContentTagsCollapsible from './ContentTagsCollapsible';
 import { extractOrgFromContentId } from './utils';
@@ -51,35 +50,25 @@ const ContentTagsDrawer = ({ id, onClose }) => {
   // Add a content tags to the staged tags for a taxonomy
   const addStagedContentTag = useCallback((taxonomyId, addedTag) => {
     setStagedContentTags(prevStagedContentTags => {
-      const updatedStagedContentTags = cloneDeep(prevStagedContentTags);
-      if (!updatedStagedContentTags[taxonomyId]) {
-        updatedStagedContentTags[taxonomyId] = [];
-      }
-      updatedStagedContentTags[taxonomyId].push(addedTag);
+      const updatedStagedContentTags = {
+        ...prevStagedContentTags,
+        [taxonomyId]: [...(prevStagedContentTags[taxonomyId] ?? []), addedTag],
+      };
       return updatedStagedContentTags;
     });
   }, [setStagedContentTags]);
 
   // Remove a content tag from the staged tags for a taxonomy
-  const removeStagedContentTag = useCallback((taxonomyId, tagLabel) => {
-    setStagedContentTags(prevStagedContentTags => {
-      const updatedStagedContentTags = cloneDeep(prevStagedContentTags);
-      let stagedTaxonomyTags = updatedStagedContentTags[taxonomyId];
-      if (stagedTaxonomyTags && stagedTaxonomyTags.length) {
-        stagedTaxonomyTags = stagedTaxonomyTags.filter((t) => t.label !== tagLabel);
-        updatedStagedContentTags[taxonomyId] = stagedTaxonomyTags;
-      }
-      return updatedStagedContentTags;
-    });
+  const removeStagedContentTag = useCallback((taxonomyId, tagValue) => {
+    setStagedContentTags(prevStagedContentTags => ({
+      ...prevStagedContentTags,
+      [taxonomyId]: prevStagedContentTags[taxonomyId].filter((t) => t.value !== tagValue),
+    }));
   }, [setStagedContentTags]);
 
   // Sets the staged content tags for taxonomy to the provided list of tags
   const setStagedTags = useCallback((taxonomyId, tagsList) => {
-    setStagedContentTags(prevStagedContentTags => {
-      const updatedStagedContentTags = cloneDeep(prevStagedContentTags);
-      updatedStagedContentTags[taxonomyId] = tagsList;
-      return updatedStagedContentTags;
-    });
+    setStagedContentTags(prevStagedContentTags => ({ ...prevStagedContentTags, [taxonomyId]: tagsList }));
   }, [setStagedContentTags]);
 
   const useTaxonomyListData = () => {

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -73,6 +73,15 @@ const ContentTagsDrawer = ({ id, onClose }) => {
     });
   }, [setStagedContentTags]);
 
+  // Sets the staged content tags for taxonomy to the provided list of tags
+  const setStagedTags = useCallback((taxonomyId, tagsList) => {
+    setStagedContentTags(prevStagedContentTags => {
+      const updatedStagedContentTags = cloneDeep(prevStagedContentTags);
+      updatedStagedContentTags[taxonomyId] = tagsList;
+      return updatedStagedContentTags;
+    });
+  }, [setStagedContentTags]);
+
   const useTaxonomyListData = () => {
     const taxonomyListData = useTaxonomyListDataResponse(org);
     const isTaxonomyListLoaded = useIsTaxonomyListDataLoaded(org);
@@ -161,6 +170,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
                 stagedContentTags={stagedContentTags[data.id] || []}
                 addStagedContentTag={addStagedContentTag}
                 removeStagedContentTag={removeStagedContentTag}
+                setStagedTags={setStagedTags}
               />
               <hr />
             </div>

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -147,7 +147,7 @@ const ContentTagsDropDownSelector = ({
                 aria-label={intl.formatMessage(messages.taxonomyTagsCheckboxAriaLabel, { tag: tagData.value })}
                 data-selectable-box="taxonomy-tags"
                 value={[...lineage, tagData.value].map(t => encodeURIComponent(t)).join(',')}
-                isIndeterminate={isImplicit(tagData)}
+                isIndeterminate={isApplied(tagData) || isImplicit(tagData)}
                 disabled={isApplied(tagData) || isImplicit(tagData)}
               >
                 <HighlightedText text={tagData.value} highlight={searchTerm} />

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -7,7 +7,7 @@ import {
 } from '@openedx/paragon';
 import { SelectableBox } from '@edx/frontend-lib-content-components';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import { ArrowDropDown, ArrowDropUp } from '@openedx/paragon/icons';
+import { ArrowDropDown, ArrowDropUp, Add } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 import messages from './messages';
 
@@ -183,11 +183,12 @@ const ContentTagsDropDownSelector = ({
 
       { hasMorePages
         ? (
-          <div className="d-flex justify-content-center align-items-center flex-row">
+          <div>
             <Button
-              variant="outline-primary"
+              variant="tertiary"
+              iconBefore={Add}
               onClick={loadMoreTags}
-              className="mb-2 taxonomy-tags-load-more-button"
+              className="mb-2 taxonomy-tags-load-more-button px-0 text-info-500"
             >
               <FormattedMessage {...messages.loadMoreTagsButtonText} />
             </Button>

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -42,7 +42,7 @@ HighlightedText.defaultProps = {
 };
 
 const ContentTagsDropDownSelector = ({
-  taxonomyId, level, lineage, tagsTree, searchTerm,
+  taxonomyId, level, lineage, appliedContentTagsTree, stagedContentTagsTree, searchTerm,
 }) => {
   const intl = useIntl();
 
@@ -89,13 +89,30 @@ const ContentTagsDropDownSelector = ({
   };
 
   const isImplicit = (tag) => {
-    // Traverse the tags tree using the lineage
-    let traversal = tagsTree;
+    // Traverse the applied tags tree using the lineage
+    let appliedTraversal = appliedContentTagsTree;
     lineage.forEach(t => {
-      traversal = traversal[t]?.children || {};
+      appliedTraversal = appliedTraversal[t]?.children || {};
     });
+    const isAppliedImplicit = (appliedTraversal[tag.value] && !appliedTraversal[tag.value].explicit);
 
-    return (traversal[tag.value] && !traversal[tag.value].explicit) || false;
+    // Traverse the staged tags tree using the lineage
+    let stagedTraversal = stagedContentTagsTree;
+    lineage.forEach(t => {
+      stagedTraversal = stagedTraversal[t]?.children || {};
+    });
+    const isStagedImplicit = (stagedTraversal[tag.value] && !stagedTraversal[tag.value].explicit);
+
+    return isAppliedImplicit || isStagedImplicit || false;
+  };
+
+  const isApplied = (tag) => {
+    // Traverse the applied tags tree using the lineage
+    let appliedTraversal = appliedContentTagsTree;
+    lineage.forEach(t => {
+      appliedTraversal = appliedTraversal[t]?.children || {};
+    });
+    return !!appliedTraversal[tag.value];
   };
 
   const loadMoreTags = useCallback(() => {
@@ -132,7 +149,7 @@ const ContentTagsDropDownSelector = ({
                 data-selectable-box="taxonomy-tags"
                 value={[...lineage, tagData.value].map(t => encodeURIComponent(t)).join(',')}
                 isIndeterminate={isImplicit(tagData)}
-                disabled={isImplicit(tagData)}
+                disabled={isApplied(tagData) || isImplicit(tagData)}
               >
                 <HighlightedText text={tagData.value} highlight={searchTerm} />
               </SelectableBox>
@@ -156,7 +173,8 @@ const ContentTagsDropDownSelector = ({
               taxonomyId={taxonomyId}
               level={level + 1}
               lineage={[...lineage, tagData.value]}
-              tagsTree={tagsTree}
+              appliedContentTagsTree={appliedContentTagsTree}
+              stagedContentTagsTree={stagedContentTagsTree}
               searchTerm={searchTerm}
             />
           )}
@@ -197,7 +215,13 @@ ContentTagsDropDownSelector.propTypes = {
   taxonomyId: PropTypes.number.isRequired,
   level: PropTypes.number.isRequired,
   lineage: PropTypes.arrayOf(PropTypes.string),
-  tagsTree: PropTypes.objectOf(
+  appliedContentTagsTree: PropTypes.objectOf(
+    PropTypes.shape({
+      explicit: PropTypes.bool.isRequired,
+      children: PropTypes.shape({}).isRequired,
+    }).isRequired,
+  ).isRequired,
+  stagedContentTagsTree: PropTypes.objectOf(
     PropTypes.shape({
       explicit: PropTypes.bool.isRequired,
       children: PropTypes.shape({}).isRequired,

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -10,7 +10,6 @@ import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { ArrowDropDown, ArrowDropUp } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 import messages from './messages';
-import './ContentTagsDropDownSelector.scss';
 
 import { useTaxonomyTagsData } from './data/apiHooks';
 

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.scss
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.scss
@@ -4,6 +4,11 @@
 
 .taxonomy-tags-load-more-button {
   flex: 1;
+
+  &:hover {
+    background-color: transparent;
+    color: $info-900 !important;
+  }
 }
 
 .pgn__selectable_box.taxonomy-tags-selectable-box {

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.scss
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.scss
@@ -9,6 +9,14 @@
 .pgn__selectable_box.taxonomy-tags-selectable-box {
   box-shadow: none;
   padding: 0;
+
+  // Override indeterminate [-] (implicit) checkbox styles to match checked checkbox styles
+  // In the future, this customizability should be implemented in paragon instead
+  input.pgn__form-checkbox-input {
+    &:indeterminate {
+      @extend :checked; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
+    }
+  }
 }
 
 .pgn__selectable_box.taxonomy-tags-selectable-box:disabled,

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
@@ -25,10 +25,12 @@ const data = {
   taxonomyId: 123,
   level: 0,
   tagsTree: {},
+  appliedContentTagsTree: {},
+  stagedContentTagsTree: {},
 };
 
 const ContentTagsDropDownSelectorComponent = ({
-  taxonomyId, level, lineage, tagsTree, searchTerm,
+  taxonomyId, level, lineage, tagsTree, searchTerm, appliedContentTagsTree, stagedContentTagsTree,
 }) => (
   <IntlProvider locale="en" messages={{}}>
     <ContentTagsDropDownSelector
@@ -37,6 +39,8 @@ const ContentTagsDropDownSelectorComponent = ({
       lineage={lineage}
       tagsTree={tagsTree}
       searchTerm={searchTerm}
+      appliedContentTagsTree={appliedContentTagsTree}
+      stagedContentTagsTree={stagedContentTagsTree}
     />
   </IntlProvider>
 );
@@ -53,15 +57,25 @@ describe('<ContentTagsDropDownSelector />', () => {
     jest.clearAllMocks();
   });
 
+  async function getComponent(updatedData) {
+    const componentData = (!updatedData ? data : updatedData);
+
+    return render(
+      <ContentTagsDropDownSelectorComponent
+        taxonomyId={componentData.taxonomyId}
+        level={componentData.level}
+        lineage={componentData.lineage}
+        tagsTree={componentData.tagsTree}
+        searchTerm={componentData.searchTerm}
+        appliedContentTagsTree={componentData.appliedContentTagsTree}
+        stagedContentTagsTree={componentData.stagedContentTagsTree}
+      />,
+    );
+  }
+
   it('should render taxonomy tags drop down selector loading with spinner', async () => {
     await act(async () => {
-      const { getByRole } = render(
-        <ContentTagsDropDownSelectorComponent
-          taxonomyId={data.taxonomyId}
-          level={data.level}
-          tagsTree={data.tagsTree}
-        />,
-      );
+      const { getByRole } = await getComponent();
       const spinner = getByRole('status');
       expect(spinner.textContent).toEqual('Loading tags'); // Uses <Spinner />
     });
@@ -86,14 +100,8 @@ describe('<ContentTagsDropDownSelector />', () => {
     });
 
     await act(async () => {
-      const { container, getByText } = render(
-        <ContentTagsDropDownSelectorComponent
-          key={`selector-${data.taxonomyId}`}
-          taxonomyId={data.taxonomyId}
-          level={data.level}
-          tagsTree={data.tagsTree}
-        />,
-      );
+      const { container, getByText } = await getComponent();
+
       await waitFor(() => {
         expect(getByText('Tag 1')).toBeInTheDocument();
         expect(container.getElementsByClassName('taxonomy-tags-arrow-drop-down').length).toBe(0);
@@ -120,13 +128,8 @@ describe('<ContentTagsDropDownSelector />', () => {
     });
 
     await act(async () => {
-      const { container, getByText } = render(
-        <ContentTagsDropDownSelectorComponent
-          taxonomyId={data.taxonomyId}
-          level={data.level}
-          tagsTree={data.tagsTree}
-        />,
-      );
+      const { container, getByText } = await getComponent();
+
       await waitFor(() => {
         expect(getByText('Tag 2')).toBeInTheDocument();
         expect(container.getElementsByClassName('taxonomy-tags-arrow-drop-down').length).toBe(1);
@@ -162,13 +165,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           },
         },
       };
-      const { container, getByText } = render(
-        <ContentTagsDropDownSelectorComponent
-          taxonomyId={dataWithTagsTree.taxonomyId}
-          level={dataWithTagsTree.level}
-          tagsTree={dataWithTagsTree.tagsTree}
-        />,
-      );
+      const { container, getByText } = await getComponent(dataWithTagsTree);
       await waitFor(() => {
         expect(getByText('Tag 2')).toBeInTheDocument();
         expect(container.getElementsByClassName('taxonomy-tags-arrow-drop-down').length).toBe(1);
@@ -230,13 +227,7 @@ describe('<ContentTagsDropDownSelector />', () => {
           },
         },
       };
-      const { container, getByText } = render(
-        <ContentTagsDropDownSelectorComponent
-          taxonomyId={dataWithTagsTree.taxonomyId}
-          level={dataWithTagsTree.level}
-          tagsTree={dataWithTagsTree.tagsTree}
-        />,
-      );
+      const { container, getByText } = await getComponent(dataWithTagsTree);
       await waitFor(() => {
         expect(getByText('Tag 2')).toBeInTheDocument();
         expect(container.getElementsByClassName('taxonomy-tags-arrow-drop-down').length).toBe(1);
@@ -291,15 +282,7 @@ describe('<ContentTagsDropDownSelector />', () => {
 
     const initalSearchTerm = 'test 1';
     await act(async () => {
-      const { rerender } = render(
-        <ContentTagsDropDownSelectorComponent
-          key={`selector-${data.taxonomyId}`}
-          taxonomyId={data.taxonomyId}
-          level={data.level}
-          tagsTree={data.tagsTree}
-          searchTerm={initalSearchTerm}
-        />,
-      );
+      const { rerender } = await getComponent({ ...data, searchTerm: initalSearchTerm });
 
       await waitFor(() => {
         expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, initalSearchTerm);
@@ -312,6 +295,8 @@ describe('<ContentTagsDropDownSelector />', () => {
         level={data.level}
         tagsTree={data.tagsTree}
         searchTerm={updatedSearchTerm}
+        appliedContentTagsTree={{}}
+        stagedContentTagsTree={{}}
       />);
 
       await waitFor(() => {
@@ -326,6 +311,8 @@ describe('<ContentTagsDropDownSelector />', () => {
         level={data.level}
         tagsTree={data.tagsTree}
         searchTerm={cleanSearchTerm}
+        appliedContentTagsTree={{}}
+        stagedContentTagsTree={{}}
       />);
 
       await waitFor(() => {
@@ -347,15 +334,7 @@ describe('<ContentTagsDropDownSelector />', () => {
 
     const searchTerm = 'uncommon search term';
     await act(async () => {
-      const { getByText } = render(
-        <ContentTagsDropDownSelectorComponent
-          key={`selector-${data.taxonomyId}`}
-          taxonomyId={data.taxonomyId}
-          level={data.level}
-          tagsTree={data.tagsTree}
-          searchTerm={searchTerm}
-        />,
-      );
+      const { getByText } = await getComponent({ ...data, searchTerm });
 
       await waitFor(() => {
         expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, searchTerm);

--- a/src/content-tags-drawer/TagBubble.jsx
+++ b/src/content-tags-drawer/TagBubble.jsx
@@ -14,7 +14,7 @@ const TagBubble = ({
 
   const handleClick = React.useCallback(() => {
     if (!implicit && canRemove) {
-      removeTagHandler(lineage.join(','), false);
+      removeTagHandler(lineage.join(','));
     }
   }, [implicit, lineage, canRemove, removeTagHandler]);
 

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -33,9 +33,13 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.selectable-box.selection.aria.label',
     defaultMessage: 'taxonomy tags selection',
   },
+  collapsibleAddTagsPlaceholderText: {
+    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.placeholder-text',
+    defaultMessage: 'Add a tag',
+  },
   collapsibleAddStagedTagsButtonText: {
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.save-staged-tags',
-    defaultMessage: 'Add',
+    defaultMessage: 'Add tags',
   },
   collapsibleCancelStagedTagsButtonText: {
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.cancel-staged-tags',

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -33,6 +33,14 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.selectable-box.selection.aria.label',
     defaultMessage: 'taxonomy tags selection',
   },
+  collapsibleAddStagedTagsButtonText: {
+    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.save-staged-tags',
+    defaultMessage: 'Add',
+  },
+  collapsibleCancelStagedTagsButtonText: {
+    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.cancel-staged-tags',
+    defaultMessage: 'Cancel',
+  },
 });
 
 export default messages;

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -45,6 +45,10 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.cancel-staged-tags',
     defaultMessage: 'Cancel',
   },
+  collapsibleInlineAddStagedTagsButtonText: {
+    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.inline-save-staged-tags',
+    defaultMessage: 'Add',
+  },
 });
 
 export default messages;

--- a/src/index.scss
+++ b/src/index.scss
@@ -24,3 +24,4 @@
 @import "course-unit/CourseUnit";
 @import "course-checklist/CourseChecklist";
 @import "content-tags-drawer/ContentTagsDropDownSelector";
+@import "content-tags-drawer/ContentTagsCollapsible";

--- a/src/index.scss
+++ b/src/index.scss
@@ -23,3 +23,4 @@
 @import "course-outline/CourseOutline";
 @import "course-unit/CourseUnit";
 @import "course-checklist/CourseChecklist";
+@import "content-tags-drawer/ContentTagsDropDownSelector";


### PR DESCRIPTION
## Description

This PR add the new "Add Tags" widget. Which separates out staging tags when checking them and committing (saving) them. 

![add-tags-widget](https://github.com/openedx/frontend-app-course-authoring/assets/6829768/f976e9c3-5822-41bd-979f-adc8e91416fd)

## Supporting information

Related Tickets:
- Closes https://github.com/openedx/modular-learning/issues/188

## Testing instructions

1. Run you local dev stack.
1. If you don't already have sample taxonomy/tags data, follow the instructions in this repo to generate sample data: https://github.com/open-craft/taxonomy-sample-data
1. Navigate to a sample course and open the tags drawer by clicking on "Manage Tags"
1. Expand some taxonomies and click on the "Add a Tag" select input
1. Confirm the following:
    1. When checking tags in the dropdown, it keeps track of which tags are being newly added (staged). If you presse cancel, no changes are made. If press "Add Tags", the new tags are saved
    1. Newly added tags appear as chips in the add tags field, and can be removed by clicking on their X.
    1. Existing tags (already applied) that were added before the user clicks "Add Tags" do not appear as chips in the "Add Tags" widget.
    1. You can type into the widget to search the tags by keyword
    1. The functionality from https://github.com/openedx/frontend-app-course-authoring/pull/799 still exists. i.e matches are highlighted, parent tags are expanded but only if their child/grandchild matches the search, and a message is displayed if there are no matching tags.
    1. You can continue to type to search/filter tags even when there are chips displayed inside the field.
    1. Very long tag names wrap to the next line; they are not truncated.
    1. "Load More" is only shown if there are more pages of tags and is updated with the new style
    1. The styling of checkboxes of implicit tags has changed. Instead of a dash, it is now a checkmark (the transparency remains the same i.e. 40% opacity).
    1. The inline "Add" button is only shown if there is at least one newly added tag/chip visible.
    1. The second "Add Tags" button at the bottom of the dropdown is disabled until/unless there is at least one newly added tag/chip visible.
    1. The dropdown is shown when the "Add Tags" search box or the dropdown itself has focus. If the user clicks off the dropdown onto somewhere else on the tagging drawer, the dropdown will close but the chips will remain in the box and the tags won't be added until/unless the user clicks "Add Tags".
    1. If the user selects "cancel" on the dropdown menu, their selections (i.e. chips) are forgotten and the select menu is closed.
    1. Existing (previously saved) tags are shown as disabled checkmarks and cannot be removed using the checkboxes in the dropdown "Add Tags" widget. Instead, users click on the (X) next to them to remove them. But newly-added tags (that appear as chips) can be undone by un-checking them in the tag tree dropdown. This is the same as clicking the X on the chip.
---
Private-ref: [FAL-3643](https://tasks.opencraft.com/browse/FAL-3643)