### PR TITLE
feat: [FC-0044] Course unit page - Modal windows for course unit page components

### DIFF
--- a/src/course-unit/add-component/AddComponent.test.jsx
+++ b/src/course-unit/add-component/AddComponent.test.jsx
@@ -169,11 +169,11 @@ describe('<AddComponent />', () => {
   it('creates new "Library" xblock on click', () => {
     const { getByRole } = renderComponent();
 
-    const discussionButton = getByRole('button', {
+    const libraryButton = getByRole('button', {
       name: new RegExp(`${messages.buttonText.defaultMessage} Library Content`, 'i'),
     });
 
-    userEvent.click(discussionButton);
+    userEvent.click(libraryButton);
     expect(handleCreateNewCourseXBlockMock).toHaveBeenCalled();
     expect(handleCreateNewCourseXBlockMock).toHaveBeenCalledWith({
       parentLocator: '123',
@@ -293,11 +293,11 @@ describe('<AddComponent />', () => {
 
   it('verifies "Text" component creation and submission in modal', () => {
     const { getByRole } = renderComponent();
-    const advancedButton = getByRole('button', {
+    const textButton = getByRole('button', {
       name: new RegExp(`${messages.buttonText.defaultMessage} Text`, 'i'),
     });
 
-    userEvent.click(advancedButton);
+    userEvent.click(textButton);
     const modalContainer = getByRole('dialog');
 
     const radioInput = within(modalContainer).getByRole('radio', { name: 'Text' });
@@ -319,11 +319,11 @@ describe('<AddComponent />', () => {
 
   it('verifies "Open Response" component creation and submission in modal', () => {
     const { getByRole } = renderComponent();
-    const advancedButton = getByRole('button', {
+    const openResponseButton = getByRole('button', {
       name: new RegExp(`${messages.buttonText.defaultMessage} Open Response`, 'i'),
     });
 
-    userEvent.click(advancedButton);
+    userEvent.click(openResponseButton);
     const modalContainer = getByRole('dialog');
 
     const radioInput = within(modalContainer).getByRole('radio', { name: 'Peer Assessment Only' });


### PR DESCRIPTION
**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```

### Description

This pull request adds functionality to display modal windows for the Add component block.

The primary features were implemented:
- Added modals for: Open Response, Advanced components and Text buttons.

**Issue:** https://github.com/openedx/platform-roadmap/issues/321

### Developer notes
- Current changes to the module switching widget are in preparation for the final changes to replace the LMS endpoints.
- In the upcoming pull request, the LMS endpoints of the MFE Learning will be substituted with distinct and independent endpoints from the CMS.
- After the [associated pull request](https://github.com/openedx/frontend-app-course-authoring/pull/831) is merged, the first two commits from that pull request will be deleted.

### Design
[Figma design](https://www.figma.com/file/YeKFwSpyLaJFDs3f3p3TSa/Studio-1%3A1-mock-ups?type=design&node-id=599-23595&mode=design&t=icsTrD5n70NSEnND-0)

<img width="605" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/93188219/5ad6a1a9-0b66-4193-94b2-a147273b0bc5">

### Testing instructions
1. Run master devstack.
2. Start platform make dev.up.lms+cms+frontend-app-course-authoring and make checkout on this branch.
3. Enable the new Unit page by adding a waffle flag `contentstore.new_studio_mfe.use_new_unit_page` in the CMS admin panel.
4. Make sure that the MFE setting `ENABLE_UNIT_PAGE=true` is enabled.
5. Go to the Course Unit page from the Course Outline page.
6. Make sure the course you are viewing is not outdated.
7. Publish all sections on the Course Outline page.
8. Open the legacy page of the current unit.
9. After click on each of the working buttons (Open Response, Advanced components and Text), a modal window opens with xblock template options.
10. The added xblock is displayed on the legacy page of the current unit.