### PR TITLE
fix: show the "+ New Library" button

### DIFF
--- a/src/studio-home/StudioHome.jsx
+++ b/src/studio-home/StudioHome.jsx
@@ -42,7 +42,6 @@ const StudioHome = ({ intl }) => {
     studioRequestEmail,
     libraryAuthoringMfeUrl,
     redirectToLibraryAuthoringMfe,
-    splitStudioHome,
   } = studioHomeData;
 
   function getHeaderButtons() {
@@ -68,25 +67,23 @@ const StudioHome = ({ intl }) => {
       );
     }
 
-    let libraryHref = `${getConfig().STUDIO_BASE_URL}/home#libraries-tab`;
-    if (splitStudioHome) {
-      libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
-    }
+    let libraryHref = `${getConfig().STUDIO_BASE_URL}/home_library`;
     if (redirectToLibraryAuthoringMfe) {
       libraryHref = `${libraryAuthoringMfeUrl}/create`;
-      headerButtons.push(
-        <Button
-          variant="outline-primary"
-          iconBefore={AddIcon}
-          size="sm"
-          disabled={showNewCourseContainer}
-          href={libraryHref}
-          data-testid="new-library-button"
-        >
-          {intl.formatMessage(messages.addNewLibraryBtnText)}
-        </Button>,
-      );
     }
+
+    headerButtons.push(
+      <Button
+        variant="outline-primary"
+        iconBefore={AddIcon}
+        size="sm"
+        disabled={showNewCourseContainer}
+        href={libraryHref}
+        data-testid="new-library-button"
+      >
+        {intl.formatMessage(messages.addNewLibraryBtnText)}
+      </Button>,
+    );
 
     return headerButtons;
   }

--- a/src/studio-home/StudioHome.test.jsx
+++ b/src/studio-home/StudioHome.test.jsx
@@ -116,15 +116,16 @@ describe('<StudioHome />', async () => {
   });
 
   describe('render new library button', () => {
-    it('should not show button', async () => {
+    it('href should include home_library', async () => {
       useSelector.mockReturnValue({
         ...studioHomeMock,
         courseCreatorStatus: COURSE_CREATOR_STATES.granted,
       });
+      const studioBaseUrl = 'http://localhost:18010';
 
-      const { queryByTestId } = render(<RootWrapper />);
-      const createNewLibraryButton = queryByTestId('new-library-button');
-      expect(createNewLibraryButton).toBeNull();
+      const { getByTestId } = render(<RootWrapper />);
+      const createNewLibraryButton = getByTestId('new-library-button');
+      expect(createNewLibraryButton.getAttribute('href')).toBe(`${studioBaseUrl}/home_library`);
     });
     it('href should include create', async () => {
       useSelector.mockReturnValue({


### PR DESCRIPTION
## Description

**This is a backport from master** https://github.com/openedx/frontend-app-course-authoring/pull/710

The "+ New Library" button is absent on the Course Home Page if the Library Authoring MFE is not installed/configured. 
These changes allow usage of the URL to the legacy libraries page.

Before:
<img width="1570" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/47273130/653c3ea5-266e-41a2-a690-8868a4725037">

After:
<img width="1584" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/47273130/63ad3b09-901f-44ec-8027-a670bb5c04c8">

