### PR TITLE
feat: [FC-0044] Unit page - display xblock components

### DIFF
--- a/src/course-unit/CourseUnit.test.jsx
+++ b/src/course-unit/CourseUnit.test.jsx
@@ -95,14 +95,15 @@ describe('<CourseUnit />', () => {
   });
 
   it('render CourseUnit component correctly', async () => {
-    const { getByText, getByRole } = render(<RootWrapper />);
+    const { getByText, getByRole, getByTestId } = render(<RootWrapper />);
     const currentSectionName = courseUnitIndexMock.ancestor_info.ancestors[1].display_name;
     const currentSubSectionName = courseUnitIndexMock.ancestor_info.ancestors[1].display_name;
 
     await waitFor(() => {
+      const unitHeaderTitle = getByTestId('unit-header-title');
       expect(getByText(unitDisplayName)).toBeInTheDocument();
-      expect(getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage })).toBeInTheDocument();
-      expect(getByRole('button', { name: headerTitleMessages.altButtonSettings.defaultMessage })).toBeInTheDocument();
+      expect(within(unitHeaderTitle).getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage })).toBeInTheDocument();
+      expect(within(unitHeaderTitle).getByRole('button', { name: headerTitleMessages.altButtonSettings.defaultMessage })).toBeInTheDocument();
       expect(getByRole('button', { name: headerNavigationsMessages.viewLiveButton.defaultMessage })).toBeInTheDocument();
       expect(getByRole('button', { name: headerNavigationsMessages.previewButton.defaultMessage })).toBeInTheDocument();
       expect(getByRole('button', { name: currentSectionName })).toBeInTheDocument();
@@ -136,7 +137,10 @@ describe('<CourseUnit />', () => {
 
   it('checks courseUnit title changing when edit query is successfully', async () => {
     const {
-      findByText, queryByRole, getByRole,
+      findByText,
+      queryByRole,
+      getByRole,
+      getByTestId,
     } = render(<RootWrapper />);
     let editTitleButton = null;
     let titleEditField = null;
@@ -160,8 +164,11 @@ describe('<CourseUnit />', () => {
       });
 
     await waitFor(() => {
-      editTitleButton = getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage });
-      titleEditField = queryByRole('textbox', { name: headerTitleMessages.ariaLabelButtonEdit.defaultMessage });
+      const unitHeaderTitle = getByTestId('unit-header-title');
+      editTitleButton = within(unitHeaderTitle)
+        .getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage });
+      titleEditField = within(unitHeaderTitle)
+        .queryByRole('textbox', { name: headerTitleMessages.ariaLabelButtonEdit.defaultMessage });
     });
     expect(titleEditField).not.toBeInTheDocument();
     fireEvent.click(editTitleButton);
@@ -299,7 +306,7 @@ describe('<CourseUnit />', () => {
   });
 
   it('the sequence unit is updated after changing the unit header', async () => {
-    const { getAllByTestId, getByRole } = render(<RootWrapper />);
+    const { getAllByTestId, getByTestId } = render(<RootWrapper />);
     const updatedCourseSectionVerticalData = cloneDeep(courseSectionVerticalMock);
     const updatedAncestorsChild = updatedCourseSectionVerticalData.xblock_info.ancestor_info.ancestors[0];
     set(updatedCourseSectionVerticalData, 'xblock_info.ancestor_info.ancestors[0].child_info.children', [
@@ -331,10 +338,12 @@ describe('<CourseUnit />', () => {
 
     await executeThunk(fetchCourseSectionVerticalData(blockId), store.dispatch);
 
-    const editTitleButton = getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage });
+    const unitHeaderTitle = getByTestId('unit-header-title');
+
+    const editTitleButton = within(unitHeaderTitle).getByRole('button', { name: headerTitleMessages.altButtonEdit.defaultMessage });
     fireEvent.click(editTitleButton);
 
-    const titleEditField = getByRole('textbox', { name: headerTitleMessages.ariaLabelButtonEdit.defaultMessage });
+    const titleEditField = within(unitHeaderTitle).getByRole('textbox', { name: headerTitleMessages.ariaLabelButtonEdit.defaultMessage });
     fireEvent.change(titleEditField, { target: { value: newDisplayName } });
 
     await act(async () => fireEvent.blur(titleEditField));

--- a/src/course-unit/course-xblock/messages.js
+++ b/src/course-unit/course-xblock/messages.js
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   blockAltButtonEdit: {
     id: 'course-authoring.course-unit.xblock.button.edit.alt',
-    defaultMessage: 'Edit Item',
+    defaultMessage: 'Edit',
   },
   blockActionsDropdownAlt: {
     id: 'course-authoring.course-unit.xblock.button.actions.alt',

--- a/src/course-unit/header-title/HeaderTitle.jsx
+++ b/src/course-unit/header-title/HeaderTitle.jsx
@@ -27,7 +27,7 @@ const HeaderTitle = ({
   }, [unitTitle]);
 
   return (
-    <div className="d-flex align-items-center lead">
+    <div className="d-flex align-items-center lead" data-testid="unit-header-title">
       {isTitleEditFormOpen ? (
         <Form.Group className="m-0">
           <Form.Control
@@ -55,7 +55,8 @@ const HeaderTitle = ({
         alt={intl.formatMessage(messages.altButtonSettings)}
         className="flex-shrink-0"
         iconAs={SettingsIcon}
-        onClick={() => {}}
+        onClick={() => {
+        }}
       />
     </div>
   );


### PR DESCRIPTION
**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/raccoongang/edx-platform.git
EDX_PLATFORM_VERSION: ruzniaievdm/feat/unit-children

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true
  - name: new_core_editors.use_new_problem_editor
    everyone: true
  - name: new_core_editors.use_new_video_editor
    everyone: true
  - name: new_core_editors.use_new_text_editor
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
    ENABLE_NEW_EDITOR_PAGES: true
```

### Description
This merge request introduces a new feature that enhances page rendering by incorporating dynamic components. The key components include:

**Component Header:**
- Title: Displays the title of the xblock.
- Edit Button: Allows users to edit the xblock.
- Dropdown Menu: Provides a dropdown menu with various actions for additional functionalities like copy, duplicate, move, manage access and delete.

**Component Content:**
As a first iteration, xblock content is displayed as a placeholder block. The next iteration will change the rendering of the content by displaying HTML and resources received from the legacy endpoint (not using an iframe).

Issue: https://github.com/openedx/platform-roadmap/issues/321

### Depends on:
- https://github.com/openedx/edx-platform/pull/34055

### Design
https://www.figma.com/file/YeKFwSpyLaJFDs3f3p3TSa/Studio-1%3A1-mock-ups?node-id=599%3A23595

<img width="682" alt="Screenshot at Feb 28 16-54-29" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/fe4ba85a-6f26-4717-9c66-a2cd43e0ef2b">

### Testing instructions
1. Run master devstack.
2. Start platform make dev.up.lms+cms+frontend-app-course-authoring and make checkout on this branch.
3. Enable new Unit page by adding a waffle flad `contentstore.new_studio_mfe.use_new_unit_page` in CMS admin panel.
4. Go to Course Unit page from the Course Outline page.
5. Make sure the course you are viewing is not outdated.
6. Publish all sections on the Course Outline page.