### PR TITLE
fix: correct the group configuration link in the header dropdown

### DIFF
--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -44,7 +44,7 @@ export const getSettingMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
     title: intl.formatMessage(messages['header.links.courseTeam']),
   },
   {
-    href: `${studioBaseUrl}/group_configurations/course-v1:${courseId}`,
+    href: `${studioBaseUrl}/group_configurations/${courseId}`,
     title: intl.formatMessage(messages['header.links.groupConfigurations']),
   },
   {


### PR DESCRIPTION
This is a backport of the master branch fix: https://github.com/openedx/frontend-app-course-authoring/pull/687

Remove the duplicated `course-v1` prefix from the URL.

