### PR TITLE
fix: Incorrect redirect link to Pages & Resources from pages within Course Authoring MFE

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -95,12 +95,31 @@ export function parseArrayOrObjectValues(obj) {
   return result;
 }
 
+/**
+ * Create a correct inner path depend on config PUBLIC_PATH.
+ * @param {string} checkPath - the internal route path that is validated
+ * @returns {string} - the correct internal route path
+ */
+export const createCorrectInternalRoute = (checkPath) => {
+  let basePath = getPath(getConfig().PUBLIC_PATH);
+
+  if (basePath.endsWith('/')) {
+    basePath = basePath.slice(0, -1);
+  }
+
+  if (!checkPath.startsWith(basePath)) {
+    return `${basePath}${checkPath}`;
+  }
+
+  return checkPath;
+};
+
 export function getPagePath(courseId, isMfePageEnabled, urlParameter) {
   if (isMfePageEnabled === 'true') {
     if (urlParameter === 'tabs') {
-      return `${getConfig().BASE_URL}/course/${courseId}/pages-and-resources`;
+      return createCorrectInternalRoute(`/course/${courseId}/pages-and-resources`);
     }
-    return `${getConfig().BASE_URL}/course/${courseId}/${urlParameter}`;
+    return createCorrectInternalRoute(`/course/${courseId}/${urlParameter}`);
   }
   return `${getConfig().STUDIO_BASE_URL}/${urlParameter}/${courseId}`;
 }
@@ -267,23 +286,4 @@ export const getFileSizeToClosestByte = (fileSize) => {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   const fileSizeFixedDecimal = Number.parseFloat(size).toFixed(2);
   return `${fileSizeFixedDecimal} ${units[divides]}`;
-};
-
-/**
- * Create a correct inner path depend on config PUBLIC_PATH.
- * @param {string} checkPath - the internal route path that is validated
- * @returns {string} - the correct internal route path
- */
-export const createCorrectInternalRoute = (checkPath) => {
-  let basePath = getPath(getConfig().PUBLIC_PATH);
-
-  if (basePath.endsWith('/')) {
-    basePath = basePath.slice(0, -1);
-  }
-
-  if (!checkPath.startsWith(basePath)) {
-    return `${basePath}${checkPath}`;
-  }
-
-  return checkPath;
 };


### PR DESCRIPTION
## Description
The Content dropdown items have incorrect URLs for the
internal routing when MFEs are deployed using the common
domain and the PUBLIC_PATH.

## Steps to reproduce
1. Open any MFE page for the studio, e.g. Files and Uploads
2. Use the "Content" dropdown in the header to navigate to the "Pages and Resources" page ![image](https://github.com/openedx/frontend-app-course-authoring/assets/47273130/7b6e3676-44e1-4cdb-9b29-c308f1373de8)
3. Observe the result

## Actual result (before the fix)
Incorrect routing - the URL is threaded as a relative one.
![image](https://github.com/openedx/frontend-app-course-authoring/assets/47273130/3630fe41-eb8e-4b63-aeee-52d59903fb4c)

## Expected result (after the fix)
Pages and Resources page is opened correctly
![image](https://github.com/openedx/frontend-app-course-authoring/assets/47273130/4c183fed-8658-472d-85ec-767d7a65bb5d)

## Notes
- the issue can't be reproduced on the devstack because it doesn't use PUBLIC_PATH for MFEs 
- related issue: https://github.com/openedx/frontend-app-course-authoring/issues/865
- related backport PR for Quince: https://github.com/openedx/frontend-app-course-authoring/pull/864