### PR TITLE
[FC-0036] feat: Make tags widget keyboard accessible

### DIFF
--- a/src/content-tags-drawer/ContentTagsCollapsible.d.ts
+++ b/src/content-tags-drawer/ContentTagsCollapsible.d.ts
@@ -1,3 +1,4 @@
+import { Ref } from 'react';
 import type {} from 'react-select/base';
 // This import is necessary for module augmentation.
 // It allows us to extend the 'Props' interface in the 'react-select/base' module
@@ -16,6 +17,9 @@ export interface TaxonomySelectProps {
     appliedContentTagsTree: Record<string, TagTreeEntry>;
     stagedContentTagsTree: Record<string, TagTreeEntry>;
     checkedTags: string[];
+    selectCancelRef: Ref,
+    selectAddRef: Ref,
+    selectInlineAddRef: Ref,
     handleCommitStagedTags: () => void;
     handleCancelStagedTags: () => void;
     handleSelectableBoxChange: React.ChangeEventHandler;

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -97,6 +97,13 @@ const CustomMenu = (props) => {
   );
 };
 
+const disableActionKeys = (e) => {
+  const arrowKeys = ['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'Backspace'];
+  if (arrowKeys.includes(e.code)) {
+    e.preventDefault();
+  }
+};
+
 const CustomLoadingIndicator = () => {
   const intl = useIntl();
   return (
@@ -131,6 +138,7 @@ const CustomIndicatorsContainer = (props) => {
             onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
             ref={selectInlineAddRef}
             tabIndex="0"
+            onKeyDown={disableActionKeys} // To prevent navigating staged tags when button focused
           >
             { intl.formatMessage(messages.collapsibleInlineAddStagedTagsButtonText) }
           </Button>

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -351,6 +351,13 @@ const ContentTagsCollapsible = ({
     setSearchTerm('');
   }, [setSelectMenuIsOpen, setSearchTerm]);
 
+  // Handles logic to close the select menu when clicking outside
+  const handleOnBlur = React.useCallback((event) => {
+    if (!event.relatedTarget || !event.relatedTarget.className?.includes('dropdown-selector')) {
+      setSelectMenuIsOpen(false);
+    }
+  }, [setSelectMenuIsOpen]);
+
   return (
     <div className="d-flex">
       <Collapsible title={name} styling="card-lg" className="taxonomy-tags-collapsible">
@@ -362,6 +369,7 @@ const ContentTagsCollapsible = ({
 
           {canTagObject && (
             <Select
+              onBlur={handleOnBlur}
               styles={{
                 // Overriding 'x' button styles for staged tags when navigating by keyboard
                 multiValueRemove: (base, state) => ({

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -337,8 +337,9 @@ const ContentTagsCollapsible = ({
         } else if (focusedElement === selectCancelRef.current && selectAddRef.current?.disabled) {
           setSelectMenuIsOpen(false);
         }
-        // Navigating backwards
-      } else if (event.shiftKey && focusedElement.classList.contains('react-select-add-tags__input')) {
+      // Navigating backwards
+      // @ts-ignore inputRef actually exists under the current selectRef
+      } else if (event.shiftKey && focusedElement === selectRef.current?.inputRef) {
         setSelectMenuIsOpen(false);
       }
     }

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -286,7 +286,7 @@ const ContentTagsCollapsible = ({
         handleSearch(value);
       }
     }
-  }, []);
+  }, [selectMenuIsOpen, setSearchTerm, handleSearch]);
 
   // onChange handler for react-select component, currently only called when
   // staged tags in the react-select input are removed or fully cleared.
@@ -344,6 +344,12 @@ const ContentTagsCollapsible = ({
     }
   };
 
+  // Open the select menu and make sure the search term is cleared when focused
+  const onSelectMenuFocus = React.useCallback(() => {
+    setSelectMenuIsOpen(true);
+    setSearchTerm('');
+  }, [setSelectMenuIsOpen, setSearchTerm]);
+
   return (
     <div className="d-flex">
       <Collapsible title={name} styling="card-lg" className="taxonomy-tags-collapsible">
@@ -356,7 +362,7 @@ const ContentTagsCollapsible = ({
           {canTagObject && (
             <Select
               menuIsOpen={selectMenuIsOpen} // FIX: The menu currently does not close when clicking outside
-              onFocus={() => setSelectMenuIsOpen(true)}
+              onFocus={onSelectMenuFocus}
               onKeyDown={handleSelectOnKeyDown}
               ref={/** @type {React.RefObject} */(selectRef)}
               isMulti

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -362,6 +362,14 @@ const ContentTagsCollapsible = ({
 
           {canTagObject && (
             <Select
+              styles={{
+                // Overriding 'x' button styles for staged tags when navigating by keyboard
+                multiValueRemove: (base, state) => ({
+                  ...base,
+                  background: state.isFocused ? 'black' : base.background,
+                  color: state.isFocused ? 'white' : base.color,
+                }),
+              }}
               menuIsOpen={selectMenuIsOpen} // FIX: The menu currently does not close when clicking outside
               onFocus={onSelectMenuFocus}
               onKeyDown={handleSelectOnKeyDown}

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -58,6 +58,7 @@ const CustomMenu = (props) => {
           className="taxonomy-tags-selectable-box-set"
           onChange={handleSelectableBoxChange}
           value={checkedTags}
+          tabIndex="-1"
         >
           <ContentTagsDropDownSelector
             key={`selector-${taxonomyId}`}
@@ -133,7 +134,7 @@ const CustomIndicatorsContainer = (props) => {
           <Button
             variant="dark"
             size="sm"
-            className="mt-2 mb-2 rounded-0"
+            className="mt-2 mb-2 rounded-0 inline-add-button"
             onClick={handleCommitStagedTags}
             onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
             ref={selectInlineAddRef}
@@ -353,7 +354,9 @@ const ContentTagsCollapsible = ({
 
   // Handles logic to close the select menu when clicking outside
   const handleOnBlur = React.useCallback((event) => {
-    if (!event.relatedTarget || !event.relatedTarget.className?.includes('dropdown-selector')) {
+    // Check if a target we are focusing to is an element in our select menu, if not close it
+    const menuClasses = ['dropdown-selector', 'inline-add-button', 'cancel-add-tags-button'];
+    if (!event.relatedTarget || !menuClasses.some(cls => event.relatedTarget.className?.includes(cls))) {
       setSelectMenuIsOpen(false);
     }
   }, [setSelectMenuIsOpen]);
@@ -378,7 +381,7 @@ const ContentTagsCollapsible = ({
                   color: state.isFocused ? 'white' : base.color,
                 }),
               }}
-              menuIsOpen={selectMenuIsOpen} // FIX: The menu currently does not close when clicking outside
+              menuIsOpen={selectMenuIsOpen}
               onFocus={onSelectMenuFocus}
               onKeyDown={handleSelectOnKeyDown}
               ref={/** @type {React.RefObject} */(selectRef)}

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -118,8 +118,8 @@ const ContentTagsDropDownSelector = ({
     setNumPages((x) => x + 1);
   }, []);
 
-  const handleKeyBoardNav = (e) => {
-    const keyPressed = e.key;
+  const handleKeyBoardNav = (e, hasChildren) => {
+    const keyPressed = e.code;
     const currentElement = e.target;
     const encapsulator = currentElement.closest('.dropdown-selector-tag-encapsulator');
 
@@ -130,14 +130,15 @@ const ContentTagsDropDownSelector = ({
     tagValue = tagValue ? decodeURIComponent(tagValue) : tagValue;
 
     if (keyPressed === 'ArrowRight') {
+      e.preventDefault();
       if (tagValue && !isOpen(tagValue)) {
         clickAndEnterHandler(tagValue);
       }
     } else if (keyPressed === 'ArrowLeft') {
+      e.preventDefault();
       if (tagValue && isOpen(tagValue)) {
         clickAndEnterHandler(tagValue);
       }
-      // TODO: Implement remaining cases when left key pressed
     } else if (keyPressed === 'ArrowUp') {
       const prevSubTags = encapsulator?.previousElementSibling?.querySelectorAll('.dropdown-selector-tag-actions');
       const prevSubTag = prevSubTags && prevSubTags[prevSubTags.length - 1];
@@ -153,7 +154,6 @@ const ContentTagsDropDownSelector = ({
         // Handles case of jumping out of subtags to previous parent tag
         const prevParentTagEncapsulator = encapsulator?.parentNode.closest('.dropdown-selector-tag-encapsulator');
         const prevParentTag = prevParentTagEncapsulator?.querySelector('.dropdown-selector-tag-actions');
-
         prevParentTag?.focus();
       }
     } else if (keyPressed === 'ArrowDown') {
@@ -185,9 +185,17 @@ const ContentTagsDropDownSelector = ({
         }
       }
     } else if (keyPressed === 'Enter') {
-      // TODO: Implement
+      e.preventDefault();
+      if (hasChildren && tagValue) {
+        clickAndEnterHandler(tagValue);
+      } else {
+        const checkbox = currentElement.querySelector('.taxonomy-tags-selectable-box');
+        checkbox.click();
+      }
     } else if (keyPressed === 'Space') {
-      // TODO: Implmenet
+      e.preventDefault();
+      const checkbox = currentElement.querySelector('.taxonomy-tags-selectable-box');
+      checkbox.click();
     }
   };
 
@@ -216,7 +224,7 @@ const ContentTagsDropDownSelector = ({
             <div
               className="d-flex dropdown-selector-tag-actions"
               tabIndex={i === 0 && level === 0 ? 0 : -1} // Only enable tab into top of dropdown to set focus
-              onKeyDown={handleKeyBoardNav}
+              onKeyDown={(e) => handleKeyBoardNav(e, tagData.childCount > 0)}
             >
               <SelectableBox
                 inputHidden={false}

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -218,7 +218,7 @@ const ContentTagsDropDownSelector = ({
       {tagPages.isError ? 'Error...' : null /* TODO: show a proper error message */}
 
       {tagPages.data?.map((tagData, i) => (
-        <div key={tagData.value} className="dropdown-selector-tag-encapsulator">
+        <div key={tagData.value} className="mt-1 ml-1 dropdown-selector-tag-encapsulator">
           <div
             className="d-flex flex-row"
             style={{
@@ -281,7 +281,7 @@ const ContentTagsDropDownSelector = ({
               variant="tertiary"
               iconBefore={Add}
               onClick={loadMoreTags}
-              className="mb-2 taxonomy-tags-load-more-button px-0 text-info-500"
+              className="mb-2 ml-1 taxonomy-tags-load-more-button px-0 text-info-500"
             >
               <FormattedMessage {...messages.loadMoreTagsButtonText} />
             </Button>

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -118,6 +118,38 @@ const ContentTagsDropDownSelector = ({
     setNumPages((x) => x + 1);
   }, []);
 
+  const handleKeyBoardNav = (e) => {
+    const keyPressed = e.key;
+    const currentElement = e.target;
+    const encapsulator = currentElement.closest('.dropdown-selector-tag-encapsulator');
+
+    let tagValue = currentElement.querySelector('.pgn__form-checkbox-input')?.value;
+    tagValue = tagValue ? decodeURIComponent(tagValue) : tagValue;
+
+    if (keyPressed === 'ArrowRight') {
+      if (tagValue && !isOpen(tagValue)) {
+        clickAndEnterHandler(tagValue);
+      }
+    } else if (keyPressed === 'ArrowLeft') {
+      if (tagValue && isOpen(tagValue)) {
+        clickAndEnterHandler(tagValue);
+      }
+      // TODO: Implement remaining cases when left key pressed
+    } else if (keyPressed === 'ArrowUp') {
+      const prevTag = encapsulator?.previousElementSibling?.querySelector('.dropdown-selector-tag-actions');
+      prevTag?.focus();
+      // TODO: Implement navigating inside sub tags
+    } else if (keyPressed === 'ArrowDown') {
+      const nextTag = encapsulator?.nextElementSibling?.querySelector('.dropdown-selector-tag-actions');
+      nextTag?.focus();
+      // TODO: Implement navigating inside sub tags
+    } else if (keyPressed === 'Enter') {
+      // TODO: Implement
+    } else if (keyPressed === 'Space') {
+      // TODO: Implmenet
+    }
+  };
+
   return (
     <div style={{ marginLeft: `${level * 1 }rem` }}>
       {tagPages.isLoading ? (
@@ -131,15 +163,20 @@ const ContentTagsDropDownSelector = ({
       ) : null }
       {tagPages.isError ? 'Error...' : null /* TODO: show a proper error message */}
 
-      {tagPages.data?.map((tagData) => (
-        <React.Fragment key={tagData.value}>
+      {tagPages.data?.map((tagData, i) => (
+        <div key={tagData.value} className="dropdown-selector-tag-encapsulator">
           <div
             className="d-flex flex-row"
             style={{
               minHeight: '44px',
             }}
           >
-            <div className="d-flex">
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+            <div
+              className="d-flex dropdown-selector-tag-actions"
+              tabIndex={i === 0 && level === 0 ? 0 : -1} // Only enable tab into top of dropdown to set focus
+              onKeyDown={handleKeyBoardNav}
+            >
               <SelectableBox
                 inputHidden={false}
                 type="checkbox"
@@ -149,6 +186,7 @@ const ContentTagsDropDownSelector = ({
                 value={[...lineage, tagData.value].map(t => encodeURIComponent(t)).join(',')}
                 isIndeterminate={isApplied(tagData) || isImplicit(tagData)}
                 disabled={isApplied(tagData) || isImplicit(tagData)}
+                tabIndex="-1"
               >
                 <HighlightedText text={tagData.value} highlight={searchTerm} />
               </SelectableBox>
@@ -158,7 +196,7 @@ const ContentTagsDropDownSelector = ({
                     <Icon
                       src={isOpen(tagData.value) ? ArrowDropUp : ArrowDropDown}
                       onClick={() => clickAndEnterHandler(tagData.value)}
-                      tabIndex="0"
+                      tabIndex="-1"
                       onKeyPress={(event) => (event.key === 'Enter' ? clickAndEnterHandler(tagData.value) : null)}
                     />
                   </div>
@@ -178,13 +216,14 @@ const ContentTagsDropDownSelector = ({
             />
           )}
 
-        </React.Fragment>
+        </div>
       ))}
 
       { hasMorePages
         ? (
           <div>
             <Button
+              tabIndex="0"
               variant="tertiary"
               iconBefore={Add}
               onClick={loadMoreTags}

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -123,7 +123,10 @@ const ContentTagsDropDownSelector = ({
     const currentElement = e.target;
     const encapsulator = currentElement.closest('.dropdown-selector-tag-encapsulator');
 
-    let tagValue = currentElement.querySelector('.pgn__form-checkbox-input')?.value;
+    // Get tag value with full lineage, this is URI encoded
+    const tagValueWithLineage = currentElement.querySelector('.pgn__form-checkbox-input')?.value;
+    // Extract and decode the actual tag value
+    let tagValue = tagValueWithLineage.split(',').slice(-1)[0];
     tagValue = tagValue ? decodeURIComponent(tagValue) : tagValue;
 
     if (keyPressed === 'ArrowRight') {
@@ -136,13 +139,51 @@ const ContentTagsDropDownSelector = ({
       }
       // TODO: Implement remaining cases when left key pressed
     } else if (keyPressed === 'ArrowUp') {
+      const prevSubTags = encapsulator?.previousElementSibling?.querySelectorAll('.dropdown-selector-tag-actions');
+      const prevSubTag = prevSubTags && prevSubTags[prevSubTags.length - 1];
       const prevTag = encapsulator?.previousElementSibling?.querySelector('.dropdown-selector-tag-actions');
-      prevTag?.focus();
-      // TODO: Implement navigating inside sub tags
+
+      if (prevSubTag) {
+        // Handles case of jumping in to subtags
+        prevSubTag.focus();
+      } else if (prevTag) {
+        // Handles case of navigating to previous tag on same level
+        prevTag.focus();
+      } else {
+        // Handles case of jumping out of subtags to previous parent tag
+        const prevParentTagEncapsulator = encapsulator?.parentNode.closest('.dropdown-selector-tag-encapsulator');
+        const prevParentTag = prevParentTagEncapsulator?.querySelector('.dropdown-selector-tag-actions');
+
+        prevParentTag?.focus();
+      }
     } else if (keyPressed === 'ArrowDown') {
+      const subTagEncapsulator = encapsulator?.querySelector('.dropdown-selector-tag-encapsulator');
+      const nextSubTag = subTagEncapsulator?.querySelector('.dropdown-selector-tag-actions');
       const nextTag = encapsulator?.nextElementSibling?.querySelector('.dropdown-selector-tag-actions');
-      nextTag?.focus();
-      // TODO: Implement navigating inside sub tags
+
+      if (nextSubTag) {
+        // Handles case of jumping into subtags
+        nextSubTag.focus();
+      } else if (nextTag) {
+        // Handles case of navigating to next tag on same level
+        nextTag?.focus();
+      } else {
+        // Handles case of jumping out of subtags to next focusable parent tag
+        let nextParentTagEncapsulator = encapsulator?.parentNode?.closest('.dropdown-selector-tag-encapsulator');
+
+        while (nextParentTagEncapsulator) {
+          const nextParentTag = nextParentTagEncapsulator.nextElementSibling?.querySelector(
+            '.dropdown-selector-tag-actions',
+          );
+          if (nextParentTag) {
+            nextParentTag.focus();
+            break;
+          }
+          nextParentTagEncapsulator = nextParentTagEncapsulator.parentNode.closest(
+            '.dropdown-selector-tag-encapsulator',
+          );
+        }
+      }
     } else if (keyPressed === 'Enter') {
       // TODO: Implement
     } else if (keyPressed === 'Space') {

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -284,7 +284,6 @@ const ContentTagsDropDownSelector = ({
                       src={isOpen(tagData.value) ? ArrowDropUp : ArrowDropDown}
                       onClick={() => clickAndEnterHandler(tagData.value)}
                       tabIndex="-1"
-                      onKeyPress={(event) => (event.key === 'Enter' ? clickAndEnterHandler(tagData.value) : null)}
                     />
                   </div>
                 )}

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -138,6 +138,11 @@ const ContentTagsDropDownSelector = ({
       e.preventDefault();
       if (tagValue && isOpen(tagValue)) {
         clickAndEnterHandler(tagValue);
+      } else {
+        // Handles case of jumping out of subtags to previous parent tag
+        const prevParentTagEncapsulator = encapsulator?.parentNode.closest('.dropdown-selector-tag-encapsulator');
+        const prevParentTag = prevParentTagEncapsulator?.querySelector('.dropdown-selector-tag-actions');
+        prevParentTag?.focus();
       }
     } else if (keyPressed === 'ArrowUp') {
       const prevSubTags = encapsulator?.previousElementSibling?.querySelectorAll('.dropdown-selector-tag-actions');

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.scss
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.scss
@@ -32,3 +32,8 @@
 .pgn__selectable_box-active.taxonomy-tags-selectable-box {
   outline: none !important;
 }
+
+.dropdown-selector-tag-actions:focus-visible {
+  outline: solid 2px $info-900;
+  border-radius: 4px;
+}

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
@@ -199,68 +199,6 @@ describe('<ContentTagsDropDownSelector />', () => {
     });
   });
 
-  it('should expand on enter key taxonomy tags drop down selector with sub tags', async () => {
-    useTaxonomyTagsData.mockReturnValueOnce({
-      hasMorePages: false,
-      tagPages: {
-        isLoading: false,
-        isError: false,
-        data: [{
-          value: 'Tag 2',
-          externalId: null,
-          childCount: 1,
-          depth: 0,
-          parentValue: null,
-          id: 12345,
-          subTagsUrl: 'http://localhost:18010/api/content_tagging/v1/taxonomies/4/tags/?parent_tag=Tag%202',
-        }],
-      },
-    });
-
-    await act(async () => {
-      const dataWithTagsTree = {
-        ...data,
-        tagsTree: {
-          'Tag 3': {
-            explicit: false,
-            children: {},
-          },
-        },
-      };
-      const { container, getByText } = await getComponent(dataWithTagsTree);
-      await waitFor(() => {
-        expect(getByText('Tag 2')).toBeInTheDocument();
-        expect(container.getElementsByClassName('taxonomy-tags-arrow-drop-down').length).toBe(1);
-      });
-
-      // Mock useTaxonomyTagsData again since it gets called in the recursive call
-      useTaxonomyTagsData.mockReturnValueOnce({
-        hasMorePages: false,
-        tagPages: {
-          isLoading: false,
-          isError: false,
-          data: [{
-            value: 'Tag 3',
-            externalId: null,
-            childCount: 0,
-            depth: 1,
-            parentValue: 'Tag 2',
-            id: 12346,
-            subTagsUrl: null,
-          }],
-        },
-      });
-
-      // Expand the dropdown to see the subtags selectors
-      const expandToggle = container.querySelector('.taxonomy-tags-arrow-drop-down span');
-      fireEvent.keyPress(expandToggle, { key: 'Enter', charCode: 13 });
-
-      await waitFor(() => {
-        expect(getByText('Tag 3')).toBeInTheDocument();
-      });
-    });
-  });
-
   it('should render taxonomy tags drop down selector and change search term', async () => {
     useTaxonomyTagsData.mockReturnValueOnce({
       hasMorePages: false,

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -25,9 +25,25 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.no-tags-found',
     defaultMessage: 'No tags found with the search term "{searchTerm}"',
   },
-  taxonomyTagsCheckboxAriaLabel: {
-    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.selectable-box.aria.label',
-    defaultMessage: '{tag} checkbox',
+  taxonomyTagChecked: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-checked',
+    defaultMessage: 'Checked',
+  },
+  taxonomyTagUnchecked: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-unchecked',
+    defaultMessage: 'Unchecked',
+  },
+  taxonomyTagImplicit: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-implicit',
+    defaultMessage: 'Implicit',
+  },
+  taxonomyTagActionInstructionsAriaLabel: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-action-instructions.aria.label',
+    defaultMessage: '{tagState} Tag: {tag}. Use the arrow keys to move among the tags in this taxonomy. Press space to select a tag.',
+  },
+  taxonomyTagActionsAriaLabel: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-actions.aria.label',
+    defaultMessage: '{tagState} Tag: {tag}',
   },
   taxonomyTagsAriaLabel: {
     id: 'course-authoring.content-tags-drawer.content-tags-collapsible.selectable-box.selection.aria.label',


### PR DESCRIPTION
## Description

This PR adds the ability to navigate the new "Add Tags" widget using the keyboard, making it fully accessible through the keyboard.

## Supporting Information

Related Tickets:
- Closes https://github.com/openedx/modular-learning/issues/189

## Testing Instructions
1. Run you local dev stack on this branch
1. If you don't already have sample taxonomy/tags data, follow the instructions in this repo to generate sample data: https://github.com/open-craft/taxonomy-sample-data
1. Navigate to a sample course and open the tags drawer by clicking on "Manage Tags"
1. Expand a taxonomy, and navigate to the "Add a Tag" select input using the keyboard by "tabbing" to it
1. Confirm the following:
    1. Once you've navigated to the "Add a Tag" select input the menu should open
    1. Tab again and that should take you to the first element in the menu
    1. Once you're in the tags menu, navigate around using the arrows, confirm that:
        - up/down - go up or down.
        - Left - if leaf or already collapsed: jump to parent tag. Otherwise: collapse the current level.
        - Right - expand the current tag if possible.
        - Enter - if current tag has children: expand/collapse. If leaf: add tag.
        - Space - add tag (or undo adding if it's already added). Same as clicking the checkbox.
    1. When navigating the tags, each tag should be focused as a single widget (the checkbox, the label, and the expand arrow).
    1. When a tag anywhere in the tree is focused, pressing TAB should move the focus to the "Load More" link at the bottom, then to "Cancel" then to "Add Tags". The only way to move among rows/tags in the tag tree area is using the arrow keys. (To test out the "load more", change https://github.com/openedx/frontend-app-course-authoring/blob/6ae9cdac0088117836138e713606c423bec317d5/src/content-tags-drawer/data/api.js#L27 to have a smaller threshold)
    1. Confirm The Load More / Cancel / Add Tags actions must all be usable via keyboard.
    1. Stage a few tags (do not add them yet), then set the focus to the input, by Tabbing back
    1. Confirm that moving the cursor around with the arrow keys will select/focus on different chips. Specifically, the X receives the focus.
    1. Inspect element and check that each staged tag chip's X  has an aria-label
    1. Pressing BACKSPACE in the "Add Tags" text field once will focus on the chip before the cursor. Pressing it a second time will delete that chip. Pressing DELETE will also delete any focused/selected chip.
    1. if you type anything (e.g. types a letter), the focus always jumps to the end (after all the chips). Search keywords cannot be typed before/between the chips.
    1. Inspect the tag elements in the dropdown and confirm that the aria label of the first element in the tag tree dropdown  has: "[Unchecked/implicit/checked] Tag: [Name of the tag]. Use the arrow keys to move among the tags in this taxonomy. Press space to select a tag.", the rest should have "[Unchecked/implicit/checked] Tag: [Name of the tag]."
    1. Confirm that the select menu closes when you Tab out of it, or when you click outside

---
Private-ref: [FAL-3644](https://tasks.opencraft.com/browse/FAL-3644)