### PR TITLE
fix: content tags drawer width [FC-0036]

### DIFF
--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -124,7 +124,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
 
   return (
 
-    <div className="mt-1">
+    <div id="content-tags-drawer" className="mt-1">
       <Container size="xl">
         <CloseButton onClick={() => onCloseDrawer()} data-testid="drawer-close-button" />
         <span>{intl.formatMessage(messages.headerSubtitle)}</span>

--- a/src/content-tags-drawer/ContentTagsDrawer.scss
+++ b/src/content-tags-drawer/ContentTagsDrawer.scss
@@ -1,0 +1,9 @@
+.pgn__sheet-component:has(#content-tags-drawer) {
+  min-width: max(500px, 33vw);
+}
+
+@media only screen and (max-width: 500px) {
+  .pgn__sheet-component:has(#content-tags-drawer) {
+    min-width: 100vw;
+  }
+}

--- a/src/content-tags-drawer/index.scss
+++ b/src/content-tags-drawer/index.scss
@@ -1,2 +1,3 @@
 @import "content-tags-drawer/TagBubble";
 @import "content-tags-drawer/tags-sidebar-controls/TagsSidebarControls";
+@import "content-tags-drawer/ContentTagsDrawer";


### PR DESCRIPTION
## Description

This PR changes the `min-width` of the content tags drawer to better fit content in the screen

## Supporting information
### Small screen (< 500px)
Before | After
:-:|:-:
![2024-03-20-100835](https://github.com/openedx/frontend-app-course-authoring/assets/849463/cee3e2fc-064e-452e-8fa9-dcc64993560d) | ![2024-03-20-100855](https://github.com/openedx/frontend-app-course-authoring/assets/849463/aac57daf-7a23-4567-bdb3-cec287db8320)

### Normal screen (> 500px)
Before | After
:-:|:-:
![2024-03-20-100946](https://github.com/openedx/frontend-app-course-authoring/assets/849463/0be74e75-180c-4d63-a307-a66e0960da30)|![2024-03-20-103844](https://github.com/openedx/frontend-app-course-authoring/assets/849463/178c42ad-266a-4311-9e1e-b2566c8d4eba)

## Testing instructions

- Open the Course Outline
- Click on a Unit to edit it
- Click on the `Manage Tags` button in the Side bar of the unit
- Check the results

___
Private ref: [FAL-3687](https://tasks.opencraft.com/browse/FAL-3687)
