### PR TITLE
[BACKPORT] Fix assignments count on the Grading page

### DIFF
--- a/src/grading-settings/assignment-section/AssignmentSection.test.jsx
+++ b/src/grading-settings/assignment-section/AssignmentSection.test.jsx
@@ -62,10 +62,10 @@ describe('<AssignmentSection />', () => {
   it('checking correct assignment weight of total grade value', async () => {
     const { getByTestId } = render(<RootWrapper setGradingData={setGradingData} />);
     await waitFor(() => {
-      const assignmentShortLabelInput = getByTestId('assignment-weight-input');
-      expect(assignmentShortLabelInput.value).toBe('100');
-      fireEvent.change(assignmentShortLabelInput, { target: { value: '123' } });
-      expect(testObj.graders[0].weight).toBe('123');
+      const assignmentWeightInput = getByTestId('assignment-weight-input');
+      expect(assignmentWeightInput.value).toBe('100');
+      fireEvent.change(assignmentWeightInput, { target: { value: '123' } });
+      expect(testObj.graders[0].weight).toBe(123);
     });
   });
   it('checking correct assignment total number value', async () => {
@@ -74,7 +74,7 @@ describe('<AssignmentSection />', () => {
       const assignmentTotalNumberInput = getByTestId('assignment-minCount-input');
       expect(assignmentTotalNumberInput.value).toBe('1');
       fireEvent.change(assignmentTotalNumberInput, { target: { value: '123' } });
-      expect(testObj.graders[0].minCount).toBe('123');
+      expect(testObj.graders[0].minCount).toBe(123);
     });
   });
   it('checking correct assignment number of droppable value', async () => {
@@ -83,7 +83,7 @@ describe('<AssignmentSection />', () => {
       const assignmentNumberOfDroppableInput = getByTestId('assignment-dropCount-input');
       expect(assignmentNumberOfDroppableInput.value).toBe('1');
       fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '2' } });
-      expect(testObj.graders[0].dropCount).toBe('2');
+      expect(testObj.graders[0].dropCount).toBe(2);
     });
   });
   it('checking correct error msg if dropCount have negative number or empty string', async () => {
@@ -100,20 +100,20 @@ describe('<AssignmentSection />', () => {
   it('checking correct error msg if minCount have negative number or empty string', async () => {
     const { getByText, getByTestId } = render(<RootWrapper />);
     await waitFor(() => {
-      const assignmentNumberOfDroppableInput = getByTestId('assignment-minCount-input');
-      expect(assignmentNumberOfDroppableInput.value).toBe('1');
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '-2' } });
+      const assignmentMinCountInput = getByTestId('assignment-minCount-input');
+      expect(assignmentMinCountInput.value).toBe('1');
+      fireEvent.change(assignmentMinCountInput, { target: { value: '-2' } });
       expect(getByText(messages.totalNumberErrorMessage.defaultMessage)).toBeInTheDocument();
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '' } });
+      fireEvent.change(assignmentMinCountInput, { target: { value: '' } });
       expect(getByText(messages.totalNumberErrorMessage.defaultMessage)).toBeInTheDocument();
     });
   });
   it('checking correct error msg if total weight have negative number', async () => {
     const { getByText, getByTestId } = render(<RootWrapper />);
     await waitFor(() => {
-      const assignmentNumberOfDroppableInput = getByTestId('assignment-weight-input');
-      expect(assignmentNumberOfDroppableInput.value).toBe('100');
-      fireEvent.change(assignmentNumberOfDroppableInput, { target: { value: '-100' } });
+      const assignmentWeightInput = getByTestId('assignment-weight-input');
+      expect(assignmentWeightInput.value).toBe('100');
+      fireEvent.change(assignmentWeightInput, { target: { value: '-100' } });
       expect(getByText(messages.weightOfTotalGradeErrorMessage.defaultMessage)).toBeInTheDocument();
     });
   });

--- a/src/grading-settings/assignment-section/index.jsx
+++ b/src/grading-settings/assignment-section/index.jsx
@@ -34,7 +34,12 @@ const AssignmentSection = ({
   }
 
   const handleAssignmentChange = (e, assignmentId) => {
-    const { name, value } = e.target;
+    const { name, value, type: inputType } = e.target;
+
+    let inputValue = value;
+    if (inputType === 'number') {
+      inputValue = parseInt(value, 10);
+    }
 
     setShowSavePrompt(true);
 
@@ -42,7 +47,7 @@ const AssignmentSection = ({
       ...prevState,
       graders: graders.map(grader => {
         if (grader.id === assignmentId) {
-          return { ...grader, [name]: value };
+          return { ...grader, [name]: inputValue };
         }
         return grader;
       }),
@@ -66,7 +71,7 @@ const AssignmentSection = ({
   return (
     <div className="assignment-items">
       {graders?.map((gradeField) => {
-        const courseAssignmentUsage = courseAssignmentLists[gradeField.type.toLowerCase()];
+        const courseAssignmentUsage = courseAssignmentLists[gradeField.type];
         const showDefinedCaseAlert = gradeField.minCount !== courseAssignmentUsage?.length
             && Boolean(courseAssignmentUsage?.length);
         const showNotDefinedCaseAlert = !courseAssignmentUsage?.length && Boolean(gradeField.type);


### PR DESCRIPTION
## This is a backport from the master branch: https://github.com/openedx/frontend-app-course-authoring/pull/730

## The issue
The assignments counter doesn't work, so the user will see the warning banner with misleading info:
![image](https://github.com/openedx/frontend-app-course-authoring/assets/47273130/99993b89-a4c6-40ca-a45f-d00de55a1abc)

## Steps to reproduce
1. Create a course and set up assignment types (e.g. final exam, homework, etc). To ease the process - set the total number of subsections with this type to 1.
2. Go to the Course Content and change the subsection grading to the type you've defined on the previous step
3. Go back to the Course Grading page

## Actual result
The assignments counter doesn't work, so the user will see the warning banner with misleading info

## Expected result (after the fix was applied):
The correct message is shown 
![image](https://github.com/openedx/frontend-app-course-authoring/assets/47273130/10c10fa5-e0e9-4c74-8ba7-39ab16370bf2)
