### PR TITLE
feat: [FC-0044] Unit page - make xblock edit functional

### DIFF
--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -118,11 +118,14 @@ const CourseUnit = ({ courseId }) => {
                 />
               )}
               <Stack gap={4} className="mb-4">
-                {courseVerticalChildren.children.map(({ name, blockId: id, shouldScroll }) => (
+                {courseVerticalChildren.children.map(({
+                  name, blockId: id, blockType: type, shouldScroll,
+                }) => (
                   <CourseXBlock
                     id={id}
                     key={id}
                     title={name}
+                    type={type}
                     shouldScroll={shouldScroll}
                     unitXBlockActions={unitXBlockActions}
                     data-testid="course-xblock"

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -5,21 +5,38 @@ import {
 } from '@openedx/paragon';
 import { EditOutline as EditIcon, MoreVert as MoveVertIcon } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
 import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import { scrollToElement } from '../../course-outline/utils';
+import { getCourseId } from '../data/selectors';
+import { COMPONENT_ICON_TYPES } from '../constants';
 import messages from './messages';
 
 const CourseXBlock = ({
-  id, title, unitXBlockActions, shouldScroll, ...props
+  id, title, type, unitXBlockActions, shouldScroll, ...props
 }) => {
   const courseXBlockElementRef = useRef(null);
   const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
+  const navigate = useNavigate();
+  const courseId = useSelector(getCourseId);
   const intl = useIntl();
 
   const onXBlockDelete = () => {
     unitXBlockActions.handleDelete(id);
     closeDeleteModal();
+  };
+
+  const handleEdit = () => {
+    switch (type) {
+    case COMPONENT_ICON_TYPES.html:
+    case COMPONENT_ICON_TYPES.problem:
+    case COMPONENT_ICON_TYPES.video:
+      navigate(`/course/${courseId}/editor/${type}/${id}`);
+      break;
+    default:
+    }
   };
 
   useEffect(() => {
@@ -40,7 +57,7 @@ const CourseXBlock = ({
                 alt={intl.formatMessage(messages.blockAltButtonEdit)}
                 iconAs={EditIcon}
                 size="md"
-                onClick={() => {}}
+                onClick={handleEdit}
               />
               <Dropdown>
                 <Dropdown.Toggle
@@ -94,6 +111,7 @@ CourseXBlock.defaultProps = {
 CourseXBlock.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
   shouldScroll: PropTypes.bool,
   unitXBlockActions: PropTypes.shape({
     handleDelete: PropTypes.func,

--- a/src/course-unit/course-xblock/CourseXBlock.test.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.test.jsx
@@ -1,9 +1,12 @@
 import { render, waitFor } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { initializeMockApp } from '@edx/frontend-platform';
+import { camelCaseObject, initializeMockApp } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
 
+import { getCourseId } from '../data/selectors';
+import { COMPONENT_ICON_TYPES } from '../constants';
 import { courseVerticalChildrenMock } from '../__mocks__';
 import CourseXBlock from './CourseXBlock';
 
@@ -11,26 +14,57 @@ import deleteModalMessages from '../../generic/delete-modal/messages';
 import messages from './messages';
 
 let store;
+const courseId = '1234';
+const blockId = '567890';
 const handleDeleteMock = jest.fn();
 const handleDuplicateMock = jest.fn();
-const xblockData = courseVerticalChildrenMock.children[0];
+const handleConfigureSubmitMock = jest.fn();
+const mockedUsedNavigate = jest.fn();
+const {
+  name,
+  block_id: id,
+  block_type: type,
+  user_partition_info: userPartitionInfo,
+} = courseVerticalChildrenMock.children[0];
 const unitXBlockActionsMock = {
   handleDelete: handleDeleteMock,
   handleDuplicate: handleDuplicateMock,
 };
 
-const renderComponent = () => render(
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const renderComponent = (props) => render(
   <AppProvider store={store}>
     <IntlProvider locale="en">
       <CourseXBlock
-        id={xblockData.block_id}
-        title={xblockData.block_id}
+        id={id}
+        title={name}
+        type={type}
+        blockId={blockId}
         unitXBlockActions={unitXBlockActionsMock}
+        userPartitionInfo={camelCaseObject(userPartitionInfo)}
         shouldScroll={false}
+        handleConfigureSubmit={handleConfigureSubmitMock}
+        {...props}
       />
     </IntlProvider>
   </AppProvider>,
 );
+
+useSelector.mockImplementation((selector) => {
+  if (selector === getCourseId) {
+    return courseId;
+  }
+  return null;
+});
 
 describe('<CourseXBlock />', () => {
   beforeEach(async () => {
@@ -48,7 +82,7 @@ describe('<CourseXBlock />', () => {
     const { getByText, getByLabelText } = renderComponent();
 
     await waitFor(() => {
-      expect(getByText(xblockData.block_id)).toBeInTheDocument();
+      expect(getByText(name)).toBeInTheDocument();
       expect(getByLabelText(messages.blockAltButtonEdit.defaultMessage)).toBeInTheDocument();
       expect(getByLabelText(messages.blockActionsDropdownAlt.defaultMessage)).toBeInTheDocument();
     });
@@ -76,7 +110,7 @@ describe('<CourseXBlock />', () => {
 
       userEvent.click(duplicateBtn);
       expect(handleDuplicateMock).toHaveBeenCalledTimes(1);
-      expect(handleDuplicateMock).toHaveBeenCalledWith(xblockData.block_id);
+      expect(handleDuplicateMock).toHaveBeenCalledWith(id);
     });
   });
 
@@ -102,7 +136,51 @@ describe('<CourseXBlock />', () => {
       userEvent.click(deleteBtn);
       userEvent.click(getByRole('button', { name: deleteModalMessages.deleteButton.defaultMessage }));
       expect(handleDeleteMock).toHaveBeenCalled();
-      expect(handleDeleteMock).toHaveBeenCalledWith(xblockData.block_id);
+      expect(handleDeleteMock).toHaveBeenCalledWith(id);
+    });
+  });
+
+  describe('edit', () => {
+    it('navigates to editor page on edit HTML xblock', () => {
+      const { getByText, getByRole } = renderComponent({
+        type: COMPONENT_ICON_TYPES.html,
+      });
+
+      const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });
+      expect(getByText(name)).toBeInTheDocument();
+      expect(editButton).toBeInTheDocument();
+
+      userEvent.click(editButton);
+      expect(mockedUsedNavigate).toHaveBeenCalled();
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(`/course/${courseId}/editor/html/${id}`);
+    });
+
+    it('navigates to editor page on edit Video xblock', () => {
+      const { getByText, getByRole } = renderComponent({
+        type: COMPONENT_ICON_TYPES.video,
+      });
+
+      const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });
+      expect(getByText(name)).toBeInTheDocument();
+      expect(editButton).toBeInTheDocument();
+
+      userEvent.click(editButton);
+      expect(mockedUsedNavigate).toHaveBeenCalled();
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(`/course/${courseId}/editor/video/${id}`);
+    });
+
+    it('navigates to editor page on edit Problem xblock', () => {
+      const { getByText, getByRole } = renderComponent({
+        type: COMPONENT_ICON_TYPES.problem,
+      });
+
+      const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });
+      expect(getByText(name)).toBeInTheDocument();
+      expect(editButton).toBeInTheDocument();
+
+      userEvent.click(editButton);
+      expect(mockedUsedNavigate).toHaveBeenCalled();
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(`/course/${courseId}/editor/problem/${id}`);
     });
   });
 });


### PR DESCRIPTION
**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS: |
  MFE_CONFIG["ENABLE_UNIT_PAGE"] = True
  MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
```

### Description
This pull request adds to the unit page the ability to edit (for types: `html`, `problem`, `video` only) the settings and content of XBlocks by redirecting creator to full-screen editor pages.

Issue: https://github.com/openedx/platform-roadmap/issues/321

### Design
https://www.figma.com/file/YeKFwSpyLaJFDs3f3p3TSa/Studio-1%3A1-mock-ups?node-id=599%3A23595

![image (1)](https://github.com/openedx/frontend-app-course-authoring/assets/17108583/fc38d4d0-c055-4403-9deb-f780c9ac759a)

### Testing instructions
1. Run master devstack.
2. Start platform make dev.up.lms+cms+frontend-app-course-authoring and make checkout on this branch.
3. Enable new Unit page by adding a waffle flad `contentstore.new_studio_mfe.use_new_unit_page` in CMS admin panel.
4. Go to Course Unit page from the Course Outline page.
5. Make sure the course you are viewing is not outdated.
6. Publish all sections on the Course Outline page.