### PR TITLE
feat: [FC-0044] Unit page - display component support label

### DIFF
--- a/src/course-unit/add-component/AddComponent.jsx
+++ b/src/course-unit/add-component/AddComponent.jsx
@@ -5,7 +5,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { useToggle } from '@openedx/paragon';
 
 import { getCourseSectionVertical } from '../data/selectors';
-import { COMPONENT_ICON_TYPES } from '../constants';
+import { COMPONENT_TYPES } from '../constants';
 import ComponentModalView from './add-component-modals/ComponentModalView';
 import AddComponentButton from './add-component-btn';
 import messages from './messages';
@@ -20,32 +20,32 @@ const AddComponent = ({ blockId, handleCreateNewCourseXBlock }) => {
 
   const handleCreateNewXBlock = (type, moduleName) => {
     switch (type) {
-    case COMPONENT_ICON_TYPES.discussion:
-    case COMPONENT_ICON_TYPES.dragAndDrop:
+    case COMPONENT_TYPES.discussion:
+    case COMPONENT_TYPES.dragAndDrop:
       handleCreateNewCourseXBlock({ type, parentLocator: blockId });
       break;
-    case COMPONENT_ICON_TYPES.problem:
-    case COMPONENT_ICON_TYPES.video:
+    case COMPONENT_TYPES.problem:
+    case COMPONENT_TYPES.video:
       handleCreateNewCourseXBlock({ type, parentLocator: blockId }, ({ courseKey, locator }) => {
         navigate(`/course/${courseKey}/editor/${type}/${locator}`);
       });
       break;
     // TODO: The library functional will be a bit different of current legacy (CMS)
     //  behaviour and this ticket is on hold (blocked by other development team).
-    case COMPONENT_ICON_TYPES.library:
+    case COMPONENT_TYPES.library:
       handleCreateNewCourseXBlock({ type, category: 'library_content', parentLocator: blockId });
       break;
-    case COMPONENT_ICON_TYPES.advanced:
+    case COMPONENT_TYPES.advanced:
       handleCreateNewCourseXBlock({
         type: moduleName, category: moduleName, parentLocator: blockId,
       });
       break;
-    case COMPONENT_ICON_TYPES.openassessment:
+    case COMPONENT_TYPES.openassessment:
       handleCreateNewCourseXBlock({
         boilerplate: moduleName, category: type, parentLocator: blockId,
       });
       break;
-    case COMPONENT_ICON_TYPES.html:
+    case COMPONENT_TYPES.html:
       handleCreateNewCourseXBlock({
         type,
         boilerplate: moduleName,
@@ -70,22 +70,26 @@ const AddComponent = ({ blockId, handleCreateNewCourseXBlock }) => {
           const { type, displayName } = component;
           let modalParams;
 
+          if (!component.templates.length) {
+            return null;
+          }
+
           switch (type) {
-          case COMPONENT_ICON_TYPES.advanced:
+          case COMPONENT_TYPES.advanced:
             modalParams = {
               open: openAdvanced,
               close: closeAdvanced,
               isOpen: isOpenAdvanced,
             };
             break;
-          case COMPONENT_ICON_TYPES.html:
+          case COMPONENT_TYPES.html:
             modalParams = {
               open: openHtml,
               close: closeHtml,
               isOpen: isOpenHtml,
             };
             break;
-          case COMPONENT_ICON_TYPES.openassessment:
+          case COMPONENT_TYPES.openassessment:
             modalParams = {
               open: openOpenAssessment,
               close: closeOpenAssessment,

--- a/src/course-unit/add-component/add-component-btn/AddComponentIcon.jsx
+++ b/src/course-unit/add-component/add-component-btn/AddComponentIcon.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Icon } from '@openedx/paragon';
 import { EditNote as EditNoteIcon } from '@openedx/paragon/icons';
 
-import { COMPONENT_ICON_TYPES, COMPONENT_TYPE_ICON_MAP } from '../../constants';
+import { COMPONENT_TYPES, COMPONENT_TYPE_ICON_MAP } from '../../constants';
 
 const AddComponentIcon = ({ type }) => {
   const icon = COMPONENT_TYPE_ICON_MAP[type] || EditNoteIcon;
@@ -11,7 +11,7 @@ const AddComponentIcon = ({ type }) => {
 };
 
 AddComponentIcon.propTypes = {
-  type: PropTypes.oneOf(Object.values(COMPONENT_ICON_TYPES)).isRequired,
+  type: PropTypes.oneOf(Object.values(COMPONENT_TYPES)).isRequired,
 };
 
 export default AddComponentIcon;

--- a/src/course-unit/add-component/add-component-modals/ComponentModalView.jsx
+++ b/src/course-unit/add-component/add-component-modals/ComponentModalView.jsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Form } from '@openedx/paragon';
+import { Form, OverlayTrigger, Tooltip } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { updateQueryPendingStatus } from '../../data/slice';
+import { getXBlockSupportMessages } from '../../constants';
 import AddComponentButton from '../add-component-btn';
 import messages from '../messages';
 import ModalContainer from './ModalContainer';
@@ -18,7 +19,10 @@ const ComponentModalView = ({
   const dispatch = useDispatch();
   const [moduleTitle, setModuleTitle] = useState('');
   const { open, close, isOpen } = modalParams;
-  const { type, displayName, templates } = component;
+  const {
+    type, displayName, templates, supportLegend,
+  } = component;
+  const supportLabels = getXBlockSupportMessages(intl);
 
   const handleSubmit = () => {
     handleCreateNewXBlock(type, moduleTitle);
@@ -51,15 +55,32 @@ const ComponentModalView = ({
           >
             {templates.map((componentTemplate) => {
               const value = componentTemplate.boilerplateName || componentTemplate.category;
+              const isDisplaySupportLabel = supportLegend.showLegend && supportLabels[componentTemplate.supportLevel];
 
               return (
-                <Form.Radio
-                  key={componentTemplate.displayName}
-                  className="add-component-modal-radio mb-2.5"
-                  value={value}
-                >
-                  {componentTemplate.displayName}
-                </Form.Radio>
+                <div className="d-flex justify-content-between w-100 mb-2.5 align-items-end">
+                  <Form.Radio
+                    key={componentTemplate.displayName}
+                    className="add-component-modal-radio"
+                    value={value}
+                  >
+                    {componentTemplate.displayName}
+                  </Form.Radio>
+                  {isDisplaySupportLabel && (
+                    <OverlayTrigger
+                      placement="right"
+                      overlay={(
+                        <Tooltip>
+                          {supportLabels[componentTemplate.supportLevel].tooltip}
+                        </Tooltip>
+                      )}
+                    >
+                      <span className="x-small text-gray-500 flex-shrink-0 ml-2">
+                        {supportLabels[componentTemplate.supportLevel].label}
+                      </span>
+                    </OverlayTrigger>
+                  )}
+                </div>
               );
             })}
           </Form.RadioSet>
@@ -85,8 +106,14 @@ ComponentModalView.propTypes = {
         boilerplateName: PropTypes.string,
         category: PropTypes.string,
         displayName: PropTypes.string.isRequired,
+        supportLevel: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
       }),
     ),
+    supportLegend: PropTypes.shape({
+      allowUnsupportedXblocks: PropTypes.bool,
+      documentationLabel: PropTypes.string,
+      showLegend: PropTypes.bool,
+    }),
   }).isRequired,
 };
 

--- a/src/course-unit/add-component/messages.js
+++ b/src/course-unit/add-component/messages.js
@@ -21,6 +21,40 @@ const messages = defineMessages({
     id: 'course-authoring.course-unit.modal.container.cancel.button.text',
     defaultMessage: 'Cancel',
   },
+  modalComponentSupportLabelFullySupported: {
+    id: 'course-authoring.course-unit.modal.component.support.label.fully-supported',
+    defaultMessage: 'Fully supported',
+  },
+  modalComponentSupportLabelProvisionallySupported: {
+    id: 'course-authoring.course-unit.modal.component.support.label.provisionally-support',
+    defaultMessage: 'Provisionally supported',
+  },
+  modalComponentSupportLabelNotSupported: {
+    id: 'course-authoring.course-unit.modal.component.support.label.not-supported',
+    defaultMessage: 'Not supported',
+  },
+  modalComponentSupportTooltipFullySupported: {
+    id: 'course-authoring.course-unit.modal.component.support.tooltip.fully-supported',
+    defaultMessage: 'Fully supported tools and features are available on edX, are '
+      + 'fully tested, have user interfaces where applicable, and are documented in the '
+      + 'official edX guides that are available on docs.edx.org.',
+  },
+  modalComponentSupportTooltipNotSupported: {
+    id: 'course-authoring.course-unit.modal.component.support.tooltip.not-supported',
+    defaultMessage: 'Tools with no support are not maintained by edX, and might be '
+      + 'deprecated in the future. They are not recommended for use in courses due to '
+      + 'non-compliance with one or more of the base requirements, such as testing, '
+      + 'accessibility, internationalization, and documentation.',
+  },
+  modalComponentSupportTooltipProvisionallySupported: {
+    id: 'course-authoring.course-unit.modal.component.support.tooltip.provisionally-support',
+    defaultMessage: 'Provisionally supported tools might lack the robustness of functionality '
+      + 'that your courses require. edX does not have control over the quality of the software, '
+      + 'or of the content that can be provided using these tools. Test these tools thoroughly '
+      + 'before using them in your course, especially in graded sections. Complete documentation '
+      + 'might not be available for provisionally supported tools, or documentation might be '
+      + 'available from sources other than edX.',
+  },
 });
 
 export default messages;

--- a/src/course-unit/add-component/messages.js
+++ b/src/course-unit/add-component/messages.js
@@ -24,20 +24,24 @@ const messages = defineMessages({
   modalComponentSupportLabelFullySupported: {
     id: 'course-authoring.course-unit.modal.component.support.label.fully-supported',
     defaultMessage: 'Fully supported',
+    description: 'Label for advance problem type\'s support status with full platform support',
   },
   modalComponentSupportLabelProvisionallySupported: {
     id: 'course-authoring.course-unit.modal.component.support.label.provisionally-support',
     defaultMessage: 'Provisionally supported',
+    description: 'Label for advance problem type\'s support status with provisional platform support',
   },
   modalComponentSupportLabelNotSupported: {
     id: 'course-authoring.course-unit.modal.component.support.label.not-supported',
     defaultMessage: 'Not supported',
+    description: 'Label for advance problem type\'s support status with no platform support',
   },
   modalComponentSupportTooltipFullySupported: {
     id: 'course-authoring.course-unit.modal.component.support.tooltip.fully-supported',
     defaultMessage: 'Fully supported tools and features are available on edX, are '
       + 'fully tested, have user interfaces where applicable, and are documented in the '
       + 'official edX guides that are available on docs.edx.org.',
+    description: 'Message for support status tooltip for modules with full platform support',
   },
   modalComponentSupportTooltipNotSupported: {
     id: 'course-authoring.course-unit.modal.component.support.tooltip.not-supported',
@@ -45,6 +49,7 @@ const messages = defineMessages({
       + 'deprecated in the future. They are not recommended for use in courses due to '
       + 'non-compliance with one or more of the base requirements, such as testing, '
       + 'accessibility, internationalization, and documentation.',
+    description: 'Message for support status tooltip for modules which is not supported',
   },
   modalComponentSupportTooltipProvisionallySupported: {
     id: 'course-authoring.course-unit.modal.component.support.tooltip.provisionally-support',
@@ -54,6 +59,7 @@ const messages = defineMessages({
       + 'before using them in your course, especially in graded sections. Complete documentation '
       + 'might not be available for provisionally supported tools, or documentation might be '
       + 'available from sources other than edX.',
+    description: 'Message for support status tooltip for modules with provisional platform support',
   },
 });
 

--- a/src/course-unit/constants.js
+++ b/src/course-unit/constants.js
@@ -12,11 +12,13 @@ import {
   TextFields as TextFieldsIcon,
   VideoCamera as VideoCameraIcon,
 } from '@openedx/paragon/icons';
+
 import messages from './sidebar/messages';
+import addComponentMessages from './add-component/messages';
 
 export const UNIT_ICON_TYPES = ['video', 'other', 'vertical', 'problem', 'lock'];
 
-export const COMPONENT_ICON_TYPES = {
+export const COMPONENT_TYPES = {
   advanced: 'advanced',
   discussion: 'discussion',
   library: 'library',
@@ -36,14 +38,14 @@ export const TYPE_ICONS_MAP = {
 };
 
 export const COMPONENT_TYPE_ICON_MAP = {
-  [COMPONENT_ICON_TYPES.advanced]: ScienceIcon,
-  [COMPONENT_ICON_TYPES.discussion]: QuestionAnswerOutlineIcon,
-  [COMPONENT_ICON_TYPES.library]: LibraryIcon,
-  [COMPONENT_ICON_TYPES.html]: TextFieldsIcon,
-  [COMPONENT_ICON_TYPES.openassessment]: EditNoteIcon,
-  [COMPONENT_ICON_TYPES.problem]: HelpOutlineIcon,
-  [COMPONENT_ICON_TYPES.video]: VideoCameraIcon,
-  [COMPONENT_ICON_TYPES.dragAndDrop]: BackHandIcon,
+  [COMPONENT_TYPES.advanced]: ScienceIcon,
+  [COMPONENT_TYPES.discussion]: QuestionAnswerOutlineIcon,
+  [COMPONENT_TYPES.library]: LibraryIcon,
+  [COMPONENT_TYPES.html]: TextFieldsIcon,
+  [COMPONENT_TYPES.openassessment]: EditNoteIcon,
+  [COMPONENT_TYPES.problem]: HelpOutlineIcon,
+  [COMPONENT_TYPES.video]: VideoCameraIcon,
+  [COMPONENT_TYPES.dragAndDrop]: BackHandIcon,
 };
 
 export const getUnitReleaseStatus = (intl) => ({
@@ -68,3 +70,18 @@ export const PUBLISH_TYPES = {
   discardChanges: 'discard_changes',
   makePublic: 'make_public',
 };
+
+export const getXBlockSupportMessages = (intl) => ({
+  fs: { // Fully supported
+    label: intl.formatMessage(addComponentMessages.modalComponentSupportLabelFullySupported),
+    tooltip: intl.formatMessage(addComponentMessages.modalComponentSupportTooltipFullySupported),
+  },
+  ps: { // Provisionally supported
+    label: intl.formatMessage(addComponentMessages.modalComponentSupportLabelProvisionallySupported),
+    tooltip: intl.formatMessage(addComponentMessages.modalComponentSupportTooltipProvisionallySupported),
+  },
+  us: { // Not supported
+    label: intl.formatMessage(addComponentMessages.modalComponentSupportLabelNotSupported),
+    tooltip: intl.formatMessage(addComponentMessages.modalComponentSupportTooltipNotSupported),
+  },
+});

--- a/src/course-unit/course-xblock/CourseXBlock.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.jsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import { scrollToElement } from '../../course-outline/utils';
 import { getCourseId } from '../data/selectors';
-import { COMPONENT_ICON_TYPES } from '../constants';
+import { COMPONENT_TYPES } from '../constants';
 import messages from './messages';
 
 const CourseXBlock = ({
@@ -30,9 +30,9 @@ const CourseXBlock = ({
 
   const handleEdit = () => {
     switch (type) {
-    case COMPONENT_ICON_TYPES.html:
-    case COMPONENT_ICON_TYPES.problem:
-    case COMPONENT_ICON_TYPES.video:
+    case COMPONENT_TYPES.html:
+    case COMPONENT_TYPES.problem:
+    case COMPONENT_TYPES.video:
       navigate(`/course/${courseId}/editor/${type}/${id}`);
       break;
     default:

--- a/src/course-unit/course-xblock/CourseXBlock.test.jsx
+++ b/src/course-unit/course-xblock/CourseXBlock.test.jsx
@@ -6,7 +6,7 @@ import { camelCaseObject, initializeMockApp } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
 
 import { getCourseId } from '../data/selectors';
-import { COMPONENT_ICON_TYPES } from '../constants';
+import { COMPONENT_TYPES } from '../constants';
 import { courseVerticalChildrenMock } from '../__mocks__';
 import CourseXBlock from './CourseXBlock';
 
@@ -143,7 +143,7 @@ describe('<CourseXBlock />', () => {
   describe('edit', () => {
     it('navigates to editor page on edit HTML xblock', () => {
       const { getByText, getByRole } = renderComponent({
-        type: COMPONENT_ICON_TYPES.html,
+        type: COMPONENT_TYPES.html,
       });
 
       const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });
@@ -157,7 +157,7 @@ describe('<CourseXBlock />', () => {
 
     it('navigates to editor page on edit Video xblock', () => {
       const { getByText, getByRole } = renderComponent({
-        type: COMPONENT_ICON_TYPES.video,
+        type: COMPONENT_TYPES.video,
       });
 
       const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });
@@ -171,7 +171,7 @@ describe('<CourseXBlock />', () => {
 
     it('navigates to editor page on edit Problem xblock', () => {
       const { getByText, getByRole } = renderComponent({
-        type: COMPONENT_ICON_TYPES.problem,
+        type: COMPONENT_TYPES.problem,
       });
 
       const editButton = getByRole('button', { name: messages.blockAltButtonEdit.defaultMessage });


### PR DESCRIPTION
**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS: |
  MFE_CONFIG["ENABLE_UNIT_PAGE"] = True
  MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
```

### Description
This pull request adds the display of support labels for xblocks in the advanced xblocks selector modal to the unit page.
Tags in the modal window as "Fully supported", "Provisionally supported" or "Not supported".

Issue: https://github.com/openedx/platform-roadmap/issues/321

### Developer notes
The initial 1 commit in this PR is temporary. Once the https://github.com/openedx/frontend-app-course-authoring/pull/912 is merged, the second commit of this PR will become the main commit.


### Design
https://www.figma.com/file/YeKFwSpyLaJFDs3f3p3TSa/Studio-1%3A1-mock-ups?node-id=599%3A23595

<img width="765" alt="Screenshot at Mar 21 12-48-00" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/a3d12b8b-bb3c-4b33-b427-9a71bfb34604">

### Testing instructions
1. Run master devstack.
2. Start platform make dev.up.lms+cms+frontend-app-course-authoring and make checkout on this branch.
3. Enable new Unit page by adding a waffle flad `contentstore.new_studio_mfe.use_new_unit_page` in CMS admin panel.
4. Go to Course Unit page from the Course Outline page.
5. Make sure the course you are viewing is not outdated.
6. Publish all sections on the Course Outline page.