### PR TITLE
fix: transcript and thumbnail uploads

### DIFF
--- a/src/files-and-videos/videos-page/VideoThumbnail.jsx
+++ b/src/files-and-videos/videos-page/VideoThumbnail.jsx
@@ -26,7 +26,10 @@ const VideoThumbnail = ({
   intl,
 }) => {
   const fileInputControl = useFileInput({
-    onAddFile: (file) => handleAddThumbnail(file, id),
+    onAddFile: (files) => {
+      const [file] = files;
+      handleAddThumbnail(file, id);
+    },
     setSelectedRows: () => {},
     setAddOpen: () => false,
   });
@@ -47,17 +50,29 @@ const VideoThumbnail = ({
 
   return (
     <div data-testid={`video-thumbnail-${id}`} className="video-thumbnail row justify-content-center align-itmes-center">
-      {allowThumbnailUpload && <div className="thumbnail-overlay" />}
+      {allowThumbnailUpload && showThumbnail && <div className="thumbnail-overlay" />}
       {showThumbnail && !thumbnailError && pageLoadStatus === RequestStatus.SUCCESSFUL ? (
-        <div className="border rounded">
-          <Image
-            style={imageSize}
-            className="m-1 bg-light-300"
-            src={thumbnail}
-            alt={intl.formatMessage(messages.thumbnailAltMessage, { displayName })}
-            onError={() => setThumbnailError(true)}
-          />
-        </div>
+        <>
+          <div className="border rounded">
+            <Image
+              style={imageSize}
+              className="m-1 bg-light-300"
+              src={thumbnail}
+              alt={intl.formatMessage(messages.thumbnailAltMessage, { displayName })}
+              onError={() => setThumbnailError(true)}
+            />
+          </div>
+          <div className="add-thumbnail">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={fileInputControl.click}
+              tabIndex="0"
+            >
+              {addThumbnailMessage}
+            </Button>
+          </div>
+        </>
       ) : (
         <>
           <div
@@ -76,24 +91,12 @@ const VideoThumbnail = ({
         </>
       )}
       {allowThumbnailUpload && (
-        <>
-          <div className="add-thumbnail">
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={fileInputControl.click}
-              tabIndex="0"
-            >
-              {addThumbnailMessage}
-            </Button>
-          </div>
-          <FileInput
-            key="video-thumbnail-upload"
-            fileInput={fileInputControl}
-            supportedFileFormats={supportedFiles}
-            allowMultiple={false}
-          />
-        </>
+        <FileInput
+          key="video-thumbnail-upload"
+          fileInput={fileInputControl}
+          supportedFileFormats={supportedFiles}
+          allowMultiple={false}
+        />
       )}
     </div>
   );

--- a/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
+++ b/src/files-and-videos/videos-page/info-sidebar/transcript-item/Transcript.jsx
@@ -32,7 +32,8 @@ const Transcript = ({
   }, [transcript]);
 
   const input = useFileInput({
-    onAddFile: (file) => {
+    onAddFile: (files) => {
+      const [file] = files;
       handleTranscript({
         file,
         language,


### PR DESCRIPTION
## Description

This PR fixes the ability to upload transcripts and thumbnails for videos on the Videos page. This bug was introduced in #885 as a result of not looping through the file object before sending it to the api. Now the thunk receives an individual file instead of an array of length 1.

## Testing instructions

### Thumbnail
1. Open a course with uploaded videos
2. Hover over the existing thumbnail for a video
3. Replace the thumbnail
4. Confirm the thumbnail was updated
5. Click Add videos
6. Upload a video
7. While it is uploading or in a failed state, hover over the thumbnail placeholder
8. Should not see the option to add thumbnail

### Transcripts
1. Click on the (•••) menu
2. Click Info
3. Click Transcripts
4. Add a transcript
9. Confirm that it uploads
10. Click on the (•••) menu next to the transcript
11. Click Replace
12. Confirm that the replacement transcript uploads