### PR TITLE
fix: incorrect redirection link to Pages&Resources from Custom Pages

### DIFF
--- a/src/custom-pages/CustomPages.jsx
+++ b/src/custom-pages/CustomPages.jsx
@@ -40,6 +40,7 @@ import messages from './messages';
 import CustomPagesProvider from './CustomPagesProvider';
 import EditModal from './EditModal';
 import getPageHeadTitle from '../generic/utils';
+import { getPagePath } from '../utils';
 
 const CustomPages = ({
   courseId,
@@ -118,7 +119,7 @@ const CustomPages = ({
             ariaLabel="Custom Page breadcrumbs"
             links={[
               { label: 'Content', href: `${config.STUDIO_BASE_URL}/course/${courseId}` },
-              { label: 'Pages and Resources', href: `/course/${courseId}/pages-and-resources` },
+              { label: 'Pages and Resources', href: getPagePath(courseId, 'true', 'tabs') },
             ]}
           />
         </div>


### PR DESCRIPTION
## Description
If you have organized routing on your server using the `<app.domain.com>/<name-mfe>/...` method, then an error will occur for redirection for this link (this part is lost `<name-mfe>`):

![screen_45](https://github.com/openedx/frontend-app-course-authoring/assets/98233552/0e3ff6dd-f5ef-477c-8fb2-36486125cedf)

You will not be able to reproduce this error on a local instance:

<img width="883" alt="screen_44" src="https://github.com/openedx/frontend-app-course-authoring/assets/98233552/e93d5b55-4ba8-4d60-ad2d-96c34c915a54">

<img width="1104" alt="screen_43" src="https://github.com/openedx/frontend-app-course-authoring/assets/98233552/190d5556-dc04-4ba5-95d6-78694721fa9a">

**The solution involves more flexible routing**