### PR TITLE
feat: Add taxonomies tab in home page

### DIFF
--- a/src/studio-home/tabs-section/TabsSection.test.jsx
+++ b/src/studio-home/tabs-section/TabsSection.test.jsx
@@ -118,6 +118,21 @@ describe('<TabsSection />', () => {
     });
   });
 
+  describe('taxonomies tab', () => {
+    it('should redirect to taxonomies page', async () => {
+      render(<RootWrapper />);
+      axiosMock.onGet(getStudioHomeApiUrl()).reply(200, generateGetStudioHomeDataApiResponse());
+      await executeThunk(fetchStudioHomeData(), store.dispatch);
+
+      const taxonomiesTab = screen.getByText(tabMessages.taxonomiesTabTitle.defaultMessage);
+      fireEvent.click(taxonomiesTab);
+
+      waitFor(() => {
+        expect(window.location.href).toContain('/taxonomies');
+      });
+    });
+  });
+
   describe('archived tab', () => {
     it('should switch to Archived tab and render specific archived course details', async () => {
       render(<RootWrapper />);

--- a/src/studio-home/tabs-section/index.jsx
+++ b/src/studio-home/tabs-section/index.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Tab, Tabs } from '@openedx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useNavigate } from 'react-router-dom';
 
 import { getLoadingStatuses, getStudioHomeData } from '../data/selectors';
 import messages from './messages';
@@ -15,10 +16,12 @@ import { fetchLibraryData } from '../data/thunks';
 const TabsSection = ({
   intl, showNewCourseContainer, onClickNewCourse, isShowProcessing, dispatch,
 }) => {
+  const navigate = useNavigate();
   const TABS_LIST = {
     courses: 'courses',
     libraries: 'libraries',
     archived: 'archived',
+    taxonomies: 'taxonomies',
   };
   const [tabKey, setTabKey] = useState(TABS_LIST.courses);
   const {
@@ -90,6 +93,14 @@ const TabsSection = ({
       );
     }
 
+    tabs.push(
+      <Tab
+        key={TABS_LIST.taxonomies}
+        eventKey={TABS_LIST.taxonomies}
+        title={intl.formatMessage(messages.taxonomiesTabTitle)}
+      />,
+    );
+
     return tabs;
   }, [archivedCourses, librariesEnabled, showNewCourseContainer, isLoadingCourses, isLoadingLibraries]);
 
@@ -98,6 +109,8 @@ const TabsSection = ({
       window.location.assign(libraryAuthoringMfeUrl);
     } else if (tab === TABS_LIST.libraries && !redirectToLibraryAuthoringMfe) {
       dispatch(fetchLibraryData());
+    } else if (tab === TABS_LIST.taxonomies) {
+      navigate('/taxonomies');
     }
     setTabKey(tab);
   };

--- a/src/studio-home/tabs-section/messages.js
+++ b/src/studio-home/tabs-section/messages.js
@@ -25,6 +25,11 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.archived.tab.error.message',
     defaultMessage: 'Failed to fetch archived courses. Please try again later.',
   },
+  taxonomiesTabTitle: {
+    id: 'course-authoring.studio-home.taxonomies.tab.title',
+    defaultMessage: 'Taxonomies',
+    description: 'Title of Taxonomies tab on the home page',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

This PR adds a "Taxonomies" tab to the course authoring home page, and redirects to the taxonomies page when clicked.

<img width="1061" alt="Screenshot 2024-03-28 at 12 26 54 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/6829768/246097f3-2bc3-428b-8e25-e52c972014c2">

## Testing instructions

1. Run this branch in your local dev stack
2. Make sure you have the `new_studio_mfe.use_new_home_page` flag is enabled
3. Navigate to the course authoring home page: http://apps.local.edly.io:2001/course-authoring/home
4. Confirm that the taxonomies tab appears, as in the screenshot
5. Confirm that clicking on it navigates to the taxonomies list page

---
Private-ref: [FAL-3699](https://tasks.opencraft.com/browse/FAL-3699)