### PR TITLE
fix: message case for `Manage tags` and `Unit tags` strings [FC-0053]

### DIFF
--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -51,12 +51,12 @@ const messages = defineMessages({
   },
   manageTagsButton: {
     id: 'course-authoring.content-tags-drawer.button.manage',
-    defaultMessage: 'Manage Tags',
+    defaultMessage: 'Manage tags',
     description: 'Label in the button that opens the drawer to edit content tags',
   },
   tagsSidebarTitle: {
     id: 'course-authoring.course-unit.sidebar.tags.title',
-    defaultMessage: 'Unit Tags',
+    defaultMessage: 'Unit tags',
     description: 'Title of the tags sidebar',
   },
   collapsibleAddTagsPlaceholderText: {


### PR DESCRIPTION
## Description

This PR fixed the case for the `Manage Tags` button and the `Unit tags` header in the unit view.

![image](https://github.com/openedx/frontend-app-course-authoring/assets/849463/cd1c00e3-31d7-49a6-89dc-28dfae546630)

## Testing instructions

- Open the course authoring MFE and check if the string are show correctly.

___
Private ref: [FAL-3679](https://tasks.opencraft.com/browse/FAL-3679)