### PR TITLE
feat: send content-length in video

### DIFF
--- a/src/files-and-videos/videos-page/data/api.js
+++ b/src/files-and-videos/videos-page/data/api.js
@@ -206,6 +206,7 @@ export async function uploadVideo(
     headers: {
       'Content-Disposition': `attachment; filename="${uploadFile.name}"`,
       'Content-Type': uploadFile.type,
+      'Content-Length': uploadFile.size,
     },
     multipart: false,
     body: uploadFile,


### PR DESCRIPTION
## Description

This change sends 'Content-Length' in video uploads. AWS bucket is sometimes returning `IncompleteBody` errors, which indicates it needs this portion of the header. When this error occurs, video upload fails.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11532
