### PR TITLE
Fix the TaxonomyMenu test, which wasn't getting run at all

### DIFF
--- a/src/taxonomy/taxonomy-menu/TaxonomyMenu.jsx
+++ b/src/taxonomy/taxonomy-menu/TaxonomyMenu.jsx
@@ -21,6 +21,16 @@ import { ImportTagsWizard } from '../import-tags';
 import { ManageOrgsModal } from '../manage-orgs';
 import messages from './messages';
 
+/** @typedef {import('../data/types.mjs').TaxonomyData} TaxonomyData */
+// Note: to make mocking easier for tests, the types below only specify the subset of TaxonomyData that we actually use.
+
+/**
+ * A menu that provides actions for editing a specific taxonomy.
+ * @type {React.FC<{
+ *   taxonomy: Pick<TaxonomyData, 'id'|'name'|'tagsCount'|'systemDefined'|'canChangeTaxonomy'|'canDeleteTaxonomy'>,
+ *   iconMenu?: boolean
+ * }>}
+ */
 const TaxonomyMenu = ({
   taxonomy, iconMenu,
 }) => {

--- a/src/taxonomy/taxonomy-menu/TaxonomyMenu.test.jsx
+++ b/src/taxonomy/taxonomy-menu/TaxonomyMenu.test.jsx
@@ -83,7 +83,7 @@ describe.each([true, false])('<TaxonomyMenu iconMenu=%s />', (iconMenu) => {
     jest.clearAllMocks();
   });
 
-  test('should open and close menu on button click', async () => {
+  test('should open and close menu on button click', () => {
     const { getByRole, getByTestId, queryByLabelText } = render(
       <TaxonomyMenuComponent iconMenu={iconMenu} />,
     );
@@ -154,7 +154,7 @@ describe.each([true, false])('<TaxonomyMenu iconMenu=%s />', (iconMenu) => {
     expect(queryByTestId('taxonomy-menu-delete')).not.toBeInTheDocument();
   });
 
-  test('Hides import/delete actions for system-defined taxonomies', async () => {
+  test('Hides import/delete actions for system-defined taxonomies', () => {
     const systemDefined = true;
     const { getByTestId, queryByTestId } = render(
       <TaxonomyMenuComponent

--- a/src/taxonomy/taxonomy-menu/TaxonomyMenu.test.jsx
+++ b/src/taxonomy/taxonomy-menu/TaxonomyMenu.test.jsx
@@ -1,4 +1,6 @@
 // @ts-check
+/* eslint-disable react/prop-types */
+// ^ eslint doesn't 'see' JSDoc types; remove this lint directive when converting this to .tsx
 import React, { useMemo } from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { initializeMockApp } from '@edx/frontend-platform';
@@ -26,14 +28,18 @@ const queryClient = new QueryClient();
 
 const mockSetToastMessage = jest.fn();
 
+/**
+ * @type {React.FC<{
+ *   iconMenu: boolean,
+ *   systemDefined?: boolean,
+ *   canChangeTaxonomy?: boolean,
+ *   canDeleteTaxonomy?: boolean,
+ * }>}
+ */
 const TaxonomyMenuComponent = ({
-  // eslint-disable-next-line react/prop-types
   iconMenu,
-  // eslint-disable-next-line react/prop-types
   systemDefined = false,
-  // eslint-disable-next-line react/prop-types
   canChangeTaxonomy = true,
-  // eslint-disable-next-line react/prop-types
   canDeleteTaxonomy = true,
 }) => {
   const context = useMemo(() => ({


### PR DESCRIPTION
## Description

One of the test files wasn't running:

```
PASS src/taxonomy/taxonomy-menu/TaxonomyMenu.test.jsx
  ● Console
    console.log
        ● Test suite failed to run
      
          Returning a Promise from "describe" is not supported. Tests must be defined synchronously.
          Returning a value from "describe" will fail the test in a future version of Jest.
```

It's unfortunate that this doesn't raise an error in the current version of Jest, because this is a serious issue that is easy to overlook in the test logs.

While I was at it, I also made a few typing improvements and changed one use of `getByTestId` to the (preferred) `getByRole`

Internal ref: FAL-3702