### PR TITLE
feat: Put Taxonomies tab behind flag

### DIFF
--- a/src/studio-home/tabs-section/TabsSection.test.jsx
+++ b/src/studio-home/tabs-section/TabsSection.test.jsx
@@ -158,9 +158,21 @@ describe('<TabsSection />', () => {
   });
 
   describe('taxonomies tab', () => {
-    it('should redirect to taxonomies page', async () => {
+    it('should not show taxonomies tab on page if not enabled', async () => {
       render(<RootWrapper />);
       axiosMock.onGet(getStudioHomeApiUrl()).reply(200, generateGetStudioHomeDataApiResponse());
+      await executeThunk(fetchStudioHomeData(), store.dispatch);
+
+      expect(screen.getByText(tabMessages.coursesTabTitle.defaultMessage)).toBeInTheDocument();
+      expect(screen.queryByText(tabMessages.taxonomiesTabTitle.defaultMessage)).toBeNull();
+    });
+
+    it('should redirect to taxonomies page', async () => {
+      const data = generateGetStudioHomeDataApiResponse();
+      data.taxonomiesEnabled = true;
+
+      render(<RootWrapper />);
+      axiosMock.onGet(getStudioHomeApiUrl()).reply(200, data);
       await executeThunk(fetchStudioHomeData(), store.dispatch);
 
       const taxonomiesTab = screen.getByText(tabMessages.taxonomiesTabTitle.defaultMessage);

--- a/src/studio-home/tabs-section/index.jsx
+++ b/src/studio-home/tabs-section/index.jsx
@@ -33,7 +33,7 @@ const TabsSection = ({
     libraryAuthoringMfeUrl,
     redirectToLibraryAuthoringMfe,
     courses, librariesEnabled, libraries, archivedCourses,
-    numPages, coursesCount,
+    numPages, coursesCount, taxonomiesEnabled,
   } = useSelector(getStudioHomeData);
   const {
     courseLoadingStatus,
@@ -103,13 +103,15 @@ const TabsSection = ({
       );
     }
 
-    tabs.push(
-      <Tab
-        key={TABS_LIST.taxonomies}
-        eventKey={TABS_LIST.taxonomies}
-        title={intl.formatMessage(messages.taxonomiesTabTitle)}
-      />,
-    );
+    if (taxonomiesEnabled) {
+      tabs.push(
+        <Tab
+          key={TABS_LIST.taxonomies}
+          eventKey={TABS_LIST.taxonomies}
+          title={intl.formatMessage(messages.taxonomiesTabTitle)}
+        />,
+      );
+    }
 
     return tabs;
   }, [archivedCourses, librariesEnabled, showNewCourseContainer, isLoadingCourses, isLoadingLibraries]);


### PR DESCRIPTION
## Description

This PR is a followup on https://github.com/openedx/frontend-app-course-authoring/pull/923 putting the "Taxonomies" tab behind the `taxonomiesEnabled` flag.

## Supporting information

Related PR:

- https://github.com/openedx/frontend-app-course-authoring/pull/923

## Testing instructions

1. Run this branch in your local dev stack
1. Make sure you have the `new_studio_mfe.use_new_home_page` flag is enabled
1. Make sure you have the `new_studio_mfe.use_tagging_taxonomy_list_page` **disabled** initially
1. Navigate to the course authoring home page: http://apps.local.edly.io:2001/course-authoring/home
1. Confirm that the taxonomies tab does not appear
1. Now **enabled** the `new_studio_mfe.use_tagging_taxonomy_list_page` flag
1. Confirm that the "Taxonomies" tab now appears on the home page
1. Confirm that clicking on it navigates to the taxonomies list page

--- 
Private-ref: [FAL-3699](https://tasks.opencraft.com/browse/FAL-3699)