### PR TITLE
chore: change github workflow file to not fail pipeline for codecov

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Codecov uploads are not working right now. Thus, no PR can be merged.
I'm trying to make it so the pipeline doesn't fail if the codecov upload fails.

Relates to https://github.com/openedx/axim-engineering/issues/1109
and to https://github.com/openedx/frontend-app-course-authoring/pull/846