### PR TITLE
fix: referencing activeStatus for undefined

### DIFF
--- a/src/files-and-videos/generic/DeleteConfirmationModal.jsx
+++ b/src/files-and-videos/generic/DeleteConfirmationModal.jsx
@@ -25,7 +25,7 @@ const DeleteConfirmationModal = ({
   const firstSelectedRow = selectedRows[0]?.original;
   let activeContentRows = [];
   if (Array.isArray(selectedRows)) {
-    activeContentRows = selectedRows.filter(row => row.original.activeStatus === 'active');
+    activeContentRows = selectedRows.filter(row => row.original?.activeStatus === 'active');
   }
   const isDeletingCourseContent = activeContentRows.length > 0;
 


### PR DESCRIPTION
## Description

This PR fixes a undefined bug when deleting files with new Delete Confirmation Modal #938 (See PR for full details)

## Testing instructions

1. Navigate to the Files page
2. Select a file to delete
3. Should open delete confirmation with the file name is the title
4. Click "Delete"
5. Should successfully delete and close delete modal