### PR TITLE
fix: react datepicker workaround for local time

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -284,7 +284,7 @@ export const convertToDateFromString = (dateStr) => {
   const sign = timeZoneOffset < 0 ? '+' : '-';
   const timeZone = `${sign}${String(timeZoneHours).padStart(2, '0')}00`;
 
-  return moment(stripTimeZone(dateStr) + timeZone).toDate();
+  return moment(stripTimeZone(String(dateStr)) + timeZone).toDate();
 };
 
 export const convertToStringFromDate = (date) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -255,19 +255,49 @@ export function setupYupExtensions() {
 }
 
 export const convertToDateFromString = (dateStr) => {
+  /**
+   * Convert UTC to local time for react-datepicker
+   * Note: react-datepicker has a bug where it only interacts with local time
+   * @param {string} dateStr - YYYY-MM-DDTHH:MM:SSZ
+   * @return {Date} date in local time
+   */
   if (!dateStr) {
     return '';
   }
 
-  return moment(dateStr).utc().toDate();
+  const stripTimeZone = (stringValue) => stringValue.substring(0,19);
+
+  const differenceDueToDST = (date) => {
+    const isNowDST = moment(new Date()).isDST();
+    const isDateDST = moment(date).isDST();
+    if (isNowDST && !isDateDST) {
+      return 1;
+    } else if (!isNowDST && isDateDST) {
+      return -1;
+    }
+    return 0;
+  };
+
+  const timeZoneOffset = new Date().getTimezoneOffset();
+  const timeZoneHours = (Math.abs(timeZoneOffset) / 60) + differenceDueToDST(moment(dateStr));
+  const sign = timeZoneOffset < 0 ? '+' : '-';
+  const timeZone = sign + String(timeZoneHours).padStart(2, '0') + '00';
+
+  return moment(stripTimeZone(dateStr) + timeZone).toDate();
 };
 
 export const convertToStringFromDate = (date) => {
+  /**
+   * Convert local time to UTC from react-datepicker
+   * Note: react-datepicker has a bug where it only interacts with local time
+   * @param {Date} date - date in local time
+   * @return {string} YYYY-MM-DDTHH:MM:SSZ
+   */
   if (!date) {
     return '';
   }
 
-  return moment(date).utc().format(DATE_TIME_FORMAT);
+  return moment(date).format(DATE_TIME_FORMAT);
 };
 
 export const isValidDate = (date) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -265,14 +265,15 @@ export const convertToDateFromString = (dateStr) => {
     return '';
   }
 
-  const stripTimeZone = (stringValue) => stringValue.substring(0,19);
+  const stripTimeZone = (stringValue) => stringValue.substring(0, 19);
 
   const differenceDueToDST = (date) => {
     const isNowDST = moment(new Date()).isDST();
     const isDateDST = moment(date).isDST();
     if (isNowDST && !isDateDST) {
       return 1;
-    } else if (!isNowDST && isDateDST) {
+    }
+    if (!isNowDST && isDateDST) {
       return -1;
     }
     return 0;
@@ -281,7 +282,7 @@ export const convertToDateFromString = (dateStr) => {
   const timeZoneOffset = new Date().getTimezoneOffset();
   const timeZoneHours = (Math.abs(timeZoneOffset) / 60) + differenceDueToDST(moment(dateStr));
   const sign = timeZoneOffset < 0 ? '+' : '-';
-  const timeZone = sign + String(timeZoneHours).padStart(2, '0') + '00';
+  const timeZone = `${sign}${String(timeZoneHours).padStart(2, '0')}00`;
 
   return moment(stripTimeZone(dateStr) + timeZone).toDate();
 };


### PR DESCRIPTION
## Description

This PR fixes an issue with how we're using `react-datepicker`. Currently, the package has a bug where the date/time input only accepts local time. This PR is a workaround so our date/time is displayed and saved as UTC as expected.

Link to `react-datepicker`'s issue: https://github.com/Hacker0x01/react-datepicker/issues/1787


## Testing instructions

Test the following with date/time in daylight savings and not in daylight savings.

1. Navigate to the course outline page.
2. Configure a subsection.
3. Change the time on a due date.
4. The time on the input should be the time you selected.
5. Save.
6. The due date shown should be the time you selected.
7. Navigate to the course details page.
8. Repeat the testing steps above for the course end date field.


## Other information

https://2u-internal.atlassian.net/browse/TNL-11542