### PR TITLE
build: Update codecov and start using repo tokens.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,7 @@ jobs:
         node-version: ${{ env.NODE_VER }}
     - run: make validate.ci
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: false
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Update codecove to the latest version and start using the per repo
tokens which will soon be required to get more reliable coverage builds.

This change also has a corresponding addition of a codecov repo upload
token to the repository secrets for this repo.
