### PR TITLE
feat: Add In progress message on import taxonomy

### DIFF
--- a/src/taxonomy/TaxonomyListPage.jsx
+++ b/src/taxonomy/TaxonomyListPage.jsx
@@ -1,5 +1,5 @@
 // @ts-check
-import React, { useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -29,10 +29,27 @@ import { useImportNewTaxonomy, useTaxonomyList } from './data/apiHooks';
 import { importTaxonomy } from './import-tags';
 import messages from './messages';
 import TaxonomyCard from './taxonomy-card';
+import { TaxonomyContext } from './common/context';
 
 const TaxonomyListHeaderButtons = ({ canAddTaxonomy }) => {
   const intl = useIntl();
   const importMutation = useImportNewTaxonomy();
+  const { setToastMessage } = useContext(TaxonomyContext);
+
+  const showImportInProgressAlert = useCallback(() => {
+    /* istanbul ignore next */
+    if (setToastMessage) {
+      setToastMessage(intl.formatMessage(messages.importInProgressAlertDescription));
+    }
+  }, [setToastMessage]);
+
+  const closeImportInProgressAlert = useCallback(() => {
+    /* istanbul ignore next */
+    if (setToastMessage) {
+      setToastMessage(null);
+    }
+  }, [setToastMessage]);
+
   return (
     <>
       <OverlayTrigger
@@ -69,7 +86,12 @@ const TaxonomyListHeaderButtons = ({ canAddTaxonomy }) => {
       </OverlayTrigger>
       <Button
         iconBefore={Add}
-        onClick={() => importTaxonomy(intl, importMutation)}
+        onClick={() => importTaxonomy(
+          intl,
+          importMutation,
+          showImportInProgressAlert,
+          closeImportInProgressAlert,
+        )}
         data-testid="taxonomy-import-button"
         disabled={!canAddTaxonomy}
       >

--- a/src/taxonomy/import-tags/utils.js
+++ b/src/taxonomy/import-tags/utils.js
@@ -41,8 +41,15 @@ const selectFile = async () => new Promise((resolve) => {
  * @param {*} intl The react-intl object returned by the useIntl() hook
  * @param {ReturnType<typeof import('../data/apiHooks').useImportNewTaxonomy>} importMutation The import mutation
  *        returned by the useImportNewTaxonomy() hook.
+ * @param {() => void} showImportInProgressAlert Function to show `In progress` alert.
+ * @param {() => void} closeImportInProgressAlert Function to close `In progress` alert.
  */
-export const importTaxonomy = async (intl, importMutation) => { // eslint-disable-line import/prefer-default-export
+export const importTaxonomy = async ( // eslint-disable-line import/prefer-default-export
+  intl,
+  importMutation,
+  showImportInProgressAlert,
+  closeImportInProgressAlert,
+) => {
   /*
     * This function is a temporary "Barebones" implementation of the import
     * functionality with `prompt` and `alert`. It is intended to be replaced
@@ -86,13 +93,17 @@ export const importTaxonomy = async (intl, importMutation) => { // eslint-disabl
     return;
   }
 
+  showImportInProgressAlert();
+
   importMutation.mutateAsync({
     name,
     description,
     file,
   }).then(() => {
+    closeImportInProgressAlert();
     alert(intl.formatMessage(messages.importTaxonomySuccess));
   }).catch((error) => {
+    closeImportInProgressAlert();
     alert(intl.formatMessage(messages.importTaxonomyError));
     console.error(error.response);
   });

--- a/src/taxonomy/messages.js
+++ b/src/taxonomy/messages.js
@@ -49,6 +49,11 @@ const messages = defineMessages({
     id: 'course-authoring.taxonomy-list.alert.dismiss',
     defaultMessage: 'Dismiss',
   },
+  importInProgressAlertDescription: {
+    id: 'course-authoring.import-tags.prompt.in-progress',
+    defaultMessage: 'Please keep this window open. We\'ll let you know when it\'s done.',
+    description: 'Alert message when the taxonomy import is in progress.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Adds `In progress` message when import a taxonomy

![image](https://github.com/openedx/frontend-app-course-authoring/assets/11827305/653e18da-5682-46c4-b876-7ab5b4727272)

## Supporting information

- Closes https://github.com/openedx/modular-learning/issues/205
- Internal ticket: [FAL-3707](https://tasks.opencraft.com/browse/FAL-3707).

## Testing instructions

- Make sure you have some sample taxonomy/tags data setup: https://github.com/open-craft/taxonomy-sample-data
- Make sure you have taxonomies list page enabled: new_studio_mfe.use_tagging_taxonomy_list_page
- Navigate to the taxonomies list page.
- Click on `Import` button.
- Follow the import workflow.
- Verify the message after finish the workflow.