### PR TITLE
fix: fixed scroll issue of provider and settings

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -96,6 +96,7 @@ const DiscussionsSettings = ({ courseId, intl }) => {
             onClose={handleClose}
             isOpen
             beforeBodyNode={<Stepper.Header className="border-bottom border-light" />}
+            isOverflowVisible={false}
             footerNode={(
               <>
                 <Stepper.ActionRow eventKey={SELECTION_STEP}>


### PR DESCRIPTION
[INF-1366](https://2u-internal.atlassian.net/browse/INF-1366)

## Description

User was unable to scroll down the provider and discussion settings pages in Studio. 
The issue was due to **isOverflowVisible** className. I passed this prop for paragon component **FullscreenModal** and fixed scroll issue.

**Screenshots**

**Before**
<img width="1110" alt="Screenshot 2024-04-22 at 1 41 12 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/72802712/7b2ecd29-53d7-4e2b-beba-b5405e72baca">

**After**
<img width="1102" alt="Screenshot 2024-04-22 at 1 43 44 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/72802712/a6cac897-65aa-4db1-ad37-43d0e841000d">

