### PR TITLE
feat: search modal refinements

### DIFF
--- a/src/course-outline/section-card/SectionCard.jsx
+++ b/src/course-outline/section-card/SectionCard.jsx
@@ -42,10 +42,10 @@ const SectionCard = ({
   const intl = useIntl();
   const dispatch = useDispatch();
   const { activeId, overId } = useContext(DragContext);
-  const [isExpanded, setIsExpanded] = useState(isSectionsExpanded);
   const [searchParams] = useSearchParams();
   const locatorId = searchParams.get('show');
   const isScrolledToElement = locatorId === section.id;
+  const [isExpanded, setIsExpanded] = useState(locatorId ? !!locatorId : isSectionsExpanded);
   const [isFormOpen, openForm, closeForm] = useToggle(false);
   const namePrefix = 'section';
 
@@ -75,9 +75,17 @@ const SectionCard = ({
 
   useEffect(() => {
     if (currentRef.current && (section.shouldScroll || isScrolledToElement)) {
-      scrollToElement(currentRef.current);
+      // Align element closer to the top of the screen if scrolling for search result
+      const alignWithTop = !!isScrolledToElement;
+      scrollToElement(currentRef.current, alignWithTop);
     }
   }, [isScrolledToElement]);
+
+  useEffect(() => {
+    // If the locatorId is set/changed, we need to make sure that the section is expanded
+    // in order to scroll to search result, otherwise leave it as is.
+    setIsExpanded((prevState) => (locatorId ? !!locatorId : prevState));
+  }, [locatorId, setIsExpanded]);
 
   // re-create actions object for customizations
   const actions = { ...sectionActions };

--- a/src/course-outline/subsection-card/SubsectionCard.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.jsx
@@ -73,7 +73,14 @@ const SubsectionCard = ({
   actions.allowMoveDown = !isEmpty(moveDownDetails);
 
   // Expand the subsection if a search result should be shown/scrolled to
-  const [isExpanded, setIsExpanded] = useState(locatorId ? !!locatorId : !isHeaderVisible);
+  const containsSearchResult = () => {
+    if (locatorId) {
+      return !!subsection.childInfo?.children?.filter((child) => child.id === locatorId).length;
+    }
+
+    return false;
+  };
+  const [isExpanded, setIsExpanded] = useState(containsSearchResult() || !isHeaderVisible);
   const subsectionStatus = getItemStatus({
     published,
     visibilityState,
@@ -141,8 +148,8 @@ const SubsectionCard = ({
 
   useEffect(() => {
     // If the locatorId is set/changed, we need to make sure that the subsection is expanded
-    // in order to scroll to search result
-    setIsExpanded((prevState) => (locatorId ? !!locatorId : prevState));
+    // if it contains the result, in order to scroll to it
+    setIsExpanded((prevState) => (containsSearchResult() || prevState));
   }, [locatorId, setIsExpanded]);
 
   useEffect(() => {
@@ -273,6 +280,13 @@ SubsectionCard.propTypes = {
       duplicable: PropTypes.bool.isRequired,
     }).isRequired,
     isHeaderVisible: PropTypes.bool,
+    childInfo: PropTypes.shape({
+      children: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string.isRequired,
+        }),
+      ).isRequired,
+    }).isRequired,
   }).isRequired,
   children: PropTypes.node,
   isSelfPaced: PropTypes.bool.isRequired,

--- a/src/course-outline/subsection-card/SubsectionCard.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.jsx
@@ -72,7 +72,8 @@ const SubsectionCard = ({
   actions.allowMoveUp = !isEmpty(moveUpDetails);
   actions.allowMoveDown = !isEmpty(moveDownDetails);
 
-  const [isExpanded, setIsExpanded] = useState(locatorId ? isScrolledToElement : !isHeaderVisible);
+  // Expand the subsection if a search result should be shown/scrolled to
+  const [isExpanded, setIsExpanded] = useState(locatorId ? !!locatorId : !isHeaderVisible);
   const subsectionStatus = getItemStatus({
     published,
     visibilityState,
@@ -132,9 +133,17 @@ const SubsectionCard = ({
     // we need to check section.shouldScroll as whole section is fetched when a
     // subsection is duplicated under it.
     if (currentRef.current && (section.shouldScroll || subsection.shouldScroll || isScrolledToElement)) {
-      scrollToElement(currentRef.current);
+      // Align element closer to the top of the screen if scrolling for search result
+      const alignWithTop = !!isScrolledToElement;
+      scrollToElement(currentRef.current, alignWithTop);
     }
   }, [isScrolledToElement]);
+
+  useEffect(() => {
+    // If the locatorId is set/changed, we need to make sure that the subsection is expanded
+    // in order to scroll to search result
+    setIsExpanded((prevState) => (locatorId ? !!locatorId : prevState));
+  }, [locatorId, setIsExpanded]);
 
   useEffect(() => {
     if (savingStatus === RequestStatus.SUCCESSFUL) {

--- a/src/course-outline/subsection-card/SubsectionCard.test.jsx
+++ b/src/course-outline/subsection-card/SubsectionCard.test.jsx
@@ -32,13 +32,8 @@ const clipboardBroadcastChannelMock = {
 
 global.BroadcastChannel = jest.fn(() => clipboardBroadcastChannelMock);
 
-const section = {
-  id: '123',
-  displayName: 'Section Name',
-  published: true,
-  visibilityState: 'live',
-  hasChanges: false,
-  highlights: ['highlight 1', 'highlight 2'],
+const unit = {
+  id: 'unit-1',
 };
 
 const subsection = {
@@ -56,6 +51,25 @@ const subsection = {
   },
   isHeaderVisible: true,
   releasedToStudents: true,
+  childInfo: {
+    children: [{
+      id: unit.id,
+    }],
+  },
+};
+
+const section = {
+  id: '123',
+  displayName: 'Section Name',
+  published: true,
+  visibilityState: 'live',
+  hasChanges: false,
+  highlights: ['highlight 1', 'highlight 2'],
+  childInfo: {
+    children: [{
+      id: subsection.id,
+    }],
+  },
 };
 
 const onEditSubectionSubmit = jest.fn();
@@ -227,12 +241,22 @@ describe('<SubsectionCard />', () => {
     expect(await findByText(cardHeaderMessages.statusBadgeDraft.defaultMessage)).toBeInTheDocument();
   });
 
-  it('check extended section when URL has a "show" param', async () => {
-    const { findByTestId } = renderComponent(null, `?show=${section.id}`);
+  it('check extended subsection when URL "show" param in subsection', async () => {
+    const { findByTestId } = renderComponent(null, `?show=${unit.id}`);
 
     const cardUnits = await findByTestId('subsection-card__units');
     const newUnitButton = await findByTestId('new-unit-button');
     expect(cardUnits).toBeInTheDocument();
     expect(newUnitButton).toBeInTheDocument();
+  });
+
+  it('check not extended subsection when URL "show" param not in subsection', async () => {
+    const randomId = 'random-id';
+    const { queryByTestId } = renderComponent(null, `?show=${randomId}`);
+
+    const cardUnits = await queryByTestId('subsection-card__units');
+    const newUnitButton = await queryByTestId('new-unit-button');
+    expect(cardUnits).toBeNull();
+    expect(newUnitButton).toBeNull();
   });
 });

--- a/src/course-outline/unit-card/UnitCard.jsx
+++ b/src/course-outline/unit-card/UnitCard.jsx
@@ -114,7 +114,9 @@ const UnitCard = ({
     // we need to check section.shouldScroll as whole section is fetched when a
     // unit is duplicated under it.
     if (currentRef.current && (section.shouldScroll || unit.shouldScroll || isScrolledToElement)) {
-      scrollToElement(currentRef.current);
+      // Align element closer to the top of the screen if scrolling for search result
+      const alignWithTop = !!isScrolledToElement;
+      scrollToElement(currentRef.current, alignWithTop);
     }
   }, [isScrolledToElement]);
 

--- a/src/course-outline/utils.jsx
+++ b/src/course-outline/utils.jsx
@@ -165,12 +165,20 @@ const getHighlightsFormValues = (currentHighlights) => {
  * Method to scroll into view port, if it's outside the viewport
  *
  * @param {Object} target - DOM Element
+ * @param {boolean} alignWithTop (optional) - Whether top of the target will be aligned to
+ *                                            the top of viewpoint. (default: false)
  * @returns {undefined}
  */
-const scrollToElement = target => {
+const scrollToElement = (target, alignWithTop = false) => {
   if (target.getBoundingClientRect().bottom > window.innerHeight) {
-    //  The bottom of the target will be aligned to the bottom of the visible area of the scrollable ancestor.
-    target.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
+    // if alignWithTop is set, the top of the target will be aligned to the top of visible area
+    // of the scrollable ancestor, Otherwise, the bottom of the target will be aligned to the
+    // bottom of the visible area of the scrollable ancestor.
+    target.scrollIntoView({
+      behavior: 'smooth',
+      block: alignWithTop ? 'start' : 'end',
+      inline: 'nearest',
+    });
   }
 
   // Target is outside the view from the top

--- a/src/search-modal/SearchKeywordsField.jsx
+++ b/src/search-modal/SearchKeywordsField.jsx
@@ -15,14 +15,21 @@ const SearchKeywordsField = (props) => {
   const { searchKeywords, setSearchKeywords } = useSearchContext();
 
   return (
-    <SearchField
+    <SearchField.Advanced
       onSubmit={setSearchKeywords}
       onChange={setSearchKeywords}
       onClear={() => setSearchKeywords('')}
       value={searchKeywords}
       className={props.className}
-      placeholder={intl.formatMessage(messages.inputPlaceholder)}
-    />
+    >
+      <SearchField.Label />
+      <SearchField.Input
+        autoFocus
+        placeholder={intl.formatMessage(messages.inputPlaceholder)}
+      />
+      <SearchField.ClearButton />
+      <SearchField.SubmitButton />
+    </SearchField.Advanced>
   );
 };
 

--- a/src/search-modal/SearchModal.scss
+++ b/src/search-modal/SearchModal.scss
@@ -31,6 +31,11 @@
       // The current Open edX theme makes the search field square but the button round and it looks bad. We need this
       // hacky override until the theme is fixed to be more consistent.
       border-radius: 0;
+
+      // Needed so the the focus borders matches the button's borders
+      &:focus::before {
+        border-radius: 0;
+      }
     }
   }
 

--- a/src/search-modal/SearchUI.jsx
+++ b/src/search-modal/SearchUI.jsx
@@ -37,7 +37,7 @@ const SearchUI = (props) => {
       <ModalDialog.Header style={{ zIndex: 9 }} className="border-bottom">
         <ModalDialog.Title><FormattedMessage {...messages.title} /></ModalDialog.Title>
         <div className="d-flex mt-3">
-          <SearchKeywordsField className="flex-grow-1 mr-1" />
+          <SearchKeywordsField className="flex-grow-1 mr-2" />
           <SelectMenu variant="primary">
             <MenuItem
               onClick={switchToThisCourse}


### PR DESCRIPTION
## Description

This PR adds a few styling and UX refinements to the search modal.

## Supporting information

Related Tickets:
- https://github.com/openedx/modular-learning/issues/211

**Note:**
The following points in the related github issue could not be reproduced on master:

> 3. For each result, the course/library name should only appear in the breadcrumbs when “all courses” is selected. (Currently, it shows for the results in “this course” too.)

> 4. If I enter a search term that yields no results, I am unable to open the “type” filter. Change it to behave like the "Tags" filter and display a message like "No types in current results" in that case.

See [comment](https://github.com/openedx/modular-learning/issues/211#issuecomment-2071662503) on PR for more information.

## Testing instructions

1. Run you local devstack on this branch
1. Make sure you have the [tutor-contrib-melisearch](https://github.com/open-craft/tutor-contrib-meilisearch/) plugin installed and enabled
1. Confirm the following:
    1. The focus state of the button outline should have a square edge to match the button shape.
        <img width="330" alt="Screenshot 2024-04-28 at 1 22 02 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/6829768/30df26f8-367a-488e-8e2b-6f9d5a530319">

    1. The spacing between the search keywords field and "This Course" dropdown select menu has been increased to allow for few pixels between them when the button is focused.
    3. When the search modal opens, focus on the search keywords field so the user can start typing right away.
    4. Search for a keyword and confirm the following:
        1. ~When selecting a result, it should navigate to the page, expand the section/subsection, and scroll to it positioning it closer to the top of the page.~
         Since https://github.com/openedx/frontend-app-course-authoring/pull/957 was merged, click on unit search result redirects directly to the unit. So in order to test this the scroll/expanding of subsection in PR for units you need to include the the unit ID in the `show` queryparam in the url in order to see it in action, i.e only the subsection with the Unit will expand. For example:

            http://apps.local.edly.io:2001/course-authoring/course/course-v1:SampleTaxonomyOrg1+STC1+2023_1?show=block-v1%3ASampleTaxonomyOrg1%2BSTC1%2B2023_1%2Btype%40vertical%2Bblock%40aaf8b8eb86b54281aeeab12499d2cb0b

            _Note: Make sure the unit id is URL encoded._        

        1. Check that if you are in a course, and the section is collapsed, and you search for a subsection in the collapsed, it expands it and scrolls to it, positioning it closer to the top

---
Private-ref: [FAL-3718](https://tasks.opencraft.com/browse/FAL-3718)