### PR TITLE
fix: adding files count in toast

### DIFF
--- a/src/files-and-videos/generic/FileInput.jsx
+++ b/src/files-and-videos/generic/FileInput.jsx
@@ -11,7 +11,7 @@ export const useFileInput = ({
   const click = () => ref.current.click();
   const addFile = (e) => {
     const { files } = e.target;
-    setSelectedRows(files);
+    setSelectedRows([...files]);
     onAddFile(Object.values(files));
     setAddOpen();
     e.target.value = '';

--- a/src/files-and-videos/generic/messages.js
+++ b/src/files-and-videos/generic/messages.js
@@ -8,7 +8,7 @@ const messages = defineMessages({
   },
   apiStatusToastMessage: {
     id: 'course-authoring.files-and-upload.apiStatus.message',
-    defaultMessage: '{actionType} {selectedRowCount} {fileType}(s)',
+    defaultMessage: '{actionType} {selectedRowCount} {selectedRowCount, plural, one {{fileType}} other {{fileType}s}}',
     description: 'This message is showed in the toast when action is applied to files',
   },
   apiStatusAddingAction: {


### PR DESCRIPTION
## Description

This PR fixes the file count in the add toast for the Files and Videos pages. This bug was introduced in PR #885 by not using the spread operator in an array to allow the length of `selectedRows` to be valid and an integer. This change impacts Course Authors.

## Supporting information

JIRA Ticket: [TNL-11534](https://2u-internal.atlassian.net/browse/TNL-11534)
> When adding videos on the videos upload page, a toast appears on the bottom when you have selected your upload file. Regardless of the number of videos you’re uploading, it displays `Adding 0 video(s)`
>
> This has no impact on the actual uploading.
>
> Technical note: `<ApiStatusToast>` for the adding action in FileTable.jsx must be passed the correct value for `selectedRowCount`

## Testing instructions

1. Navigate to the Files page
2. Add one file
3. Toast in left corner should read "Adding 1 file"
4. Add multiple files
5. Toast in left corner should read "Adding {number of selected files} files"
