### PR TITLE
fix: errors for positive time zones

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -267,24 +267,7 @@ export const convertToDateFromString = (dateStr) => {
 
   const stripTimeZone = (stringValue) => stringValue.substring(0, 19);
 
-  const differenceDueToDST = (date) => {
-    const isNowDST = moment(new Date()).isDST();
-    const isDateDST = moment(date).isDST();
-    if (isNowDST && !isDateDST) {
-      return 1;
-    }
-    if (!isNowDST && isDateDST) {
-      return -1;
-    }
-    return 0;
-  };
-
-  const timeZoneOffset = new Date().getTimezoneOffset();
-  const timeZoneHours = (Math.abs(timeZoneOffset) / 60) + differenceDueToDST(moment(dateStr));
-  const sign = timeZoneOffset < 0 ? '+' : '-';
-  const timeZone = `${sign}${String(timeZoneHours).padStart(2, '0')}00`;
-
-  return moment(stripTimeZone(String(dateStr)) + timeZone).toDate();
+  return moment(stripTimeZone(String(dateStr))).toDate();
 };
 
 export const convertToStringFromDate = (date) => {


### PR DESCRIPTION
## Description

A recent PR (https://github.com/openedx/frontend-app-course-authoring/pull/944) introduces an error for users in positive time zones offsets (eg. Tokyo GMT+9 or Pakistan GMT+5). An invalid date error is encountered when navigating to the Course Updates page. This PR fixes the issue.

## Testing instructions

Test the following with your local machine set to various time zones. Test with date/time values for daylight savings and not daylight savings.

1. Navigate to the course outline page.
2. Configure a subsection.
3. Change the time on a due date.
4. The time on the input should be the time you selected.
5. Save.
6. The due date shown should be the time you selected.
7. Navigate to the course publish page.
8. Edit an update.
9. Changing the date should work as expected.


## Other information

https://2u-internal.atlassian.net/browse/TNL-11571