### PR TITLE
feat: add browser dialog to prevent navigation

### DIFF
--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -85,7 +85,7 @@ const VideosPage = ({
   useEffect(() => {
     window.onbeforeunload = () => {
       dispatch(markVideoUploadsInProgressAsFailed({ uploadingIdsRef, courseId }));
-      if (addVideoStatus === RequestStatus.IN_PROGRESS){
+      if (addVideoStatus === RequestStatus.IN_PROGRESS) {
         return '';
       }
       return undefined;

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -85,7 +85,7 @@ const VideosPage = ({
   useEffect(() => {
     window.onbeforeunload = () => {
       dispatch(markVideoUploadsInProgressAsFailed({ uploadingIdsRef, courseId }));
-      return undefined;
+      return "";
     };
   }, []);
 

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -85,9 +85,12 @@ const VideosPage = ({
   useEffect(() => {
     window.onbeforeunload = () => {
       dispatch(markVideoUploadsInProgressAsFailed({ uploadingIdsRef, courseId }));
-      return '';
+      if (addVideoStatus === RequestStatus.IN_PROGRESS){
+        return '';
+      }
+      return undefined;
     };
-  }, []);
+  }, [addVideoStatus]);
 
   const {
     isVideoTranscriptEnabled,

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -85,7 +85,7 @@ const VideosPage = ({
   useEffect(() => {
     window.onbeforeunload = () => {
       dispatch(markVideoUploadsInProgressAsFailed({ uploadingIdsRef, courseId }));
-      return "";
+      return '';
     };
   }, []);
 


### PR DESCRIPTION
## Description

Swithcing from undefined to "" tells the browser to put in a modal which requires users to confirm thier navigation away. this will prevent continued annoyances from upload failures: https://2u-internal.atlassian.net/browse/TNL-11587

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.