### PR TITLE
[FC-0036] refactor: Further refinements to tag drawer

### DIFF
--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -382,7 +382,7 @@ const ContentTagsCollapsible = ({
           <Collapsible.Visible whenOpen>
             <Icon src={KeyboardArrowUp} />
           </Collapsible.Visible>
-          <h3 className="tags-drawer-taxonomy-name flex-grow-1 pl-2">{name}</h3>
+          <h3 className="h5 flex-grow-1 pl-2">{name}</h3>
         </Collapsible.Trigger>
 
         <Collapsible.Body className="collapsible-body">

--- a/src/content-tags-drawer/ContentTagsCollapsible.jsx
+++ b/src/content-tags-drawer/ContentTagsCollapsible.jsx
@@ -382,7 +382,7 @@ const ContentTagsCollapsible = ({
           <Collapsible.Visible whenOpen>
             <Icon src={KeyboardArrowUp} />
           </Collapsible.Visible>
-          <h4 className="flex-grow-1 pl-2">{name}</h4>
+          <h3 className="tags-drawer-taxonomy-name flex-grow-1 pl-2">{name}</h3>
         </Collapsible.Trigger>
 
         <Collapsible.Body className="collapsible-body">

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -90,10 +90,10 @@ const ContentTagsDrawer = ({ id, onClose }) => {
 
   return (
     <ContentTagsDrawerContext.Provider value={context}>
-      <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100">
+      <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
         <Container size="xl">
           { isContentDataLoaded
-            ? <h2>{ contentName }</h2>
+            ? <h2 className="tags-drawer-heading pl-2.5">{ contentName }</h2>
             : (
               <div className="d-flex justify-content-center align-items-center flex-column">
                 <Spinner
@@ -103,23 +103,25 @@ const ContentTagsDrawer = ({ id, onClose }) => {
                 />
               </div>
             )}
-
           <hr />
-          <p className="lead text-gray-500 font-weight-bold">{intl.formatMessage(messages.headerSubtitle)}</p>
-
-          { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded
-            ? tagsByTaxonomy.map((data) => (
-              <div key={`taxonomy-tags-collapsible-${data.id}`}>
-                <ContentTagsCollapsible
-                  contentId={contentId}
-                  taxonomyAndTagsData={data}
-                  stagedContentTags={stagedContentTags[data.id] || []}
-                  collapsibleState={collapsibleStates[data.id] || false}
-                />
-                <hr />
-              </div>
-            ))
-            : <Loading />}
+          <Container>
+            <p className="tags-drawer-subtitle lead text-gray-500 font-weight-bold">
+              {intl.formatMessage(messages.headerSubtitle)}
+            </p>
+            { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded
+              ? tagsByTaxonomy.map((data) => (
+                <div key={`taxonomy-tags-collapsible-${data.id}`}>
+                  <ContentTagsCollapsible
+                    contentId={contentId}
+                    taxonomyAndTagsData={data}
+                    stagedContentTags={stagedContentTags[data.id] || []}
+                    collapsibleState={collapsibleStates[data.id] || false}
+                  />
+                  <hr />
+                </div>
+              ))
+              : <Loading />}
+          </Container>
         </Container>
 
         { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded && (

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -93,7 +93,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
       <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
         <Container size="xl">
           { isContentDataLoaded
-            ? <h2 className="tags-drawer-heading pl-2.5">{ contentName }</h2>
+            ? <h2 className="h3 pl-2.5">{ contentName }</h2>
             : (
               <div className="d-flex justify-content-center align-items-center flex-column">
                 <Spinner
@@ -105,7 +105,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
             )}
           <hr />
           <Container>
-            <p className="tags-drawer-subtitle lead text-gray-500 font-weight-bold">
+            <p className="h4 text-gray-500 font-weight-bold">
               {intl.formatMessage(messages.headerSubtitle)}
             </p>
             { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded

--- a/src/content-tags-drawer/ContentTagsDrawer.scss
+++ b/src/content-tags-drawer/ContentTagsDrawer.scss
@@ -9,10 +9,6 @@
 }
 
 .tags-drawer {
-  .tags-drawer-heading {
-    font-size: 1.375rem !important;
-  }
-
   .tags-drawer-footer {
     right: 0;
     bottom: 0;
@@ -21,14 +17,6 @@
   .tags-drawer-cancel-button:hover {
     background-color: transparent;
     color: $gray-300 !important;
-  }
-
-  .tags-drawer-subtitle {
-    font-size: 1.125rem !important;
-  }
-
-  .tags-drawer-taxonomy-name {
-    font-size: .875rem !important;
   }
 }
 

--- a/src/content-tags-drawer/ContentTagsDrawer.scss
+++ b/src/content-tags-drawer/ContentTagsDrawer.scss
@@ -9,6 +9,10 @@
 }
 
 .tags-drawer {
+  .tags-drawer-heading {
+    font-size: 1.375rem !important;
+  }
+
   .tags-drawer-footer {
     right: 0;
     bottom: 0;
@@ -17,6 +21,14 @@
   .tags-drawer-cancel-button:hover {
     background-color: transparent;
     color: $gray-300 !important;
+  }
+
+  .tags-drawer-subtitle {
+    font-size: 1.125rem !important;
+  }
+
+  .tags-drawer-taxonomy-name {
+    font-size: .875rem !important;
   }
 }
 


### PR DESCRIPTION
## Description

* Padding to top and left tagging drawer
* Changes in headings in the tagging drawer

## Supporting information

- Closes https://github.com/openedx/modular-learning/issues/212
- Internal ticket: [FAL-3719](https://tasks.opencraft.com/browse/FAL-3719)

## Testing instructions

- Make sure you have some sample taxonomy/tags data setup: https://github.com/open-craft/taxonomy-sample-data
- Go to studio > one course  and open the mange tags of any section/unit.
- Check [this changes](https://github.com/openedx/modular-learning/issues/212#issue-2257267784):

    - > Please increase the padding around the top and sides of the tagging drawer (it can be increased by 50-100%).
    - > The H2 should be kept as  `<h2>` but should look like an H3
    - > The “Manage tags” heading should match the size of the H4 (18px)
    - > The Taxonomies headings should should be H3 (not H4) since the next heading above them (the unit name) is H2. However, please change them to look visually like H5.