### PR TITLE
feat: better api error handling

### DIFF
--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -13,7 +13,6 @@ import { Helmet } from 'react-helmet';
 import {
   Add as IconAdd,
   CheckCircle as CheckCircleIcon,
-  Warning as WarningIcon,
 } from '@openedx/paragon/icons';
 import { useSelector } from 'react-redux';
 import {
@@ -66,7 +65,6 @@ const CourseOutline = ({ courseId }) => {
     isCustomRelativeDatesActive,
     isLoading,
     isReIndexShow,
-    showErrorAlert,
     showSuccessAlert,
     isSectionsExpanded,
     isEnableHighlightsModalOpen,
@@ -116,6 +114,7 @@ const CourseOutline = ({ courseId }) => {
     handleSectionDragAndDrop,
     handleSubsectionDragAndDrop,
     handleUnitDragAndDrop,
+    errors,
   } = useCourseOutline({ courseId });
 
   const [sections, setSections] = useState(sectionsList);
@@ -231,6 +230,7 @@ const CourseOutline = ({ courseId }) => {
             mfeProctoredExamSettingsUrl={mfeProctoredExamSettingsUrl}
             advanceSettingsUrl={advanceSettingsUrl}
             savingStatus={savingStatus}
+            errors={errors}
           />
           <TransitionReplace>
             {showSuccessAlert ? (
@@ -258,6 +258,7 @@ const CourseOutline = ({ courseId }) => {
                 isDisabledReindexButton={isDisabledReindexButton}
                 hasSections={Boolean(sectionsList.length)}
                 courseActions={courseActions}
+                errors={errors}
               />
             )}
           />
@@ -279,132 +280,134 @@ const CourseOutline = ({ courseId }) => {
                       openEnableHighlightsModal={openEnableHighlightsModal}
                       handleVideoSharingOptionChange={handleVideoSharingOptionChange}
                     />
-                    <div className="pt-4">
-                      {sections.length ? (
-                        <>
-                          <DraggableList
-                            items={sections}
-                            setSections={setSections}
-                            restoreSectionList={restoreSectionList}
-                            handleSectionDragAndDrop={handleSectionDragAndDrop}
-                            handleSubsectionDragAndDrop={handleSubsectionDragAndDrop}
-                            handleUnitDragAndDrop={handleUnitDragAndDrop}
-                          >
-                            <SortableContext
-                              id="root"
+                    {!errors?.outlineIndexApi && (
+                      <div className="pt-4">
+                        {sections.length ? (
+                          <>
+                            <DraggableList
                               items={sections}
-                              strategy={verticalListSortingStrategy}
+                              setSections={setSections}
+                              restoreSectionList={restoreSectionList}
+                              handleSectionDragAndDrop={handleSectionDragAndDrop}
+                              handleSubsectionDragAndDrop={handleSubsectionDragAndDrop}
+                              handleUnitDragAndDrop={handleUnitDragAndDrop}
                             >
-                              {sections.map((section, sectionIndex) => (
-                                <SectionCard
-                                  key={section.id}
-                                  section={section}
-                                  index={sectionIndex}
-                                  canMoveItem={canMoveSection(sections)}
-                                  isSelfPaced={statusBarData.isSelfPaced}
-                                  isCustomRelativeDatesActive={isCustomRelativeDatesActive}
-                                  savingStatus={savingStatus}
-                                  onOpenHighlightsModal={handleOpenHighlightsModal}
-                                  onOpenPublishModal={openPublishModal}
-                                  onOpenConfigureModal={openConfigureModal}
-                                  onOpenDeleteModal={openDeleteModal}
-                                  onEditSectionSubmit={handleEditSubmit}
-                                  onDuplicateSubmit={handleDuplicateSectionSubmit}
-                                  isSectionsExpanded={isSectionsExpanded}
-                                  onNewSubsectionSubmit={handleNewSubsectionSubmit}
-                                  onOrderChange={updateSectionOrderByIndex}
-                                >
-                                  <SortableContext
-                                    id={section.id}
-                                    items={section.childInfo.children}
-                                    strategy={verticalListSortingStrategy}
+                              <SortableContext
+                                id="root"
+                                items={sections}
+                                strategy={verticalListSortingStrategy}
+                              >
+                                {sections.map((section, sectionIndex) => (
+                                  <SectionCard
+                                    key={section.id}
+                                    section={section}
+                                    index={sectionIndex}
+                                    canMoveItem={canMoveSection(sections)}
+                                    isSelfPaced={statusBarData.isSelfPaced}
+                                    isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+                                    savingStatus={savingStatus}
+                                    onOpenHighlightsModal={handleOpenHighlightsModal}
+                                    onOpenPublishModal={openPublishModal}
+                                    onOpenConfigureModal={openConfigureModal}
+                                    onOpenDeleteModal={openDeleteModal}
+                                    onEditSectionSubmit={handleEditSubmit}
+                                    onDuplicateSubmit={handleDuplicateSectionSubmit}
+                                    isSectionsExpanded={isSectionsExpanded}
+                                    onNewSubsectionSubmit={handleNewSubsectionSubmit}
+                                    onOrderChange={updateSectionOrderByIndex}
                                   >
-                                    {section.childInfo.children.map((subsection, subsectionIndex) => (
-                                      <SubsectionCard
-                                        key={subsection.id}
-                                        section={section}
-                                        subsection={subsection}
-                                        index={subsectionIndex}
-                                        getPossibleMoves={possibleSubsectionMoves(
-                                          [...sections],
-                                          sectionIndex,
-                                          section,
-                                          section.childInfo.children,
-                                        )}
-                                        isSelfPaced={statusBarData.isSelfPaced}
-                                        isCustomRelativeDatesActive={isCustomRelativeDatesActive}
-                                        savingStatus={savingStatus}
-                                        onOpenPublishModal={openPublishModal}
-                                        onOpenDeleteModal={openDeleteModal}
-                                        onEditSubmit={handleEditSubmit}
-                                        onDuplicateSubmit={handleDuplicateSubsectionSubmit}
-                                        onOpenConfigureModal={openConfigureModal}
-                                        onNewUnitSubmit={handleNewUnitSubmit}
-                                        onOrderChange={updateSubsectionOrderByIndex}
-                                        onPasteClick={handlePasteClipboardClick}
-                                      >
-                                        <SortableContext
-                                          id={subsection.id}
-                                          items={subsection.childInfo.children}
-                                          strategy={verticalListSortingStrategy}
+                                    <SortableContext
+                                      id={section.id}
+                                      items={section.childInfo.children}
+                                      strategy={verticalListSortingStrategy}
+                                    >
+                                      {section.childInfo.children.map((subsection, subsectionIndex) => (
+                                        <SubsectionCard
+                                          key={subsection.id}
+                                          section={section}
+                                          subsection={subsection}
+                                          index={subsectionIndex}
+                                          getPossibleMoves={possibleSubsectionMoves(
+                                            [...sections],
+                                            sectionIndex,
+                                            section,
+                                            section.childInfo.children,
+                                          )}
+                                          isSelfPaced={statusBarData.isSelfPaced}
+                                          isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+                                          savingStatus={savingStatus}
+                                          onOpenPublishModal={openPublishModal}
+                                          onOpenDeleteModal={openDeleteModal}
+                                          onEditSubmit={handleEditSubmit}
+                                          onDuplicateSubmit={handleDuplicateSubsectionSubmit}
+                                          onOpenConfigureModal={openConfigureModal}
+                                          onNewUnitSubmit={handleNewUnitSubmit}
+                                          onOrderChange={updateSubsectionOrderByIndex}
+                                          onPasteClick={handlePasteClipboardClick}
                                         >
-                                          {subsection.childInfo.children.map((unit, unitIndex) => (
-                                            <UnitCard
-                                              key={unit.id}
-                                              unit={unit}
-                                              subsection={subsection}
-                                              section={section}
-                                              isSelfPaced={statusBarData.isSelfPaced}
-                                              isCustomRelativeDatesActive={isCustomRelativeDatesActive}
-                                              index={unitIndex}
-                                              getPossibleMoves={possibleUnitMoves(
-                                                [...sections],
-                                                sectionIndex,
-                                                subsectionIndex,
-                                                section,
-                                                subsection,
-                                                subsection.childInfo.children,
-                                              )}
-                                              savingStatus={savingStatus}
-                                              onOpenPublishModal={openPublishModal}
-                                              onOpenConfigureModal={openConfigureModal}
-                                              onOpenDeleteModal={openDeleteModal}
-                                              onEditSubmit={handleEditSubmit}
-                                              onDuplicateSubmit={handleDuplicateUnitSubmit}
-                                              getTitleLink={getUnitUrl}
-                                              onOrderChange={updateUnitOrderByIndex}
-                                              onCopyToClipboardClick={handleCopyToClipboardClick}
-                                              discussionsSettings={discussionsSettings}
-                                            />
-                                          ))}
-                                        </SortableContext>
-                                      </SubsectionCard>
-                                    ))}
-                                  </SortableContext>
-                                </SectionCard>
-                              ))}
-                            </SortableContext>
-                          </DraggableList>
-                          {courseActions.childAddable && (
-                            <Button
-                              data-testid="new-section-button"
-                              className="mt-4"
-                              variant="outline-primary"
-                              onClick={handleNewSectionSubmit}
-                              iconBefore={IconAdd}
-                              block
-                            >
-                              {intl.formatMessage(messages.newSectionButton)}
-                            </Button>
-                          )}
-                        </>
-                      ) : (
-                        <EmptyPlaceholder
-                          onCreateNewSection={handleNewSectionSubmit}
-                          childAddable={courseActions.childAddable}
-                        />
-                      )}
-                    </div>
+                                          <SortableContext
+                                            id={subsection.id}
+                                            items={subsection.childInfo.children}
+                                            strategy={verticalListSortingStrategy}
+                                          >
+                                            {subsection.childInfo.children.map((unit, unitIndex) => (
+                                              <UnitCard
+                                                key={unit.id}
+                                                unit={unit}
+                                                subsection={subsection}
+                                                section={section}
+                                                isSelfPaced={statusBarData.isSelfPaced}
+                                                isCustomRelativeDatesActive={isCustomRelativeDatesActive}
+                                                index={unitIndex}
+                                                getPossibleMoves={possibleUnitMoves(
+                                                  [...sections],
+                                                  sectionIndex,
+                                                  subsectionIndex,
+                                                  section,
+                                                  subsection,
+                                                  subsection.childInfo.children,
+                                                )}
+                                                savingStatus={savingStatus}
+                                                onOpenPublishModal={openPublishModal}
+                                                onOpenConfigureModal={openConfigureModal}
+                                                onOpenDeleteModal={openDeleteModal}
+                                                onEditSubmit={handleEditSubmit}
+                                                onDuplicateSubmit={handleDuplicateUnitSubmit}
+                                                getTitleLink={getUnitUrl}
+                                                onOrderChange={updateUnitOrderByIndex}
+                                                onCopyToClipboardClick={handleCopyToClipboardClick}
+                                                discussionsSettings={discussionsSettings}
+                                              />
+                                            ))}
+                                          </SortableContext>
+                                        </SubsectionCard>
+                                      ))}
+                                    </SortableContext>
+                                  </SectionCard>
+                                ))}
+                              </SortableContext>
+                            </DraggableList>
+                            {courseActions.childAddable && (
+                              <Button
+                                data-testid="new-section-button"
+                                className="mt-4"
+                                variant="outline-primary"
+                                onClick={handleNewSectionSubmit}
+                                iconBefore={IconAdd}
+                                block
+                              >
+                                {intl.formatMessage(messages.newSectionButton)}
+                              </Button>
+                            )}
+                          </>
+                        ) : (
+                          <EmptyPlaceholder
+                            onCreateNewSection={handleNewSectionSubmit}
+                            childAddable={courseActions.childAddable}
+                          />
+                        )}
+                      </div>
+                    )}
                   </section>
                 </div>
               </article>
@@ -453,17 +456,6 @@ const CourseOutline = ({ courseId }) => {
           isQueryPending={savingStatus === RequestStatus.PENDING}
           onInternetConnectionFailed={handleInternetConnectionFailed}
         />
-        {showErrorAlert && (
-          <AlertMessage
-            key={intl.formatMessage(messages.alertErrorTitle)}
-            show={showErrorAlert}
-            variant="danger"
-            icon={WarningIcon}
-            title={intl.formatMessage(messages.alertErrorTitle)}
-            description=""
-            aria-hidden="true"
-          />
-        )}
       </div>
     </>
   );

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -168,20 +168,22 @@ describe('<CourseOutline />', () => {
       .onGet(getCourseOutlineIndexApiUrl(courseId))
       .reply(500, 'some internal error');
 
-    const { findByText, findByRole } = render(<RootWrapper />);
+    const { findByText, queryByRole } = render(<RootWrapper />);
     expect(await findByText('"some internal error"')).toBeInTheDocument();
     // check errors in store
     expect(store.getState().courseOutline.errors).toEqual({
+      courseLaunchApi: null,
       outlineIndexApi: {
         data: '"some internal error"',
+        dismissible: false,
         status: 500,
         type: 'serverError',
       },
+      reindexApi: null,
+      sectionLoadingApi: null,
     });
 
-    const dismissBtn = await findByRole('button', { name: 'Dismiss' });
-    fireEvent.click(dismissBtn);
-    expect(store.getState().courseOutline.errors).toEqual({});
+    expect(queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument();
   });
 
   it('check reindex and render success alert is correctly', async () => {
@@ -419,12 +421,21 @@ describe('<CourseOutline />', () => {
       courseLaunchApi: {
         data: 'Request failed with status code 500',
         type: 'unknown',
+        dismissible: true,
       },
+      outlineIndexApi: null,
+      reindexApi: null,
+      sectionLoadingApi: null,
     });
 
     const dismissBtn = await findByRole('button', { name: 'Dismiss' });
     fireEvent.click(dismissBtn);
-    expect(store.getState().courseOutline.errors).toEqual({});
+    expect(store.getState().courseOutline.errors).toEqual({
+      courseLaunchApi: null,
+      outlineIndexApi: null,
+      reindexApi: null,
+      sectionLoadingApi: null,
+    });
   });
 
   it('check highlights are enabled after enable highlights query is successful', async () => {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -163,6 +163,26 @@ describe('<CourseOutline />', () => {
     });
   });
 
+  it('handles course outline fetch api errors', async () => {
+    axiosMock
+      .onGet(getCourseOutlineIndexApiUrl(courseId))
+      .reply(500);
+
+    const { findByText, findByRole } = render(<RootWrapper />);
+    expect(await findByText('Request failed with status code 500')).toBeInTheDocument();
+    // check errors in store
+    expect(store.getState().courseOutline.errors).toEqual({
+      outlineIndexApi: {
+        data: 'Request failed with status code 500',
+        type: 'unknown',
+      },
+    });
+
+    const dismissBtn = await findByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissBtn);
+    expect(store.getState().courseOutline.errors).toEqual({});
+  });
+
   it('check reindex and render success alert is correctly', async () => {
     const { findByText, findByTestId } = render(<RootWrapper />);
 
@@ -378,6 +398,32 @@ describe('<CourseOutline />', () => {
     }), store.dispatch);
 
     expect(getByText('4/9 completed')).toBeInTheDocument();
+  });
+
+  it('render alerts if checklist api fails', async () => {
+    axiosMock
+      .onGet(getCourseLaunchApiUrl({
+        courseId, gradedOnly: true, validateOras: true, all: true,
+      }))
+      .reply(500);
+    const { findByText, findByRole } = render(<RootWrapper />);
+
+    await executeThunk(fetchCourseLaunchQuery({
+      courseId, gradedOnly: true, validateOras: true, all: true,
+    }), store.dispatch);
+
+    expect(await findByText('Request failed with status code 500')).toBeInTheDocument();
+    // check errors in store
+    expect(store.getState().courseOutline.errors).toEqual({
+      courseLaunchApi: {
+        data: 'Request failed with status code 500',
+        type: 'unknown',
+      },
+    });
+
+    const dismissBtn = await findByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissBtn);
+    expect(store.getState().courseOutline.errors).toEqual({});
   });
 
   it('check highlights are enabled after enable highlights query is successful', async () => {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -166,15 +166,16 @@ describe('<CourseOutline />', () => {
   it('handles course outline fetch api errors', async () => {
     axiosMock
       .onGet(getCourseOutlineIndexApiUrl(courseId))
-      .reply(500);
+      .reply(500, 'some internal error');
 
     const { findByText, findByRole } = render(<RootWrapper />);
-    expect(await findByText('Request failed with status code 500')).toBeInTheDocument();
+    expect(await findByText('"some internal error"')).toBeInTheDocument();
     // check errors in store
     expect(store.getState().courseOutline.errors).toEqual({
       outlineIndexApi: {
-        data: 'Request failed with status code 500',
-        type: 'unknown',
+        data: '"some internal error"',
+        status: 500,
+        type: 'serverError',
       },
     });
 

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -140,6 +140,17 @@ describe('<CourseOutline />', () => {
     axiosMock
       .onGet(getCourseOutlineIndexApiUrl(courseId))
       .reply(200, courseOutlineIndexMock);
+    axiosMock
+      .onGet(getCourseBestPracticesApiUrl({
+        courseId, excludeGraded: true, all: true,
+      }))
+      .reply(200, courseBestPracticesMock);
+
+    axiosMock
+      .onGet(getCourseLaunchApiUrl({
+        courseId, gradedOnly: true, validateOras: true, all: true,
+      }))
+      .reply(200, courseLaunchMock);
     await executeThunk(fetchCourseOutlineIndexQuery(courseId), store.dispatch);
   });
 
@@ -224,7 +235,7 @@ describe('<CourseOutline />', () => {
     const reindexButton = await findByTestId('course-reindex');
     await act(async () => fireEvent.click(reindexButton));
 
-    expect(await findByText(messages.alertErrorTitle.defaultMessage)).toBeInTheDocument();
+    expect(await findByText('Request failed with status code 500')).toBeInTheDocument();
   });
 
   it('check that new section list is saved when dragged', async () => {
@@ -358,18 +369,6 @@ describe('<CourseOutline />', () => {
 
   it('render checklist value correctly', async () => {
     const { getByText } = render(<RootWrapper />);
-
-    axiosMock
-      .onGet(getCourseBestPracticesApiUrl({
-        courseId, excludeGraded: true, all: true,
-      }))
-      .reply(200, courseBestPracticesMock);
-
-    axiosMock
-      .onGet(getCourseLaunchApiUrl({
-        courseId, gradedOnly: true, validateOras: true, all: true,
-      }))
-      .reply(200, courseLaunchMock);
 
     await executeThunk(fetchCourseLaunchQuery({
       courseId, gradedOnly: true, validateOras: true, all: true,
@@ -2093,6 +2092,9 @@ describe('<CourseOutline />', () => {
     const [section] = courseOutlineIndexMock.courseStructure.childInfo.children;
     const [sectionElement] = await findAllByTestId('section-card');
     const [subsection] = section.childInfo.children;
+    axiosMock
+      .onGet(getXBlockApiUrl(section.id))
+      .reply(200, courseSectionMock);
     let [subsectionElement] = await within(sectionElement).findAllByTestId('subsection-card');
     const expandBtn = await within(subsectionElement).findByTestId('subsection-card-header__expanded-btn');
     await act(async () => fireEvent.click(expandBtn));

--- a/src/course-outline/constants.js
+++ b/src/course-outline/constants.js
@@ -82,3 +82,9 @@ export const VIDEO_SHARING_OPTIONS = /** @type {const} */ ({
   allOn: 'all-on',
   allOff: 'all-off',
 });
+
+export const API_ERROR_TYPES = /** @type {const} */ ({
+  networkError: 'networkError',
+  serverError: 'serverError',
+  unknown: 'unknown',
+});

--- a/src/course-outline/data/selectors.js
+++ b/src/course-outline/data/selectors.js
@@ -10,3 +10,4 @@ export const getCourseActions = (state) => state.courseOutline.actions;
 export const getCustomRelativeDatesActiveFlag = (state) => state.courseOutline.isCustomRelativeDatesActive;
 export const getProctoredExamsFlag = (state) => state.courseOutline.enableProctoredExams;
 export const getPasteFileNotices = (state) => state.courseOutline.pasteFileNotices;
+export const getErrors = (state) => state.courseOutline.errors;

--- a/src/course-outline/data/slice.js
+++ b/src/course-outline/data/slice.js
@@ -13,7 +13,12 @@ const slice = createSlice({
       fetchSectionLoadingStatus: RequestStatus.IN_PROGRESS,
       courseLaunchQueryStatus: RequestStatus.IN_PROGRESS,
     },
-    errors: {},
+    errors: {
+      outlineIndexApi: null,
+      reindexApi: null,
+      sectionLoadingApi: null,
+      courseLaunchApi: null,
+    },
     outlineIndexData: {},
     savingStatus: '',
     statusBarData: {
@@ -55,69 +60,31 @@ const slice = createSlice({
         ...state.loadingStatus,
         outlineIndexLoadingStatus: payload.status,
       };
-      if (payload.errors) {
-        state.errors = {
-          ...state.errors,
-          outlineIndexApi: payload.errors,
-        };
-      } else {
-        const errors = { ...state.errors };
-        delete errors.outlineIndexApi;
-        state.errors = errors;
-      }
+      state.errors.outlineIndexApi = payload.errors || null;
     },
     updateReindexLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
         reIndexLoadingStatus: payload.status,
       };
-      if (payload.errors) {
-        state.errors = {
-          ...state.errors,
-          reindexApi: payload.errors,
-        };
-      } else {
-        const errors = { ...state.errors };
-        delete errors.reindexApi;
-        state.errors = errors;
-      }
+      state.errors.reindexApi = payload.errors || null;
     },
     updateFetchSectionLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
         fetchSectionLoadingStatus: payload.status,
       };
-      if (payload.errors) {
-        state.errors = {
-          ...state.errors,
-          sectionLoadingApi: payload.errors,
-        };
-      } else {
-        const errors = { ...state.errors };
-        delete errors.sectionLoadingApi;
-        state.errors = errors;
-      }
+      state.errors.sectionLoadingApi = payload.errors || null;
     },
     updateCourseLaunchQueryStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
         courseLaunchQueryStatus: payload.status,
       };
-      if (payload.errors) {
-        state.errors = {
-          ...state.errors,
-          courseLaunchApi: payload.errors,
-        };
-      } else {
-        const errors = { ...state.errors };
-        delete errors.courseLaunchApi;
-        state.errors = errors;
-      }
+      state.errors.courseLaunchApi = payload.errors || null;
     },
     dismissError: (state, { payload }) => {
-      const errors = { ...state.errors };
-      payload.forEach((key) => delete errors[key]);
-      state.errors = errors;
+      state.errors[payload] = null;
     },
     updateStatusBar: (state, { payload }) => {
       state.statusBarData = {

--- a/src/course-outline/data/slice.js
+++ b/src/course-outline/data/slice.js
@@ -11,7 +11,9 @@ const slice = createSlice({
       outlineIndexLoadingStatus: RequestStatus.IN_PROGRESS,
       reIndexLoadingStatus: RequestStatus.IN_PROGRESS,
       fetchSectionLoadingStatus: RequestStatus.IN_PROGRESS,
+      courseLaunchQueryStatus: RequestStatus.IN_PROGRESS,
     },
+    errors: {},
     outlineIndexData: {},
     savingStatus: '',
     statusBarData: {
@@ -53,18 +55,69 @@ const slice = createSlice({
         ...state.loadingStatus,
         outlineIndexLoadingStatus: payload.status,
       };
+      if (payload.errors) {
+        state.errors = {
+          ...state.errors,
+          outlineIndexApi: payload.errors,
+        };
+      } else {
+        const errors = { ...state.errors };
+        delete errors.outlineIndexApi;
+        state.errors = errors;
+      }
     },
     updateReindexLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
         reIndexLoadingStatus: payload.status,
       };
+      if (payload.errors) {
+        state.errors = {
+          ...state.errors,
+          reindexApi: payload.errors,
+        };
+      } else {
+        const errors = { ...state.errors };
+        delete errors.reindexApi;
+        state.errors = errors;
+      }
     },
     updateFetchSectionLoadingStatus: (state, { payload }) => {
       state.loadingStatus = {
         ...state.loadingStatus,
         fetchSectionLoadingStatus: payload.status,
       };
+      if (payload.errors) {
+        state.errors = {
+          ...state.errors,
+          sectionLoadingApi: payload.errors,
+        };
+      } else {
+        const errors = { ...state.errors };
+        delete errors.sectionLoadingApi;
+        state.errors = errors;
+      }
+    },
+    updateCourseLaunchQueryStatus: (state, { payload }) => {
+      state.loadingStatus = {
+        ...state.loadingStatus,
+        courseLaunchQueryStatus: payload.status,
+      };
+      if (payload.errors) {
+        state.errors = {
+          ...state.errors,
+          courseLaunchApi: payload.errors,
+        };
+      } else {
+        const errors = { ...state.errors };
+        delete errors.courseLaunchApi;
+        state.errors = errors;
+      }
+    },
+    dismissError: (state, { payload }) => {
+      const errors = { ...state.errors };
+      payload.forEach((key) => delete errors[key]);
+      state.errors = errors;
     },
     updateStatusBar: (state, { payload }) => {
       state.statusBarData = {
@@ -188,6 +241,7 @@ export const {
   fetchStatusBarChecklistSuccess,
   fetchStatusBarSelPacedSuccess,
   updateFetchSectionLoadingStatus,
+  updateCourseLaunchQueryStatus,
   updateSavingStatus,
   updateSectionList,
   setCurrentItem,
@@ -202,6 +256,7 @@ export const {
   reorderUnitList,
   setPasteFileNotices,
   removePasteFileNotices,
+  dismissError,
 } = slice.actions;
 
 export const {

--- a/src/course-outline/data/thunk.js
+++ b/src/course-outline/data/thunk.js
@@ -54,8 +54,8 @@ import {
   updateCourseLaunchQueryStatus,
 } from './slice';
 
-const getErrorDetails = (error) => {
-  const errorInfo = {};
+const getErrorDetails = (error, dismissible = true) => {
+  const errorInfo = { dismissible };
   if (error.response?.data) {
     errorInfo.data = JSON.stringify(error.response.data);
     errorInfo.status = error.response.status;
@@ -98,7 +98,7 @@ export function fetchCourseOutlineIndexQuery(courseId) {
     } catch (error) {
       dispatch(updateOutlineIndexLoadingStatus({
         status: RequestStatus.FAILED,
-        errors: getErrorDetails(error),
+        errors: getErrorDetails(error, false),
       }));
     }
   };

--- a/src/course-outline/data/thunk.js
+++ b/src/course-outline/data/thunk.js
@@ -56,11 +56,9 @@ import {
 
 const getErrorDetails = (error) => {
   const errorInfo = {};
-  if (error.response?.data && error.response?.statusText) {
-    errorInfo.data = `${error.response.statusText}: ${JSON.stringify(error.response.data)}`;
-    errorInfo.type = API_ERROR_TYPES.serverError;
-  } else if (error.response?.statusText) {
-    errorInfo.data = error.response?.statusText;
+  if (error.response?.data) {
+    errorInfo.data = JSON.stringify(error.response.data);
+    errorInfo.status = error.response.status;
     errorInfo.type = API_ERROR_TYPES.serverError;
   } else if (error.request) {
     errorInfo.type = API_ERROR_TYPES.networkError;

--- a/src/course-outline/header-navigations/HeaderNavigations.jsx
+++ b/src/course-outline/header-navigations/HeaderNavigations.jsx
@@ -17,6 +17,7 @@ const HeaderNavigations = ({
   isDisabledReindexButton,
   hasSections,
   courseActions,
+  errors,
 }) => {
   const intl = useIntl();
   const {
@@ -37,6 +38,7 @@ const HeaderNavigations = ({
           <Button
             iconBefore={IconAdd}
             onClick={handleNewSection}
+            disabled={errors?.outlineIndexApi}
           >
             {intl.formatMessage(messages.newSectionButton)}
           </Button>
@@ -92,6 +94,10 @@ const HeaderNavigations = ({
   );
 };
 
+HeaderNavigations.defaultProps = {
+  errors: {},
+};
+
 HeaderNavigations.propTypes = {
   isReIndexShow: PropTypes.bool.isRequired,
   isSectionsExpanded: PropTypes.bool.isRequired,
@@ -109,6 +115,24 @@ HeaderNavigations.propTypes = {
     childAddable: PropTypes.bool.isRequired,
     duplicable: PropTypes.bool.isRequired,
   }).isRequired,
+  errors: PropTypes.shape({
+    outlineIndexApi: PropTypes.shape({
+      data: PropTypes.string,
+      type: PropTypes.string.isRequired,
+    }),
+    reindexApi: PropTypes.shape({
+      data: PropTypes.string,
+      type: PropTypes.string.isRequired,
+    }),
+    sectionLoadingApi: PropTypes.shape({
+      data: PropTypes.string,
+      type: PropTypes.string.isRequired,
+    }),
+    courseLaunchApi: PropTypes.shape({
+      data: PropTypes.string,
+      type: PropTypes.string.isRequired,
+    }),
+  }),
 };
 
 export default HeaderNavigations;

--- a/src/course-outline/header-navigations/HeaderNavigations.test.jsx
+++ b/src/course-outline/header-navigations/HeaderNavigations.test.jsx
@@ -124,4 +124,13 @@ describe('<HeaderNavigations />', () => {
       expect(queryByText(messages.reindexButtonTooltip.defaultMessage)).not.toBeInTheDocument();
     });
   });
+
+  it('disables new section button if course outline fetch fails', () => {
+    const { getByRole } = renderComponent({
+      errors: { outlineIndexApi: { data: 'some error', type: 'serverError' } },
+    });
+
+    expect(getByRole('button', { name: messages.newSectionButton.defaultMessage })).toBeInTheDocument();
+    expect(getByRole('button', { name: messages.newSectionButton.defaultMessage })).toBeDisabled();
+  });
 });

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -24,6 +24,7 @@ import {
   getCurrentSection,
   getCurrentSubsection,
   getCustomRelativeDatesActiveFlag,
+  getErrors,
 } from './data/selectors';
 import {
   addNewSectionQuery,
@@ -71,7 +72,7 @@ const useCourseOutline = ({ courseId }) => {
     mfeProctoredExamSettingsUrl,
     advanceSettingsUrl,
   } = useSelector(getOutlineIndexData);
-  const { outlineIndexLoadingStatus, reIndexLoadingStatus } = useSelector(getLoadingStatus);
+  const { outlineIndexLoadingStatus } = useSelector(getLoadingStatus);
   const statusBarData = useSelector(getStatusBarData);
   const savingStatus = useSelector(getSavingStatus);
   const courseActions = useSelector(getCourseActions);
@@ -81,12 +82,12 @@ const useCourseOutline = ({ courseId }) => {
   const currentSubsection = useSelector(getCurrentSubsection);
   const isCustomRelativeDatesActive = useSelector(getCustomRelativeDatesActiveFlag);
   const genericSavingStatus = useSelector(getGenericSavingStatus);
+  const errors = useSelector(getErrors);
 
   const [isEnableHighlightsModalOpen, openEnableHighlightsModal, closeEnableHighlightsModal] = useToggle(false);
   const [isSectionsExpanded, setSectionsExpanded] = useState(true);
   const [isDisabledReindexButton, setDisableReindexButton] = useState(false);
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
-  const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [isHighlightsModalOpen, openHighlightsModal, closeHighlightsModal] = useToggle(false);
   const [isPublishModalOpen, openPublishModal, closePublishModal] = useToggle(false);
   const [isConfigureModalOpen, openConfigureModal, closeConfigureModal] = useToggle(false);
@@ -135,7 +136,6 @@ const useCourseOutline = ({ courseId }) => {
     handleReIndex: () => {
       setDisableReindexButton(true);
       setShowSuccessAlert(false);
-      setShowErrorAlert(false);
 
       dispatch(fetchCourseReindexQuery(courseId, reindexLink)).then(() => {
         setDisableReindexButton(false);
@@ -290,16 +290,6 @@ const useCourseOutline = ({ courseId }) => {
     dispatch(fetchCourseLaunchQuery({ courseId }));
   }, [courseId]);
 
-  useEffect(() => {
-    if (reIndexLoadingStatus === RequestStatus.FAILED) {
-      setShowErrorAlert(true);
-    }
-
-    if (reIndexLoadingStatus === RequestStatus.SUCCESSFUL) {
-      setShowSuccessAlert(true);
-    }
-  }, [reIndexLoadingStatus]);
-
   return {
     courseActions,
     savingStatus,
@@ -308,7 +298,6 @@ const useCourseOutline = ({ courseId }) => {
     isLoading: outlineIndexLoadingStatus === RequestStatus.IN_PROGRESS,
     isReIndexShow: Boolean(reindexLink),
     showSuccessAlert,
-    showErrorAlert,
     isDisabledReindexButton,
     isSectionsExpanded,
     isPublishModalOpen,
@@ -361,6 +350,7 @@ const useCourseOutline = ({ courseId }) => {
     handleSectionDragAndDrop,
     handleSubsectionDragAndDrop,
     handleUnitDragAndDrop,
+    errors,
   };
 };
 

--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -72,7 +72,7 @@ const useCourseOutline = ({ courseId }) => {
     mfeProctoredExamSettingsUrl,
     advanceSettingsUrl,
   } = useSelector(getOutlineIndexData);
-  const { outlineIndexLoadingStatus } = useSelector(getLoadingStatus);
+  const { outlineIndexLoadingStatus, reIndexLoadingStatus } = useSelector(getLoadingStatus);
   const statusBarData = useSelector(getStatusBarData);
   const savingStatus = useSelector(getSavingStatus);
   const courseActions = useSelector(getCourseActions);
@@ -289,6 +289,10 @@ const useCourseOutline = ({ courseId }) => {
     dispatch(fetchCourseBestPracticesQuery({ courseId }));
     dispatch(fetchCourseLaunchQuery({ courseId }));
   }, [courseId]);
+
+  useEffect(() => {
+    setShowSuccessAlert(reIndexLoadingStatus === RequestStatus.SUCCESSFUL);
+  }, [reIndexLoadingStatus]);
 
   return {
     courseActions,

--- a/src/course-outline/messages.js
+++ b/src/course-outline/messages.js
@@ -25,10 +25,6 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.reindex.alert.success.aria.describedby',
     defaultMessage: 'alert-confirmation-description',
   },
-  alertErrorTitle: {
-    id: 'course-authoring.course-outline.reindex.alert.error.title',
-    defaultMessage: 'There were errors reindexing course.',
-  },
   newSectionButton: {
     id: 'course-authoring.course-outline.section-list.button.new-section',
     defaultMessage: 'New section',

--- a/src/course-outline/page-alerts/PageAlerts.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.jsx
@@ -337,24 +337,39 @@ const PageAlerts = ({
   const renderApiErrors = () => {
     const errorList = Object.entries(errors).map(([k, v]) => {
       switch (v.type) {
+      case API_ERROR_TYPES.serverError:
+        return {
+          key: k,
+          desc: v.data,
+          title: intl.formatMessage(messages.serverErrorAlert, {
+            status: v.status,
+          }),
+        };
       case API_ERROR_TYPES.networkError:
-        return [k, intl.formatMessage(messages.networkErrorAlert)];
+        return {
+          key: k,
+          title: intl.formatMessage(messages.networkErrorAlert),
+        };
       default:
-        return [k, v.data];
+        return { key: k, desc: v.data };
       }
     });
     if (!errorList?.length) {
       return null;
     }
     return (
-      errorList.map(([k, msg]) => (
+      errorList.map((msgObj) => (
         <ErrorAlert
-          hideHeading
           isError
-          key={k}
-          dismissError={() => dispatch(dismissError([k]))}
+          hideHeading
+          key={msgObj.key}
+          dismissError={() => dispatch(dismissError([msgObj.key]))}
         >
-          <Truncate lines={2}>{msg}</Truncate>
+          {msgObj.title
+            && (
+              <Alert.Heading>{msgObj.title}</Alert.Heading>
+            )}
+          {msgObj.desc && <Truncate lines={2}>{msgObj.desc}</Truncate>}
         </ErrorAlert>
       ))
     );

--- a/src/course-outline/page-alerts/PageAlerts.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.jsx
@@ -8,6 +8,7 @@ import {
   Campaign as CampaignIcon,
   InfoOutline as InfoOutlineIcon,
   Warning as WarningIcon,
+  Error as ErrorIcon,
 } from '@openedx/paragon/icons';
 import {
   Alert, Button, Hyperlink, Truncate,
@@ -335,7 +336,7 @@ const PageAlerts = ({
   };
 
   const renderApiErrors = () => {
-    const errorList = Object.entries(errors).map(([k, v]) => {
+    const errorList = Object.entries(errors).filter(obj => obj[1] !== null).map(([k, v]) => {
       switch (v.type) {
       case API_ERROR_TYPES.serverError:
         return {
@@ -344,14 +345,20 @@ const PageAlerts = ({
           title: intl.formatMessage(messages.serverErrorAlert, {
             status: v.status,
           }),
+          dismissible: v.dismissible,
         };
       case API_ERROR_TYPES.networkError:
         return {
           key: k,
           title: intl.formatMessage(messages.networkErrorAlert),
+          dismissible: v.dismissible,
         };
       default:
-        return { key: k, desc: v.data };
+        return {
+          key: k,
+          desc: v.data,
+          dismissible: v.dismissible,
+        };
       }
     });
     if (!errorList?.length) {
@@ -359,18 +366,32 @@ const PageAlerts = ({
     }
     return (
       errorList.map((msgObj) => (
-        <ErrorAlert
-          isError
-          hideHeading
-          key={msgObj.key}
-          dismissError={() => dispatch(dismissError([msgObj.key]))}
-        >
-          {msgObj.title
-            && (
-              <Alert.Heading>{msgObj.title}</Alert.Heading>
-            )}
-          {msgObj.desc && <Truncate lines={2}>{msgObj.desc}</Truncate>}
-        </ErrorAlert>
+        msgObj.dismissible ? (
+          <ErrorAlert
+            isError
+            hideHeading
+            key={msgObj.key}
+            dismissError={() => dispatch(dismissError(msgObj.key))}
+          >
+            {msgObj.title
+              && (
+                <Alert.Heading>{msgObj.title}</Alert.Heading>
+              )}
+            {msgObj.desc && <Truncate lines={2}>{msgObj.desc}</Truncate>}
+          </ErrorAlert>
+        ) : (
+          <Alert
+            variant="danger"
+            icon={ErrorIcon}
+            key={msgObj.key}
+          >
+            {msgObj.title
+                && (
+                  <Alert.Heading>{msgObj.title}</Alert.Heading>
+                )}
+            {msgObj.desc && <Truncate lines={2}>{msgObj.desc}</Truncate>}
+          </Alert>
+        )
       ))
     );
   };

--- a/src/course-outline/page-alerts/PageAlerts.test.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.test.jsx
@@ -195,13 +195,14 @@ describe('<PageAlerts />', () => {
     const { queryByText } = renderComponent({
       ...pageAlertsData,
       errors: {
-        outlineIndexApi: { data: 'BadRequest: some error', type: API_ERROR_TYPES.serverError },
+        outlineIndexApi: { data: 'some error', status: 400, type: API_ERROR_TYPES.serverError },
         courseLaunchApi: { type: API_ERROR_TYPES.networkError },
         reindexApi: { type: API_ERROR_TYPES.unknown, data: 'some unknown error' },
       },
     });
     expect(queryByText(messages.networkErrorAlert.defaultMessage)).toBeInTheDocument();
-    expect(queryByText('BadRequest: some error')).toBeInTheDocument();
+    expect(queryByText(messages.serverErrorAlert.defaultMessage)).toBeInTheDocument();
+    expect(queryByText('some error')).toBeInTheDocument();
     expect(queryByText('some unknown error')).toBeInTheDocument();
   });
 });

--- a/src/course-outline/page-alerts/PageAlerts.test.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.test.jsx
@@ -8,6 +8,7 @@ import { initializeMockApp, getConfig } from '@edx/frontend-platform';
 import PageAlerts from './PageAlerts';
 import messages from './messages';
 import initializeStore from '../../store';
+import { API_ERROR_TYPES } from '../constants';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
@@ -188,5 +189,19 @@ describe('<PageAlerts />', () => {
       'href',
       `${getConfig().STUDIO_BASE_URL}/assets/course-id`,
     );
+  });
+
+  it('renders api error alerts', async () => {
+    const { queryByText } = renderComponent({
+      ...pageAlertsData,
+      errors: {
+        outlineIndexApi: { data: 'some error', type: API_ERROR_TYPES.serverError, statusText: 'BadRequest' },
+        courseLaunchApi: { type: API_ERROR_TYPES.networkError },
+        reindexApi: { type: API_ERROR_TYPES.unknown, msg: 'some unknown error' },
+      },
+    });
+    expect(queryByText(messages.networkErrorAlert.defaultMessage)).toBeInTheDocument();
+    expect(queryByText('BadRequest: some error')).toBeInTheDocument();
+    expect(queryByText('some unknown error')).toBeInTheDocument();
   });
 });

--- a/src/course-outline/page-alerts/PageAlerts.test.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.test.jsx
@@ -195,9 +195,9 @@ describe('<PageAlerts />', () => {
     const { queryByText } = renderComponent({
       ...pageAlertsData,
       errors: {
-        outlineIndexApi: { data: 'some error', type: API_ERROR_TYPES.serverError, statusText: 'BadRequest' },
+        outlineIndexApi: { data: 'BadRequest: some error', type: API_ERROR_TYPES.serverError },
         courseLaunchApi: { type: API_ERROR_TYPES.networkError },
-        reindexApi: { type: API_ERROR_TYPES.unknown, msg: 'some unknown error' },
+        reindexApi: { type: API_ERROR_TYPES.unknown, data: 'some unknown error' },
       },
     });
     expect(queryByText(messages.networkErrorAlert.defaultMessage)).toBeInTheDocument();

--- a/src/course-outline/page-alerts/messages.js
+++ b/src/course-outline/page-alerts/messages.js
@@ -106,8 +106,13 @@ const messages = defineMessages({
     defaultMessage: 'The following {conflictingFilesLen, plural, one {file} other {files}} already exist in this course but don\'t match the version used by the component you pasted:  {conflictingFilesStr}',
     description: 'This alert description is displayed when files being imported conflict with existing files in the course and advises the user to update the conflicting files manually.',
   },
+  serverErrorAlert: {
+    id: 'course-authoring.course-outline.page-alert.server-error.title',
+    defaultMessage: 'Request failed with status: {status}',
+    description: 'Generic server error alert title.',
+  },
   networkErrorAlert: {
-    id: 'course-authoring.course-outline.page-alert.network-error.description',
+    id: 'course-authoring.course-outline.page-alert.network-error.title',
     defaultMessage: 'Network error',
     description: 'Generic network error alert.',
   },

--- a/src/course-outline/page-alerts/messages.js
+++ b/src/course-outline/page-alerts/messages.js
@@ -106,6 +106,11 @@ const messages = defineMessages({
     defaultMessage: 'The following {conflictingFilesLen, plural, one {file} other {files}} already exist in this course but don\'t match the version used by the component you pasted:  {conflictingFilesStr}',
     description: 'This alert description is displayed when files being imported conflict with existing files in the course and advises the user to update the conflicting files manually.',
   },
+  networkErrorAlert: {
+    id: 'course-authoring.course-outline.page-alert.network-error.description',
+    defaultMessage: 'Network error',
+    description: 'Generic network error alert.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

Saves API errors in redux state and displays them as alerts.

## Supporting information
`Private-ref`: [BB-8831](https://tasks.opencraft.com/browse/BB-8831)

## Testing instructions

* Try blocking course outline index (`http://studio.local.edly.io:8001/api/contentstore/v1/course_index/course-v1:OpenedX+DemoX+DemoCourse` in tutor) fetch api using network tab in developer console.
* Refresh and you should see an alert: `Network error`.
* You can also update this [response](https://github.com/openedx/edx-platform/blob/45cd459ddec2ca73d16fc00dfcd2feaccb16efa6/cms/djangoapps/contentstore/rest_api/v1/views/course_index.py#L100-L100) in edx-platform and return a error status code with some message, it will be displayed in the alert. `return Response("some error", status=500)`

![image](https://github.com/openedx/frontend-app-course-authoring/assets/10894099/15c1bcf7-4bda-4a2c-80f1-103a658a8007)


![image](https://github.com/openedx/frontend-app-course-authoring/assets/10894099/cf3c3244-c339-4935-b09f-2580f728f086)

