### PR TITLE
feat: search filters refinement

### DIFF
--- a/src/search-modal/FilterByBlockType.jsx
+++ b/src/search-modal/FilterByBlockType.jsx
@@ -25,7 +25,39 @@ const FilterByBlockType = () => {
     blockTypesFilter,
     setBlockTypesFilter,
   } = useSearchContext();
-  // TODO: sort blockTypes first by count, then by name
+
+  // Sort blocktypes in order of hierarchy followed by alphabetically for components
+  const sortedBlockTypeKeys = Object.keys(blockTypes).sort((a, b) => {
+    const order = {
+      chapter: 1,
+      sequential: 2,
+      vertical: 3,
+    };
+
+    // If both blocktypes are in the order dictionary, sort them based on the order defined
+    if (order[a] && order[b]) {
+      return order[a] - order[b];
+    }
+
+    // If only blocktype 'a' is in the order dictionary, place it before 'b'
+    if (order[a]) {
+      return -1;
+    }
+
+    // If only blocktype 'b' is in the order dictionary, place it before 'a'
+    if (order[b]) {
+      return 1;
+    }
+
+    // If neither blocktype is in the order dictionary, sort alphabetically
+    return a.localeCompare(b);
+  });
+
+  // Rebuild sorted blocktypes dictionary
+  const sortedBlockTypes = {};
+  sortedBlockTypeKeys.forEach(key => {
+    sortedBlockTypes[key] = blockTypes[key];
+  });
 
   const handleCheckboxChange = React.useCallback((e) => {
     setBlockTypesFilter(currentFilters => {
@@ -48,7 +80,7 @@ const FilterByBlockType = () => {
         >
           <Menu className="block-type-refinement-menu" style={{ boxShadow: 'none' }}>
             {
-              Object.entries(blockTypes).map(([blockType, count]) => (
+              Object.entries(sortedBlockTypes).map(([blockType, count]) => (
                 <MenuItem
                   key={blockType}
                   as={Form.Checkbox}
@@ -63,7 +95,7 @@ const FilterByBlockType = () => {
             }
             {
               // Show a message if there are no options at all to avoid the impression that the dropdown isn't working
-              blockTypes.length === 0 ? (
+              sortedBlockTypes.length === 0 ? (
                 <MenuItem disabled><FormattedMessage {...messages['blockTypeFilter.empty']} /></MenuItem>
               ) : null
             }

--- a/src/search-modal/FilterByBlockType.jsx
+++ b/src/search-modal/FilterByBlockType.jsx
@@ -46,7 +46,7 @@ const FilterByBlockType = () => {
           name="block-type-filter"
           defaultValue={blockTypesFilter}
         >
-          <Menu style={{ boxShadow: 'none' }}>
+          <Menu className="block-type-refinement-menu" style={{ boxShadow: 'none' }}>
             {
               Object.entries(blockTypes).map(([blockType, count]) => (
                 <MenuItem

--- a/src/search-modal/SearchModal.scss
+++ b/src/search-modal/SearchModal.scss
@@ -47,6 +47,14 @@
     }
   }
 
+  // Options for the "filter by block type" menu
+  .pgn__menu.block-type-refinement-menu {
+    .pgn__menu-item {
+      // Make the "filter by block type" menu expand to fit longer block types names
+      width: 100%;
+    }
+  }
+
   .pgn__menu-item {
     // Fix a bug in Paragon menu dropdowns: the checkbox currently shrinks if the text is too long.
     // https://github.com/openedx/paragon/pull/3019

--- a/src/search-modal/__mocks__/search-result.json
+++ b/src/search-modal/__mocks__/search-result.json
@@ -280,6 +280,7 @@
       "estimatedTotalHits": 0,
       "facetDistribution": {
         "block_type": {
+          "chapter": 1,
           "html": 2,
           "problem": 16,
           "vertical": 2,


### PR DESCRIPTION
## Description

This fixes a visual bug and sorts the blocktypes in the search filters.

Based on https://github.com/openedx/modular-learning/issues/211

> 6. the number is not visible next to longer filter names (see “Open Response Assessmen...” below.

Dropdown expands to show fullname + count: 

<img width="354" alt="Screenshot 2024-05-06 at 5 18 54 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/6829768/2a1a2238-eee8-4d38-b5cf-2e25cf64d0f6">



> 7. Please order the options in the type filter by hierarchy:
Section
Subsection
Unit
and then the components in whichever order (perhaps alphabetical)


Dropdown blocktypes are sorted, section -> subsection -> unit -> [the rest alphabetically]:

<img width="352" alt="Screenshot 2024-05-06 at 5 18 37 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/6829768/540d540a-4562-40e3-af88-07f7a1a0e859">

## Supporting information

Related Ticket:

- Closes https://github.com/openedx/modular-learning/issues/211

## Testing instructions

1. Run this branch in your local tutor
2. Make sure you have sample taxonomy/tags setup
3. Make sure you have https://github.com/open-craft/tutor-contrib-meilisearch/ enabled
4. Click on the search icon at the top of the page
5. Confirm the 2 changes described above

---
Private-ref: [FAL-3718](https://tasks.opencraft.com/browse/FAL-3718)