### PR TITLE
fix: [FC-0044] Group configurations - Add a counter for usage groups

### DIFF
--- a/src/group-configurations/messages.js
+++ b/src/group-configurations/messages.js
@@ -13,7 +13,7 @@ const messages = defineMessages({
   },
   containsGroups: {
     id: 'course-authoring.group-configurations.container.contains-groups',
-    defaultMessage: 'Contains {len, plural, one {group} other {groups}}',
+    defaultMessage: 'Contains {len, plural, one {1 group} other {{len} groups}}',
     description: 'Message indicating the number of groups contained within a container.',
   },
   notInUse: {
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   usedInLocations: {
     id: 'course-authoring.group-configurations.container.used-in-locations',
-    defaultMessage: 'Used in {len, plural, one {location} other {locations}}',
+    defaultMessage: 'Used in {len, plural, one {1 location} other {{len} locations}}',
     description: 'Message indicating the number of locations where the group configurations are used.',
   },
 });


### PR DESCRIPTION
**Settings**
```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/raccoongang/edx-platform.git
EDX_PLATFORM_VERSION: ts-develop
TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_group_configurations_page
    everyone: true
```

### Closes https://github.com/openedx/frontend-app-course-authoring/issues/981
Referring to the decision to return the counters in accordance with the legacy implementation.

### Testing instructions
1. Run master devstack.
2. Start platform `make dev.up.lms+cms + frontend-app-course-authoring` and make checkout on this branch.
3. Enable the new Group Configurations page by adding a waffle flag `contentstore.new_studio_mfe.use_new_group_configurations_page` in the CMS admin panel.
4. Go to the Group Configurations page.

### Demo
#### Before:
<img width="1179" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/26650868/722c3e14-22b4-4a82-8984-130b44fd15b9">

#### After:
<img width="1194" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/26650868/d092c471-ee2d-40fc-b1d8-0ed5b5966f76">
