### PR TITLE
feat: [FC-0044] Added errors handling 4xx, 5xx

### DIFF
--- a/src/certificates/data/selectors.js
+++ b/src/certificates/data/selectors.js
@@ -3,6 +3,7 @@ import { createSelector } from '@reduxjs/toolkit';
 export const getLoadingStatus = (state) => state.certificates.loadingStatus;
 export const getSavingStatus = (state) => state.certificates.savingStatus;
 export const getSavingImageStatus = (state) => state.certificates.savingImageStatus;
+export const getErrorMessage = (state) => state.certificates.errorMessage;
 export const getSendRequestErrors = (state) => state.certificates.sendRequestErrors.developer_message;
 export const getCertificates = state => state.certificates.certificatesData.certificates;
 export const getHasCertificateModes = state => state.certificates.certificatesData.hasCertificateModes;

--- a/src/certificates/data/slice.js
+++ b/src/certificates/data/slice.js
@@ -12,10 +12,13 @@ const slice = createSlice({
     loadingStatus: RequestStatus.PENDING,
     savingStatus: '',
     savingImageStatus: '',
+    errorMessage: '',
   },
   reducers: {
     updateSavingStatus: (state, { payload }) => {
-      state.savingStatus = payload.status;
+      const { status, errorMessage } = payload;
+      state.savingStatus = status;
+      state.errorMessage = errorMessage;
     },
     updateSavingImageStatus: (state, { payload }) => {
       state.savingImageStatus = payload.status;

--- a/src/certificates/data/thunks.js
+++ b/src/certificates/data/thunks.js
@@ -3,6 +3,7 @@ import {
   hideProcessingNotification,
   showProcessingNotification,
 } from '../../generic/processing-notification/data/slice';
+import { handleResponseErrors } from '../../generic/saving-error-alert';
 import { NOTIFICATION_MESSAGES } from '../../constants';
 import {
   getCertificates,
@@ -51,8 +52,7 @@ export function createCourseCertificate(courseId, certificate) {
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -70,8 +70,7 @@ export function updateCourseCertificate(courseId, certificate) {
       dispatch(updateCertificateSuccess(certificatesValues));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -89,8 +88,7 @@ export function deleteCourseCertificate(courseId, certificateId) {
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -111,8 +109,7 @@ export function updateCertificateActiveStatus(courseId, path, activationStatus) 
       dispatch(fetchCertificates(courseId));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }

--- a/src/certificates/layout/MainLayout.jsx
+++ b/src/certificates/layout/MainLayout.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import { Container, Layout } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import { SavingErrorAlert } from '../../generic/saving-error-alert';
 import ProcessingNotification from '../../generic/processing-notification';
-import InternetConnectionAlert from '../../generic/internet-connection-alert';
 import SubHeader from '../../generic/sub-header/SubHeader';
 import messages from '../messages';
 import CertificatesSidebar from './certificates-sidebar/CertificatesSidebar';
@@ -14,8 +14,8 @@ const MainLayout = ({ courseId, showHeaderButtons, children }) => {
   const intl = useIntl();
 
   const {
-    isQueryPending,
-    isQueryFailed,
+    errorMessage,
+    savingStatus,
     isShowProcessingNotification,
     processingNotificationTitle,
   } = useLayout();
@@ -54,9 +54,9 @@ const MainLayout = ({ courseId, showHeaderButtons, children }) => {
           isShow={isShowProcessingNotification}
           title={processingNotificationTitle}
         />
-        <InternetConnectionAlert
-          isFailed={isQueryFailed}
-          isQueryPending={isQueryPending}
+        <SavingErrorAlert
+          savingStatus={savingStatus}
+          errorMessage={errorMessage}
         />
       </div>
     </>

--- a/src/certificates/layout/hooks/useLayout.jsx
+++ b/src/certificates/layout/hooks/useLayout.jsx
@@ -3,18 +3,16 @@ import { useSelector } from 'react-redux';
 
 import { RequestStatus } from '../../../data/constants';
 import { getProcessingNotification } from '../../../generic/processing-notification/data/selectors';
-import { getSavingStatus, getSavingImageStatus } from '../../data/selectors';
+import { getSavingStatus, getErrorMessage } from '../../data/selectors';
 
 const useLayout = () => {
   const savingStatus = useSelector(getSavingStatus);
-  const savingImageStatus = useSelector(getSavingImageStatus);
+  const errorMessage = useSelector(getErrorMessage);
+
   const {
     isShow: isShowProcessingNotification,
     title: processingNotificationTitle,
   } = useSelector(getProcessingNotification);
-
-  const isQueryPending = savingStatus === RequestStatus.PENDING || savingImageStatus === RequestStatus.PENDING;
-  const isQueryFailed = savingStatus === RequestStatus.FAILED || savingImageStatus === RequestStatus.FAILED;
 
   useEffect(() => {
     if (savingStatus === RequestStatus.SUCCESSFUL) {
@@ -23,8 +21,8 @@ const useLayout = () => {
   }, [savingStatus]);
 
   return {
-    isQueryPending,
-    isQueryFailed,
+    errorMessage,
+    savingStatus,
     isShowProcessingNotification,
     processingNotificationTitle,
   };

--- a/src/course-unit/CourseUnit.jsx
+++ b/src/course-unit/CourseUnit.jsx
@@ -5,9 +5,9 @@ import { useParams } from 'react-router-dom';
 import { Container, Layout, Stack } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl, injectIntl } from '@edx/frontend-platform/i18n';
-import { DraggableList, ErrorAlert } from '@edx/frontend-lib-content-components';
 import { Warning as WarningIcon } from '@openedx/paragon/icons';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { DraggableList } from '@edx/frontend-lib-content-components';
 
 import { getProcessingNotification } from '../generic/processing-notification/data/selectors';
 import SubHeader from '../generic/sub-header/SubHeader';
@@ -16,7 +16,7 @@ import getPageHeadTitle from '../generic/utils';
 import AlertMessage from '../generic/alert-message';
 import { PasteComponent } from '../generic/clipboard';
 import ProcessingNotification from '../generic/processing-notification';
-import InternetConnectionAlert from '../generic/internet-connection-alert';
+import { SavingErrorAlert } from '../generic/saving-error-alert';
 import ConnectionErrorAlert from '../generic/ConnectionErrorAlert';
 import Loading from '../generic/Loading';
 import AddComponent from './add-component/AddComponent';
@@ -40,14 +40,12 @@ const CourseUnit = ({ courseId }) => {
     isLoading,
     sequenceId,
     unitTitle,
-    isQueryPending,
+    errorMessage,
     sequenceStatus,
     savingStatus,
     isTitleEditFormOpen,
-    isErrorAlert,
     staticFileNotices,
     currentlyVisibleToStudents,
-    isInternetConnectionAlertFailed,
     unitXBlockActions,
     sharedClipboardData,
     showPasteXBlock,
@@ -55,7 +53,6 @@ const CourseUnit = ({ courseId }) => {
     handleTitleEditSubmit,
     headerNavigationsActions,
     handleTitleEdit,
-    handleInternetConnectionFailed,
     handleCreateNewCourseXBlock,
     handleConfigureSubmit,
     courseVerticalChildren,
@@ -101,9 +98,6 @@ const CourseUnit = ({ courseId }) => {
     <>
       <Container size="xl" className="course-unit px-4">
         <section className="course-unit-container mb-4 mt-5">
-          <ErrorAlert hideHeading isError={savingStatus === RequestStatus.FAILED && isErrorAlert}>
-            {intl.formatMessage(messages.alertFailedGeneric, { actionName: 'save', type: 'changes' })}
-          </ErrorAlert>
           <SubHeader
             hideBorder
             title={(
@@ -220,13 +214,10 @@ const CourseUnit = ({ courseId }) => {
           isShow={isShowProcessingNotification}
           title={processingNotificationTitle}
         />
-        {isQueryPending && (
-          <InternetConnectionAlert
-            isFailed={isInternetConnectionAlertFailed}
-            isQueryPending={savingStatus === RequestStatus.PENDING}
-            onInternetConnectionFailed={handleInternetConnectionFailed}
-          />
-        )}
+        <SavingErrorAlert
+          savingStatus={savingStatus}
+          errorMessage={errorMessage}
+        />
       </div>
     </>
   );

--- a/src/course-unit/data/selectors.js
+++ b/src/course-unit/data/selectors.js
@@ -6,6 +6,7 @@ export const getCanEdit = (state) => state.courseUnit.canEdit;
 export const getStaticFileNotices = (state) => state.courseUnit.staticFileNotices;
 export const getCourseUnit = (state) => state.courseUnit;
 export const getSavingStatus = (state) => state.courseUnit.savingStatus;
+export const getErrorMessage = (state) => state.courseUnit.errorMessage;
 export const getSequenceStatus = (state) => state.courseUnit.sequenceStatus;
 export const getSequenceIds = (state) => state.courseUnit.courseSectionVertical.courseSequenceIds;
 export const getCourseSectionVertical = (state) => state.courseUnit.courseSectionVertical;

--- a/src/course-unit/data/slice.js
+++ b/src/course-unit/data/slice.js
@@ -7,6 +7,7 @@ const slice = createSlice({
   name: 'courseUnit',
   initialState: {
     savingStatus: '',
+    errorMessage: '',
     isQueryPending: false,
     isTitleEditFormOpen: false,
     canEdit: true,
@@ -37,7 +38,9 @@ const slice = createSlice({
       state.isTitleEditFormOpen = payload;
     },
     updateSavingStatus: (state, { payload }) => {
-      state.savingStatus = payload.status;
+      const { status, errorMessage } = payload;
+      state.savingStatus = status;
+      state.errorMessage = errorMessage;
     },
     fetchSequenceRequest: (state, { payload }) => {
       state.sequenceId = payload.sequenceId;

--- a/src/course-unit/data/thunk.js
+++ b/src/course-unit/data/thunk.js
@@ -4,6 +4,7 @@ import {
   hideProcessingNotification,
   showProcessingNotification,
 } from '../../generic/processing-notification/data/slice';
+import { handleResponseErrors } from '../../generic/saving-error-alert';
 import { RequestStatus } from '../../data/constants';
 import { NOTIFICATION_MESSAGES } from '../../constants';
 import { updateModel, updateModels } from '../../generic/model-store';
@@ -113,7 +114,7 @@ export function editCourseItemQuery(itemId, displayName, sequenceId) {
       });
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     }
   };
 }
@@ -138,7 +139,7 @@ export function editCourseUnitVisibilityAndData(itemId, type, isVisible, groupAc
       });
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     }
   };
 }
@@ -186,7 +187,7 @@ export function createNewCourseXBlock(body, callback, blockId) {
     } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateLoadingCourseXblockStatus({ status: RequestStatus.FAILED }));
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     }
   };
 }
@@ -221,7 +222,7 @@ export function deleteUnitItemQuery(itemId, xblockId) {
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     }
   };
 }
@@ -244,7 +245,7 @@ export function duplicateUnitItemQuery(itemId, xblockId) {
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     }
   };
 }
@@ -265,7 +266,7 @@ export function setXBlockOrderListQuery(blockId, xblockListIds, restoreCallback)
       });
     } catch (error) {
       restoreCallback();
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }

--- a/src/course-unit/hooks.jsx
+++ b/src/course-unit/hooks.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -20,6 +20,7 @@ import {
   getCourseUnitData,
   getIsLoading,
   getSavingStatus,
+  getErrorMessage,
   getSequenceStatus,
   getStaticFileNotices,
   getCanEdit,
@@ -34,18 +35,16 @@ export const useCourseUnit = ({ courseId, blockId }) => {
   const dispatch = useDispatch();
   const [searchParams] = useSearchParams();
 
-  const [isErrorAlert, toggleErrorAlert] = useState(false);
-  const [hasInternetConnectionError, setInternetConnectionError] = useState(false);
   const courseUnit = useSelector(getCourseUnitData);
   const savingStatus = useSelector(getSavingStatus);
   const isLoading = useSelector(getIsLoading);
+  const errorMessage = useSelector(getErrorMessage);
   const sequenceStatus = useSelector(getSequenceStatus);
   const { draftPreviewLink, publishedPreviewLink } = useSelector(getCourseSectionVertical);
   const courseVerticalChildren = useSelector(getCourseVerticalChildren);
   const staticFileNotices = useSelector(getStaticFileNotices);
   const navigate = useNavigate();
   const isTitleEditFormOpen = useSelector(state => state.courseUnit.isTitleEditFormOpen);
-  const isQueryPending = useSelector(state => state.courseUnit.isQueryPending);
   const canEdit = useSelector(getCanEdit);
   const { currentlyVisibleToStudents } = courseUnit;
   const { sharedClipboardData, showPasteXBlock, showPasteUnit } = useCopyToClipboard(canEdit);
@@ -61,10 +60,6 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     handlePreview: () => {
       window.open(draftPreviewLink, '_blank');
     },
-  };
-
-  const handleInternetConnectionFailed = () => {
-    setInternetConnectionError(true);
   };
 
   const handleTitleEdit = () => {
@@ -119,8 +114,6 @@ export const useCourseUnit = ({ courseId, blockId }) => {
   useEffect(() => {
     if (savingStatus === RequestStatus.SUCCESSFUL) {
       dispatch(updateQueryPendingStatus(true));
-    } else if (savingStatus === RequestStatus.FAILED && !hasInternetConnectionError) {
-      toggleErrorAlert(true);
     }
   }, [savingStatus]);
 
@@ -136,19 +129,16 @@ export const useCourseUnit = ({ courseId, blockId }) => {
     sequenceId,
     courseUnit,
     unitTitle,
+    errorMessage,
     sequenceStatus,
     savingStatus,
-    isQueryPending,
-    isErrorAlert,
     staticFileNotices,
     currentlyVisibleToStudents,
     isLoading,
     isTitleEditFormOpen,
-    isInternetConnectionAlertFailed: savingStatus === RequestStatus.FAILED,
     sharedClipboardData,
     showPasteXBlock,
     showPasteUnit,
-    handleInternetConnectionFailed,
     unitXBlockActions,
     headerNavigationsActions,
     handleTitleEdit,

--- a/src/generic/saving-error-alert/SavingErrorAlert.jsx
+++ b/src/generic/saving-error-alert/SavingErrorAlert.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Warning as WarningIcon } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import { RequestStatus } from '../../data/constants';
+import AlertMessage from '../alert-message';
+import messages from './messages';
+
+const SavingErrorAlert = ({
+  savingStatus,
+  errorMessage,
+}) => {
+  const intl = useIntl();
+  const [showAlert, setShowAlert] = useState(false);
+  const [isOnline, setIsOnline] = useState(window.navigator.onLine);
+  const isQueryFailed = savingStatus === RequestStatus.FAILED;
+
+  useEffect(() => {
+    const handleOnlineStatus = () => setIsOnline(window.navigator.onLine);
+    const events = ['online', 'offline'];
+
+    events.forEach((event) => {
+      window.addEventListener(event, handleOnlineStatus);
+    });
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, handleOnlineStatus);
+      });
+    };
+  }, [isOnline]);
+
+  useEffect(() => {
+    setShowAlert((!isOnline && isQueryFailed) || isQueryFailed);
+  }, [isQueryFailed, isOnline]);
+
+  return (
+    <AlertMessage
+      show={showAlert}
+      variant="danger"
+      icon={WarningIcon}
+      title={intl.formatMessage(messages.warningTitle)}
+      description={
+        errorMessage || intl.formatMessage(messages.warningDescription)
+      }
+      aria-hidden="true"
+      aria-labelledby={intl.formatMessage(
+        messages.warningTitleAriaLabelledBy,
+      )}
+      aria-describedby={intl.formatMessage(
+        messages.warningDescriptionAriaDescribedBy,
+      )}
+    />
+  );
+};
+
+SavingErrorAlert.defaultProps = {
+  errorMessage: undefined,
+};
+
+SavingErrorAlert.propTypes = {
+  savingStatus: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string,
+};
+
+export default SavingErrorAlert;

--- a/src/generic/saving-error-alert/index.js
+++ b/src/generic/saving-error-alert/index.js
@@ -1,0 +1,2 @@
+export { default as SavingErrorAlert } from './SavingErrorAlert';
+export { handleResponseErrors } from './utils';

--- a/src/generic/saving-error-alert/messages.js
+++ b/src/generic/saving-error-alert/messages.js
@@ -1,0 +1,26 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  warningTitle: {
+    id: 'course-authoring.generic.saving-error-alert.title',
+    defaultMessage: 'Studio\'s having trouble saving your work',
+    description: 'Title for an alert indicating saving error in the studio environment',
+  },
+  warningDescription: {
+    id: 'course-authoring.generic.saving-error-alert.description',
+    defaultMessage: 'This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.',
+    description: 'Description providing possible reasons and solutions for saving error in the studio environment',
+  },
+  warningTitleAriaLabelledBy: {
+    id: 'course-authoring.generic.saving-error-alert.title.aria.labelled-by',
+    defaultMessage: 'saving-error-alert-title',
+    description: 'ARIA label ID for the title of the saving error alert',
+  },
+  warningDescriptionAriaDescribedBy: {
+    id: 'course-authoring.generic.saving-error-alert.aria.described-by',
+    defaultMessage: 'saving-error-alert-description',
+    description: 'ARIA description ID for the saving error alert',
+  },
+});
+
+export default messages;

--- a/src/generic/saving-error-alert/utils.js
+++ b/src/generic/saving-error-alert/utils.js
@@ -1,0 +1,26 @@
+import { RequestStatus } from '../../data/constants';
+
+const handleResponseErrors = (error, dispatch, savingStatusFunction) => {
+  let errorMessage = '';
+
+  try {
+    const {
+      customAttributes: { httpErrorResponseData },
+    } = error;
+    const parsedData = JSON.parse(httpErrorResponseData);
+    errorMessage = parsedData?.error || errorMessage;
+  } catch (err) {
+    errorMessage = '';
+  }
+
+  dispatch(
+    savingStatusFunction({
+      status: RequestStatus.FAILED,
+      errorMessage,
+    }),
+  );
+  return false;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { handleResponseErrors };

--- a/src/group-configurations/data/selectors.js
+++ b/src/group-configurations/data/selectors.js
@@ -1,3 +1,4 @@
 export const getGroupConfigurationsData = (state) => state.groupConfigurations.groupConfigurations;
 export const getLoadingStatus = (state) => state.groupConfigurations.loadingStatus;
 export const getSavingStatus = (state) => state.groupConfigurations.savingStatus;
+export const getErrorMessage = (state) => state.groupConfigurations.errorMessage;

--- a/src/group-configurations/data/slice.js
+++ b/src/group-configurations/data/slice.js
@@ -7,6 +7,7 @@ const slice = createSlice({
   name: 'groupConfigurations',
   initialState: {
     savingStatus: '',
+    errorMessage: '',
     loadingStatus: RequestStatus.IN_PROGRESS,
     groupConfigurations: {},
   },
@@ -37,7 +38,9 @@ const slice = createSlice({
       state.loadingStatus = payload.status;
     },
     updateSavingStatuses: (state, { payload }) => {
-      state.savingStatus = payload.status;
+      const { status, errorMessage } = payload;
+      state.savingStatus = status;
+      state.errorMessage = errorMessage;
     },
     updateExperimentConfigurationSuccess: (state, { payload }) => {
       const { configuration } = payload;

--- a/src/group-configurations/data/thunk.js
+++ b/src/group-configurations/data/thunk.js
@@ -4,6 +4,7 @@ import {
   hideProcessingNotification,
   showProcessingNotification,
 } from '../../generic/processing-notification/data/slice';
+import { handleResponseErrors } from '../../generic/saving-error-alert';
 import {
   getGroupConfigurations,
   createContentGroup,
@@ -48,8 +49,7 @@ export function createContentGroupQuery(courseId, group) {
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -67,8 +67,7 @@ export function editContentGroupQuery(courseId, group) {
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -85,7 +84,7 @@ export function deleteContentGroupQuery(courseId, parentGroupId, groupId) {
       dispatch(deleteGroupConfigurationsSuccess({ parentGroupId, groupId }));
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -98,32 +97,39 @@ export function createExperimentConfigurationQuery(courseId, newConfiguration) {
     dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
 
     try {
-      const configuration = await createExperimentConfiguration(courseId, newConfiguration);
+      const configuration = await createExperimentConfiguration(
+        courseId,
+        newConfiguration,
+      );
       dispatch(updateExperimentConfigurationSuccess({ configuration }));
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }
   };
 }
 
-export function editExperimentConfigurationQuery(courseId, editedConfiguration) {
+export function editExperimentConfigurationQuery(
+  courseId,
+  editedConfiguration,
+) {
   return async (dispatch) => {
     dispatch(updateSavingStatuses({ status: RequestStatus.PENDING }));
     dispatch(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
 
     try {
-      const configuration = await editExperimentConfiguration(courseId, editedConfiguration);
+      const configuration = await editExperimentConfiguration(
+        courseId,
+        editedConfiguration,
+      );
       dispatch(updateExperimentConfigurationSuccess({ configuration }));
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
       return true;
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
-      return false;
+      return handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -140,7 +146,7 @@ export function deleteExperimentConfigurationQuery(courseId, configurationId) {
       dispatch(deleteExperimentConfigurationSuccess({ configurationId }));
       dispatch(updateSavingStatuses({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateSavingStatuses({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatuses);
     } finally {
       dispatch(hideProcessingNotification());
     }

--- a/src/group-configurations/hooks.jsx
+++ b/src/group-configurations/hooks.jsx
@@ -7,6 +7,7 @@ import {
   getGroupConfigurationsData,
   getLoadingStatus,
   getSavingStatus,
+  getErrorMessage,
 } from './data/selectors';
 import { updateSavingStatuses } from './data/slice';
 import {
@@ -24,6 +25,7 @@ const useGroupConfigurations = (courseId) => {
   const groupConfigurations = useSelector(getGroupConfigurationsData);
   const loadingStatus = useSelector(getLoadingStatus);
   const savingStatus = useSelector(getSavingStatus);
+  const errorMessage = useSelector(getErrorMessage);
   const {
     isShow: isShowProcessingNotification,
     title: processingNotificationTitle,
@@ -86,6 +88,7 @@ const useGroupConfigurations = (courseId) => {
     savingStatus,
     contentGroupActions,
     experimentConfigurationActions,
+    errorMessage,
     groupConfigurations,
     isShowProcessingNotification,
     processingNotificationTitle,

--- a/src/group-configurations/index.jsx
+++ b/src/group-configurations/index.jsx
@@ -4,13 +4,12 @@ import {
   Container, Layout, Stack, Row,
 } from '@openedx/paragon';
 
-import { RequestStatus } from '../data/constants';
 import { LoadingSpinner } from '../generic/Loading';
 import { useModel } from '../generic/model-store';
 import SubHeader from '../generic/sub-header/SubHeader';
 import getPageHeadTitle from '../generic/utils';
 import ProcessingNotification from '../generic/processing-notification';
-import InternetConnectionAlert from '../generic/internet-connection-alert';
+import { SavingErrorAlert } from '../generic/saving-error-alert';
 import messages from './messages';
 import ContentGroupsSection from './content-groups-section';
 import ExperimentConfigurationsSection from './experiment-configurations-section';
@@ -24,6 +23,7 @@ const GroupConfigurations = ({ courseId }) => {
   const {
     isLoading,
     savingStatus,
+    errorMessage,
     contentGroupActions,
     experimentConfigurationActions,
     processingNotificationTitle,
@@ -34,7 +34,6 @@ const GroupConfigurations = ({ courseId }) => {
       shouldShowExperimentGroups,
       experimentGroupConfigurations,
     },
-    handleInternetConnectionFailed,
   } = useGroupConfigurations(courseId);
 
   document.title = getPageHeadTitle(
@@ -71,7 +70,10 @@ const GroupConfigurations = ({ courseId }) => {
           xl={[{ span: 9 }, { span: 3 }]}
         >
           <Layout.Element>
-            <Stack gap={3} data-testid="group-configurations-main-content-wrapper">
+            <Stack
+              gap={3}
+              data-testid="group-configurations-main-content-wrapper"
+            >
               {!!enrollmentTrackGroup && (
                 <EnrollmentTrackGroupsSection
                   availableGroup={enrollmentTrackGroup}
@@ -102,10 +104,9 @@ const GroupConfigurations = ({ courseId }) => {
         </Layout>
       </Container>
       <div className="alert-toast">
-        <InternetConnectionAlert
-          isFailed={savingStatus === RequestStatus.FAILED}
-          isQueryPending={savingStatus === RequestStatus.PENDING}
-          onInternetConnectionFailed={handleInternetConnectionFailed}
+        <SavingErrorAlert
+          savingStatus={savingStatus}
+          errorMessage={errorMessage}
         />
         <ProcessingNotification
           isShow={isShowProcessingNotification}

--- a/src/textbooks/Textbooks.jsx
+++ b/src/textbooks/Textbooks.jsx
@@ -9,14 +9,13 @@ import {
 } from '@openedx/paragon';
 import { Add as AddIcon } from '@openedx/paragon/icons';
 import { useSelector } from 'react-redux';
-
 import { Helmet } from 'react-helmet';
-import React from 'react';
+
+import { SavingErrorAlert } from '../generic/saving-error-alert';
 import { getProcessingNotification } from '../generic/processing-notification/data/selectors';
 import { useModel } from '../generic/model-store';
 import { LoadingSpinner } from '../generic/Loading';
 import SubHeader from '../generic/sub-header/SubHeader';
-import InternetConnectionAlert from '../generic/internet-connection-alert';
 import ProcessingNotification from '../generic/processing-notification';
 import EmptyPlaceholder from './empty-placeholder/EmptyPlaceholder';
 import TextbookCard from './textbook-card/TextbooksCard';
@@ -35,11 +34,11 @@ const Textbooks = ({ courseId }) => {
     textbooks,
     isLoading,
     breadcrumbs,
+    errorMessage,
+    savingStatus,
     isTextbookFormOpen,
     openTextbookForm,
     closeTextbookForm,
-    isInternetConnectionAlertFailed,
-    isQueryPending,
     handleTextbookFormSubmit,
     handleSavingStatusDispatch,
     handleTextbookEditFormSubmit,
@@ -131,9 +130,9 @@ const Textbooks = ({ courseId }) => {
         title={processingNotificationTitle}
       />
       <div className="alert-toast">
-        <InternetConnectionAlert
-          isFailed={isInternetConnectionAlertFailed}
-          isQueryPending={isQueryPending}
+        <SavingErrorAlert
+          savingStatus={savingStatus}
+          errorMessage={errorMessage}
         />
       </div>
     </>

--- a/src/textbooks/data/selectors.js
+++ b/src/textbooks/data/selectors.js
@@ -1,4 +1,5 @@
 export const getTextbooksData = (state) => state.textbooks.textbooks;
 export const getLoadingStatus = (state) => state.textbooks.loadingStatus;
 export const getSavingStatus = (state) => state.textbooks.savingStatus;
+export const getErrorMessage = (state) => state.textbooks.errorMessage;
 export const getCurrentTextbookId = (state) => state.textbooks.currentTextbookId;

--- a/src/textbooks/data/slice.js
+++ b/src/textbooks/data/slice.js
@@ -9,6 +9,7 @@ const slice = createSlice({
     savingStatus: '',
     loadingStatus: RequestStatus.IN_PROGRESS,
     textbooks: [],
+    errorMessage: '',
     currentTextbookId: '',
   },
   reducers: {
@@ -19,7 +20,9 @@ const slice = createSlice({
       state.loadingStatus = payload.status;
     },
     updateSavingStatus: (state, { payload }) => {
-      state.savingStatus = payload.status;
+      const { status, errorMessage } = payload;
+      state.savingStatus = status;
+      state.errorMessage = errorMessage;
     },
     createTextbookSuccess: (state, { payload }) => {
       state.textbooks = [...state.textbooks, payload];

--- a/src/textbooks/data/thunk.js
+++ b/src/textbooks/data/thunk.js
@@ -2,6 +2,7 @@ import {
   hideProcessingNotification,
   showProcessingNotification,
 } from '../../generic/processing-notification/data/slice';
+import { handleResponseErrors } from '../../generic/saving-error-alert';
 import { RequestStatus } from '../../data/constants';
 import { NOTIFICATION_MESSAGES } from '../../constants';
 import {
@@ -43,7 +44,7 @@ export function createTextbookQuery(courseId, textbook) {
       dispatch(createTextbookSuccess(data));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -60,7 +61,7 @@ export function editTextbookQuery(courseId, textbook) {
       dispatch(editTextbookSuccess(data));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }
@@ -77,7 +78,7 @@ export function deleteTextbookQuery(courseId, textbookId) {
       dispatch(deleteTextbookSuccess(textbookId));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
-      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+      handleResponseErrors(error, dispatch, updateSavingStatus);
     } finally {
       dispatch(hideProcessingNotification());
     }

--- a/src/textbooks/data/thunk.test.js
+++ b/src/textbooks/data/thunk.test.js
@@ -78,7 +78,7 @@ describe('createTextbookQuery', () => {
     expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.IN_PROGRESS }));
     expect(dispatch).toHaveBeenCalledWith(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
     expect(createTextbook).toHaveBeenCalledWith('courseId', {});
-    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED }));
+    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED, errorMessage: '' }));
     expect(dispatch).toHaveBeenCalledWith(hideProcessingNotification());
   });
 });
@@ -106,7 +106,7 @@ describe('editTextbookQuery', () => {
     expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.IN_PROGRESS }));
     expect(dispatch).toHaveBeenCalledWith(showProcessingNotification(NOTIFICATION_MESSAGES.saving));
     expect(editTextbook).toHaveBeenCalledWith('courseId', {});
-    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED }));
+    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED, errorMessage: '' }));
     expect(dispatch).toHaveBeenCalledWith(hideProcessingNotification());
   });
 });
@@ -133,7 +133,7 @@ describe('deleteTextbookQuery', () => {
     expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.IN_PROGRESS }));
     expect(dispatch).toHaveBeenCalledWith(showProcessingNotification(NOTIFICATION_MESSAGES.deleting));
     expect(deleteTextbook).toHaveBeenCalledWith('courseId', 'textbookId');
-    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED }));
+    expect(dispatch).toHaveBeenCalledWith(updateSavingStatus({ status: RequestStatus.FAILED, errorMessage: '' }));
     expect(dispatch).toHaveBeenCalledWith(hideProcessingNotification());
   });
 });

--- a/src/textbooks/hooks.jsx
+++ b/src/textbooks/hooks.jsx
@@ -10,6 +10,7 @@ import {
   getTextbooksData,
   getLoadingStatus,
   getSavingStatus,
+  getErrorMessage,
 } from './data/selectors';
 import {
   createTextbookQuery,
@@ -27,6 +28,7 @@ const useTextbooks = (courseId) => {
   const textbooks = useSelector(getTextbooksData);
   const loadingStatus = useSelector(getLoadingStatus);
   const savingStatus = useSelector(getSavingStatus);
+  const errorMessage = useSelector(getErrorMessage);
 
   const [isTextbookFormOpen, openTextbookForm, closeTextbookForm] = useToggle(false);
 
@@ -75,8 +77,8 @@ const useTextbooks = (courseId) => {
 
   return {
     isLoading: loadingStatus === RequestStatus.IN_PROGRESS,
-    isInternetConnectionAlertFailed: savingStatus === RequestStatus.FAILED,
-    isQueryPending: savingStatus === RequestStatus.PENDING,
+    savingStatus,
+    errorMessage,
     textbooks,
     breadcrumbs,
     isTextbookFormOpen,


### PR DESCRIPTION
## Settings
```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: contentstore.new_studio_mfe.use_new_unit_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```

## Description
If we get errors when using the `POST`, `PUT`, `PATCH`, `DELETE` methods we have to show `ErrorNotification`.
Error handing implemented on the following page:
- Course Unit
- Certificate Page
- Group Configurations
- Textbooks

## Testing instructions

- Run master devstack.
- Start platform `make dev.up.lms+cms+frontend-app-course-authoring` and make checkout on this branch.
- Enable the page for which error handling logic has been added.
- Go to the page.


## Other information
https://github.com/openedx/frontend-app-course-authoring/assets/93188219/848f3b41-ed92-4f73-9b34-3be4057de0a9