### PR TITLE
fix: fixed course rerun route

### DIFF
--- a/src/studio-home/card-item/CardItem.test.jsx
+++ b/src/studio-home/card-item/CardItem.test.jsx
@@ -8,6 +8,7 @@ import { initializeMockApp, getConfig } from '@edx/frontend-platform';
 import { studioHomeMock } from '../__mocks__';
 import messages from '../messages';
 import initializeStore from '../../store';
+import { trimSlashes } from './utils';
 import CardItem from '.';
 
 jest.mock('react-redux', () => ({
@@ -50,7 +51,7 @@ describe('<CardItem />', () => {
     const courseTitleLink = getByText(props.displayName);
     expect(courseTitleLink).toHaveAttribute('href', `${getConfig().STUDIO_BASE_URL}${props.url}`);
     const btnReRunCourse = getByText(messages.btnReRunText.defaultMessage);
-    expect(btnReRunCourse).toHaveAttribute('href', props.rerunLink);
+    expect(btnReRunCourse).toHaveAttribute('href', trimSlashes(props.rerunLink));
     const viewLiveLink = getByText(messages.viewLiveBtnText.defaultMessage);
     expect(viewLiveLink).toHaveAttribute('href', props.lmsLink);
   });
@@ -63,7 +64,7 @@ describe('<CardItem />', () => {
     const dropDownMenu = getByTestId('toggle-dropdown');
     fireEvent.click(dropDownMenu);
     const btnReRunCourse = getByText(messages.btnReRunText.defaultMessage);
-    expect(btnReRunCourse).toHaveAttribute('href', props.rerunLink);
+    expect(btnReRunCourse).toHaveAttribute('href', trimSlashes(props.rerunLink));
     const viewLiveLink = getByText(messages.viewLiveBtnText.defaultMessage);
     expect(viewLiveLink).toHaveAttribute('href', props.lmsLink);
   });

--- a/src/studio-home/card-item/index.jsx
+++ b/src/studio-home/card-item/index.jsx
@@ -15,6 +15,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { COURSE_CREATOR_STATES } from '../../constants';
 import { getStudioHomeData } from '../data/selectors';
 import messages from '../messages';
+import { trimSlashes } from './utils';
 
 const CardItem = ({
   intl,
@@ -69,7 +70,7 @@ const CardItem = ({
               />
               <Dropdown.Menu>
                 {isShowRerunLink && (
-                  <Dropdown.Item href={rerunLink}>
+                  <Dropdown.Item href={trimSlashes(rerunLink)}>
                     {messages.btnReRunText.defaultMessage}
                   </Dropdown.Item>
                 )}
@@ -83,7 +84,7 @@ const CardItem = ({
               {isShowRerunLink && (
                 <Hyperlink
                   className="small"
-                  destination={rerunLink}
+                  destination={trimSlashes(rerunLink)}
                   key={`action-row-rerunLink-${courseKey}`}
                 >
                   {intl.formatMessage(messages.btnReRunText)}

--- a/src/studio-home/card-item/utils.js
+++ b/src/studio-home/card-item/utils.js
@@ -1,0 +1,7 @@
+/**
+ * Removes leading and trailing slashes from a string.
+ * @param {string} str - The string to trim.
+ * @returns {string} The trimmed string.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const trimSlashes = (str) => str.replace(/^\/|\/$/g, '');


### PR DESCRIPTION
## Settings
```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

TUTOR_GROVE_WAFFLE_FLAGS:
  - name: new_studio_mfe.use_new_home_page
    everyone: true

TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS:
  MFE_CONFIG:
    ENABLE_UNIT_PAGE: true
```
## Description

Correction of the course rerun link on the Course home page.

## Testing instructions

1. Go to the Studio home page
2. Follow the link Re-run course


## Other information

[Issue](https://github.com/openedx/frontend-app-course-authoring/issues/977)