### PR TITLE
fix: allow page grid to take plugin slot id instead

### DIFF
--- a/src/pages-and-resources/PagesAndResources.jsx
+++ b/src/pages-and-resources/PagesAndResources.jsx
@@ -65,6 +65,8 @@ const PagesAndResources = ({ courseId, intl }) => {
     );
   }
 
+  const hasAdditionalCoursePlugin = getConfig()?.pluginSlots?.additional_course_plugin != null;
+
   return (
     <PagesAndResourcesProvider courseId={courseId}>
       <main className="container container-mw-md px-3">
@@ -89,7 +91,7 @@ const PagesAndResources = ({ courseId, intl }) => {
 
         <PageGrid pages={pages} pluginSlotId="additional_course_plugin" />
         {
-          (contentPermissionsPages.length > 0 || getConfig()?.pluginSlots?.additional_course_content_plugin != null)
+          (contentPermissionsPages.length > 0 || hasAdditionalCoursePlugin)
             && (
               <>
                 <div className="d-flex justify-content-between my-4 my-md-5 align-items-center">

--- a/src/pages-and-resources/PagesAndResources.jsx
+++ b/src/pages-and-resources/PagesAndResources.jsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, Suspense } from 'react';
 import PropTypes from 'prop-types';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { PageWrap, AppContext } from '@edx/frontend-platform/react';
 
@@ -88,7 +89,7 @@ const PagesAndResources = ({ courseId, intl }) => {
 
         <PageGrid pages={pages} pluginSlotId='additional_course_plugin' />
         {
-          (contentPermissionsPages.length > 0) && (
+          (contentPermissionsPages.length > 0 || getConfig()?.pluginSlots?.additional_course_content_plugin != null) && (
             <>
               <div className="d-flex justify-content-between my-4 my-md-5 align-items-center">
                 <h3 className="m-0">{intl.formatMessage(messages.contentPermissions)}</h3>

--- a/src/pages-and-resources/PagesAndResources.jsx
+++ b/src/pages-and-resources/PagesAndResources.jsx
@@ -86,14 +86,14 @@ const PagesAndResources = ({ courseId, intl }) => {
           <Route path=":appId/settings" element={<PageWrap><Suspense fallback="..."><SettingsComponent url={redirectUrl} /></Suspense></PageWrap>} />
         </Routes>
 
-        <PageGrid pages={pages} />
+        <PageGrid pages={pages} pluginSlotId='additional_course_plugin' />
         {
           (contentPermissionsPages.length > 0) && (
             <>
               <div className="d-flex justify-content-between my-4 my-md-5 align-items-center">
                 <h3 className="m-0">{intl.formatMessage(messages.contentPermissions)}</h3>
               </div>
-              <PageGrid pages={contentPermissionsPages} />
+              <PageGrid pages={contentPermissionsPages} pluginSlotId='additional_course_content_plugin' />
             </>
           )
         }

--- a/src/pages-and-resources/PagesAndResources.jsx
+++ b/src/pages-and-resources/PagesAndResources.jsx
@@ -87,16 +87,17 @@ const PagesAndResources = ({ courseId, intl }) => {
           <Route path=":appId/settings" element={<PageWrap><Suspense fallback="..."><SettingsComponent url={redirectUrl} /></Suspense></PageWrap>} />
         </Routes>
 
-        <PageGrid pages={pages} pluginSlotId='additional_course_plugin' />
+        <PageGrid pages={pages} pluginSlotId="additional_course_plugin" />
         {
-          (contentPermissionsPages.length > 0 || getConfig()?.pluginSlots?.additional_course_content_plugin != null) && (
-            <>
-              <div className="d-flex justify-content-between my-4 my-md-5 align-items-center">
-                <h3 className="m-0">{intl.formatMessage(messages.contentPermissions)}</h3>
-              </div>
-              <PageGrid pages={contentPermissionsPages} pluginSlotId='additional_course_content_plugin' />
-            </>
-          )
+          (contentPermissionsPages.length > 0 || getConfig()?.pluginSlots?.additional_course_content_plugin != null)
+            && (
+              <>
+                <div className="d-flex justify-content-between my-4 my-md-5 align-items-center">
+                  <h3 className="m-0">{intl.formatMessage(messages.contentPermissions)}</h3>
+                </div>
+                <PageGrid pages={contentPermissionsPages} pluginSlotId="additional_course_content_plugin" />
+              </>
+            )
         }
       </main>
     </PagesAndResourcesProvider>

--- a/src/pages-and-resources/pages/PageGrid.jsx
+++ b/src/pages-and-resources/pages/PageGrid.jsx
@@ -5,7 +5,7 @@ import { CardGrid } from '@openedx/paragon';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import PageCard, { CoursePageShape } from './PageCard';
 
-const PageGrid = ({ pages }) => (
+const PageGrid = ({ pages, pluginSlotId }) => (
   <CardGrid columnSizes={{
     xs: 12,
     sm: 6,
@@ -16,12 +16,17 @@ const PageGrid = ({ pages }) => (
     {pages.map((page) => (
       <PageCard page={page} key={page.id} />
     ))}
-    <PluginSlot id="additional_course_plugin" />
+    {pluginSlotId && <PluginSlot id={pluginSlotId} />}
   </CardGrid>
 );
 
+PageGrid.defaultProps = {
+  pluginSlotId: null,
+};
+
 PageGrid.propTypes = {
   pages: PropTypes.arrayOf(CoursePageShape.isRequired).isRequired,
+  pluginSlotId: PropTypes.string,
 };
 
 export default injectIntl(PageGrid);


### PR DESCRIPTION
## Description

Allow `PageGrid` to take plugin slot id. Because we reused the component, the `additional_plugin_slot` show up twice. 

TICKET: https://2u-internal.atlassian.net/browse/AU-2022

## Supporting information

![Screenshot 2024-05-10 at 1 45 13 PM](https://github.com/openedx/frontend-app-course-authoring/assets/83240113/2ede754c-58d1-4f84-add2-1b38f36b2786)
