### PR TITLE
feat: Show toast when exporting course tags

### DIFF
--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -482,7 +482,7 @@ const CourseOutline = ({ courseId }) => {
       {toastMessage && (
         <Toast
           show
-          onClose={() => setToastMessage(null)}
+          onClose={/* istanbul ignore next */ () => setToastMessage(null)}
           data-testid="taxonomy-toast"
         >
           {toastMessage}

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -8,6 +8,7 @@ import {
   Layout,
   Row,
   TransitionReplace,
+  Toast,
 } from '@openedx/paragon';
 import { Helmet } from 'react-helmet';
 import {
@@ -20,6 +21,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import { useLocation } from 'react-router-dom';
 
 import { LoadingSpinner } from '../generic/Loading';
 import { getProcessingNotification } from '../generic/processing-notification/data/selectors';
@@ -52,9 +54,11 @@ import {
 } from '../generic/drag-helper/utils';
 import { useCourseOutline } from './hooks';
 import messages from './messages';
+import { getTagsExportFile } from './data/api';
 
 const CourseOutline = ({ courseId }) => {
   const intl = useIntl();
+  const location = useLocation();
 
   const {
     courseName,
@@ -116,6 +120,22 @@ const CourseOutline = ({ courseId }) => {
     handleUnitDragAndDrop,
     errors,
   } = useCourseOutline({ courseId });
+
+  // Use `setToastMessage` to show the toast.
+  const [toastMessage, setToastMessage] = useState(/** @type{null|string} */ (null));
+
+  useEffect(() => {
+    if (location.hash === '#export') {
+      setToastMessage(intl.formatMessage(messages.exportTagsToastMessage));
+      getTagsExportFile(courseId, courseName).finally(() => {
+        setToastMessage(null);
+      });
+
+      // Delete `#export` from location
+      const newUrl = window.location.href.split('#')[0];
+      window.history.replaceState({}, document.title, newUrl);
+    }
+  }, [location]);
 
   const [sections, setSections] = useState(sectionsList);
 
@@ -458,6 +478,15 @@ const CourseOutline = ({ courseId }) => {
           onInternetConnectionFailed={handleInternetConnectionFailed}
         />
       </div>
+      {toastMessage && (
+        <Toast
+          show
+          onClose={() => setToastMessage(null)}
+          data-testid="taxonomy-toast"
+        >
+          {toastMessage}
+        </Toast>
+      )}
     </>
   );
 };

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -126,13 +126,15 @@ const CourseOutline = ({ courseId }) => {
 
   useEffect(() => {
     if (location.hash === '#export-tags') {
-      setToastMessage(intl.formatMessage(messages.exportTagsToastMessage));
-      getTagsExportFile(courseId, courseName).finally(() => {
-        setToastMessage(null);
+      setToastMessage(intl.formatMessage(messages.exportTagsCreatingToastMessage));
+      getTagsExportFile(courseId, courseName).then(() => {
+        setToastMessage(intl.formatMessage(messages.exportTagsSuccessToastMessage));
+      }).catch(() => {
+        setToastMessage(intl.formatMessage(messages.exportTagsErrorToastMessage));
       });
 
       // Delete `#export-tags` from location
-      window.location.href = '#'
+      window.location.href = '#';
     }
   }, [location]);
 

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -125,13 +125,13 @@ const CourseOutline = ({ courseId }) => {
   const [toastMessage, setToastMessage] = useState(/** @type{null|string} */ (null));
 
   useEffect(() => {
-    if (location.hash === '#export') {
+    if (location.hash === '#export-tags') {
       setToastMessage(intl.formatMessage(messages.exportTagsToastMessage));
       getTagsExportFile(courseId, courseName).finally(() => {
         setToastMessage(null);
       });
 
-      // Delete `#export` from location
+      // Delete `#export-tags` from location
       const newUrl = window.location.href.split('#')[0];
       window.history.replaceState({}, document.title, newUrl);
     }

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -132,8 +132,7 @@ const CourseOutline = ({ courseId }) => {
       });
 
       // Delete `#export-tags` from location
-      const newUrl = window.location.href.split('#')[0];
-      window.history.replaceState({}, document.title, newUrl);
+      window.location.href = '#'
     }
   }, [location]);
 

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -2265,12 +2265,12 @@ describe('<CourseOutline />', () => {
     window.URL.createObjectURL = jest.fn().mockReturnValue('http://example.com/archivo');
     window.URL.revokeObjectURL = jest.fn();
     render(<RootWrapper />);
-    expect(await screen.findByText('Please wait. Creating export file...')).toBeInTheDocument();
+    expect(await screen.findByText('Please wait. Creating export file for course tags...')).toBeInTheDocument();
 
     const expectedRequest = axiosMock.history.get.filter(request => request.url === exportTags(courseId));
     expect(expectedRequest.length).toBe(1);
 
-    expect(await screen.findByText('File created successfully')).toBeInTheDocument();
+    expect(await screen.findByText('Course tags exported successfully')).toBeInTheDocument();
   });
 
   it('should show toast on export tags error', async () => {
@@ -2283,7 +2283,7 @@ describe('<CourseOutline />', () => {
     });
 
     render(<RootWrapper />);
-    expect(await screen.findByText('Please wait. Creating export file...')).toBeInTheDocument();
+    expect(await screen.findByText('Please wait. Creating export file for course tags...')).toBeInTheDocument();
     expect(await screen.findByText('An error has occurred creating the file')).toBeInTheDocument();
   });
 });

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -29,6 +29,7 @@ export const getXBlockBaseApiUrl = () => `${getApiBaseUrl()}/xblock/`;
 export const getCourseItemApiUrl = (itemId) => `${getXBlockBaseApiUrl()}${itemId}`;
 export const getXBlockApiUrl = (blockId) => `${getXBlockBaseApiUrl()}outline/${blockId}`;
 export const getClipboardUrl = () => `${getApiBaseUrl()}/api/content-staging/v1/clipboard/`;
+export const exportTags = (courseId) => `${getApiBaseUrl()}/api/content_tagging/v1/object_tags/${courseId}/export/`;
 
 /**
  * @typedef {Object} courseOutline
@@ -458,4 +459,29 @@ export async function pasteBlock(parentLocator) {
 export async function dismissNotification(url) {
   await getAuthenticatedHttpClient()
     .delete(url);
+}
+
+/**
+ * Downloads the file of the exported tags
+ * @param {string} courseId The ID of the content
+ * @returns void
+ */
+export async function getTagsExportFile(courseId, courseName) {
+  // Gets exported tags and builds the blob to download CSV file.
+  // This can be done with this code:
+  // `window.location.href = exportTags(contentId);`
+  // but it is done in this way to known when the operation ends to close the toast.
+  const response = await getAuthenticatedHttpClient().get(exportTags(courseId), {
+    responseType: 'blob',
+  });
+
+  const blob = new Blob([response.data], { type: 'text/csv' });
+  const url = window.URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${courseName}.csv`;
+  a.click();
+
+  window.URL.revokeObjectURL(url);
 }

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -475,6 +475,10 @@ export async function getTagsExportFile(courseId, courseName) {
     responseType: 'blob',
   });
 
+  if (response.status !== 200) {
+    throw response.statusText;
+  }
+
   const blob = new Blob([response.data], { type: 'text/csv' });
   const url = window.URL.createObjectURL(blob);
 

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -470,7 +470,7 @@ export async function getTagsExportFile(courseId, courseName) {
   // Gets exported tags and builds the blob to download CSV file.
   // This can be done with this code:
   // `window.location.href = exportTags(contentId);`
-  // but it is done in this way to known when the operation ends to close the toast.
+  // but it is done in this way so we know when the operation ends to close the toast.
   const response = await getAuthenticatedHttpClient().get(exportTags(courseId), {
     responseType: 'blob',
   });

--- a/src/course-outline/data/api.js
+++ b/src/course-outline/data/api.js
@@ -475,6 +475,7 @@ export async function getTagsExportFile(courseId, courseName) {
     responseType: 'blob',
   });
 
+  /* istanbul ignore next */
   if (response.status !== 200) {
     throw response.statusText;
   }

--- a/src/course-outline/messages.js
+++ b/src/course-outline/messages.js
@@ -29,10 +29,20 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.section-list.button.new-section',
     defaultMessage: 'New section',
   },
-  exportTagsToastMessage: {
-    id: 'course-authoring.course-outline.export-tags.toast.message',
+  exportTagsCreatingToastMessage: {
+    id: 'course-authoring.course-outline.export-tags.toast.creating.message',
     defaultMessage: 'Please wait. Creating export file...',
-    description: 'Message in toast when exporting tags of a course',
+    description: 'In progress message in toast when exporting tags of a course',
+  },
+  exportTagsSuccessToastMessage: {
+    id: 'course-authoring.course-outline.export-tags.toast.success.message',
+    defaultMessage: 'File created successfully',
+    description: 'Success message in toast when exporting tags of a course',
+  },
+  exportTagsErrorToastMessage: {
+    id: 'course-authoring.course-outline.export-tags.toast.error.message',
+    defaultMessage: 'An error has occurred creating the file',
+    description: 'Error message in toast when exporting tags of a course',
   },
 });
 

--- a/src/course-outline/messages.js
+++ b/src/course-outline/messages.js
@@ -29,6 +29,11 @@ const messages = defineMessages({
     id: 'course-authoring.course-outline.section-list.button.new-section',
     defaultMessage: 'New section',
   },
+  exportTagsToastMessage: {
+    id: 'course-authoring.course-outline.export-tags.toast.message',
+    defaultMessage: 'Please wait. Creating export file...',
+    description: 'Message in toast when exporting tags of a course',
+  },
 });
 
 export default messages;

--- a/src/course-outline/messages.js
+++ b/src/course-outline/messages.js
@@ -31,12 +31,12 @@ const messages = defineMessages({
   },
   exportTagsCreatingToastMessage: {
     id: 'course-authoring.course-outline.export-tags.toast.creating.message',
-    defaultMessage: 'Please wait. Creating export file...',
+    defaultMessage: 'Please wait. Creating export file for course tags...',
     description: 'In progress message in toast when exporting tags of a course',
   },
   exportTagsSuccessToastMessage: {
     id: 'course-authoring.course-outline.export-tags.toast.success.message',
-    defaultMessage: 'File created successfully',
+    defaultMessage: 'Course tags exported successfully',
     description: 'Success message in toast when exporting tags of a course',
   },
   exportTagsErrorToastMessage: {

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -69,7 +69,7 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
   },
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
     ? [{
-      href: `${studioBaseUrl}/api/content_tagging/v1/object_tags/${courseId}/export/`,
+      href: '#export',
       title: intl.formatMessage(messages['header.links.exportTags']),
     }] : []
   ),

--- a/src/header/utils.js
+++ b/src/header/utils.js
@@ -69,7 +69,7 @@ export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
   },
   ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
     ? [{
-      href: '#export',
+      href: '#export-tags',
       title: intl.formatMessage(messages['header.links.exportTags']),
     }] : []
   ),


### PR DESCRIPTION
## Description

- Show `In progress` toast when exporting course tags

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/215
- Internal ticket: [FAL-3733](https://tasks.opencraft.com/browse/FAL-3733)

## Technical Details

The `Export Tags` button is on the [StudioHeader](https://github.com/openedx/frontend-app-course-authoring/blob/bc63bfc7f585e3751e356eb213390ee916a742f6/src/header/Header.jsx#L47) [(frontend-component-header)](https://github.com/openedx/frontend-component-header). This component only receives as parameters the [text of the button and the link](https://github.com/openedx/frontend-app-course-authoring/pull/995/files#diff-e660e1566707a54f0764f507112244f0c929f18e3198814a49424507fac6198bL72) to where that button should redirect. 

There is no way to send an `onClick` function or know when the user clicked the button or add some flag to know if the export is in progress, this is necessary to display the toast. The component [logic is closed ](https://github.com/openedx/frontend-component-header/blob/master/src/studio-header/NavDropdownMenu.jsx#L22) in the link that is passed as a parameter.

The workaroun used on this PR is to use an internal MFE route instead the edx-platform API. The detail is that there should be no redirection. To achieve this I have used the url fragment.  The [useEffect](https://github.com/openedx/frontend-app-course-authoring/pull/995/files#diff-c1cdab5e577b1ea0584b3c117598b7f9d3cdc6603f7328951f005faa90395351R127) of this code is to verify the fragment and execute the export code we want with the respective toasts.

## Testing instructions

- Enable `contentstore.new_studio_mfe.use_new_course_outline_page`.
- Go to a course outline.
- Click on `Tools` > `Export Tags`.
- Check that the toast appears.
- Check that when the file is ready, the toast is gone.
