### PR TITLE
chore: lock @edx/react-unit-test-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "1.2.0",
-        "@edx/react-unit-test-utils": "^2.0.0",
+        "@edx/react-unit-test-utils": "2.0.0",
         "@edx/reactifex": "^1.0.3",
         "@edx/stylelint-config-edx": "2.3.0",
         "@edx/typescript-config": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "1.2.0",
-    "@edx/react-unit-test-utils": "^2.0.0",
+    "@edx/react-unit-test-utils": "2.0.0",
     "@edx/reactifex": "^1.0.3",
     "@edx/stylelint-config-edx": "2.3.0",
     "@edx/typescript-config": "^1.0.1",


### PR DESCRIPTION
`@edx/react-unit-test-utils@2.1.0` is having a breaking change dependency.

https://github.com/openedx/react-unit-test-utils/pull/22