### PR TITLE
fix: issue-1018 remove reference to edX user\nIn configure wiki opera…

### DIFF
--- a/plugins/course-apps/wiki/messages.js
+++ b/plugins/course-apps/wiki/messages.js
@@ -26,7 +26,8 @@ const messages = defineMessages({
   },
   enablePublicWikiHelp: {
     id: 'course-authoring.pages-resources.wiki.enable-public-wiki.help',
-    defaultMessage: 'If enabled, any registered user can view the course wiki even if not enrolled in the course',
+    defaultMessage: `If enabled, any registered user can view the course wiki
+    even if they are not enrolled in the course`,
   },
 });
 

--- a/plugins/course-apps/wiki/messages.js
+++ b/plugins/course-apps/wiki/messages.js
@@ -26,8 +26,7 @@ const messages = defineMessages({
   },
   enablePublicWikiHelp: {
     id: 'course-authoring.pages-resources.wiki.enable-public-wiki.help',
-    defaultMessage: `If enabled, edX users can view the course wiki even when
-    they're not enrolled in the course.`,
+    defaultMessage: 'If enabled, any registered user can view the course wiki even if not enrolled in the course',
   },
 });
 


### PR DESCRIPTION


## Description

This PR corresponds to [issue 1018]([#1018 Pages and Resources page - edX reference needs to be removed](https://github.com/openedx/frontend-app-course-authoring/issues/1018)). 

The fix entails no more than rewording a modal dialog box message. See the linked issue for a description of why the change is needed, and how to test.
