### PR TITLE
feat: improve error messaging and empty updates

### DIFF
--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -67,7 +67,7 @@ const CourseAuthoringPage = ({ courseId, children }) => {
     );
   }
   return (
-    <div className={pathname.includes('/editor/') ? '' : 'bg-light-200'}>
+    <div>
       {/* While V2 Editors are temporarily served from their own pages
       using url pattern containing /editor/,
       we shouldn't have the header and footer on these pages.

--- a/src/course-updates/CourseUpdates.jsx
+++ b/src/course-updates/CourseUpdates.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
 import { Helmet } from 'react-helmet';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -77,52 +76,52 @@ const CourseUpdates = ({ courseId }) => {
       </Helmet>
       <Container size="xl" className="px-4 pt-4">
         <section className="setting-items mb-4">
-          {!isEmpty(errors.loadingUpdates) && (
+          {errors.loadingUpdates && (
             <AlertMessage
-              title={intl.formatMessage(messages.loadingErrorAlertTitle, { errorType: 'updates' })}
-              description={intl.formatMessage(
-                messages.loadingErrorAlertDescription,
-                { message: errors.loadingUpdates },
-              )}
+              title={intl.formatMessage(messages.loadingUpdatesErrorTitle)}
+              description={intl.formatMessage(messages.loadingUpdatesErrorDescription, { courseId })}
               variant="danger"
               icon={ErrorIcon}
             />
           )}
-          {!isEmpty(errors.loadingHandouts) && (
+          {errors.loadingHandouts && (
             <AlertMessage
-              title={intl.formatMessage(messages.loadingErrorAlertTitle, { errorType: 'handouts' })}
-              description={intl.formatMessage(
-                messages.loadingErrorAlertDescription,
-                { message: errors.loadingHandouts },
-              )}
+              title={intl.formatMessage(messages.loadingHandoutsErrorTitle)}
+              description={intl.formatMessage(messages.loadingHandoutsErrorDescription, { courseId })}
               variant="danger"
               icon={ErrorIcon}
             />
           )}
-          {!isEmpty(errors.savingUpdates) && (
+          {errors.creatingUpdate && (
             <AlertMessage
-              title={intl.formatMessage(
-                messages.savingErrorAlertTitle,
-                {
-                  actionType: errors.savingUpdates.includes('delete') ? 'delete' : 'save',
-                  errorType: 'update',
-                },
-              )}
-              description={intl.formatMessage(messages.savingErrorAlertDescription, { message: errors.savingUpdates })}
+              title={intl.formatMessage(messages.savingUpdatesErrorTitle)}
+              description={intl.formatMessage(messages.savingNewUpdateErrorAlertDescription)}
               variant="danger"
               icon={ErrorIcon}
-              dismissable
-              closeLabel="Dismiss"
             />
           )}
-          {!isEmpty(errors.savingHandouts) && (
+          {errors.savingUpdates && (
             <AlertMessage
-              title={intl.formatMessage(messages.savingErrorAlertTitle, { actionType: 'save', errorType: 'handouts' })}
-              description={intl.formatMessage(messages.savingErrorAlertDescription, { message: errors.savingHandouts })}
+              title={intl.formatMessage(messages.savingUpdatesErrorTitle)}
+              description={intl.formatMessage(messages.savingUpdatesErrorDescription)}
               variant="danger"
               icon={ErrorIcon}
-              dismissable
-              closeLabel="Dismiss"
+            />
+          )}
+          {errors.deletingUpdates && (
+            <AlertMessage
+              title={intl.formatMessage(messages.deletingUpdatesErrorTitle)}
+              description={intl.formatMessage(messages.deletingUpdatesErrorDescription)}
+              variant="danger"
+              icon={ErrorIcon}
+            />
+          )}
+          {errors.savingHandouts && (
+            <AlertMessage
+              title={intl.formatMessage(messages.savingHandoutErrorTitle)}
+              description={intl.formatMessage(messages.savingHandoutsErrorDescription)}
+              variant="danger"
+              icon={ErrorIcon}
             />
           )}
           <Layout
@@ -145,7 +144,7 @@ const CourseUpdates = ({ courseId }) => {
                         iconBefore={AddIcon}
                         size="sm"
                         onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
-                        disabled={isUpdateFormOpen || !isEmpty(errors.loadingUpdates)}
+                        disabled={isUpdateFormOpen || errors.loadingUpdates}
                       >
                         {intl.formatMessage(messages.newUpdateButton)}
                       </Button>
@@ -198,7 +197,7 @@ const CourseUpdates = ({ courseId }) => {
                             iconBefore={AddIcon}
                             size="sm"
                             onClick={() => handleOpenUpdateForm(REQUEST_TYPES.add_new_update)}
-                            disabled={isUpdateFormOpen || !isEmpty(errors.loadingUpdates)}
+                            disabled={isUpdateFormOpen || errors.loadingUpdates}
                           >
                             {intl.formatMessage(messages.firstUpdateButton)}
                           </Button>
@@ -209,7 +208,7 @@ const CourseUpdates = ({ courseId }) => {
                         <CourseHandouts
                           contentForHandouts={courseHandouts?.data || ''}
                           onEdit={() => handleOpenUpdateForm(REQUEST_TYPES.edit_handouts)}
-                          isDisabledButtons={isUpdateFormOpen || !isEmpty(errors.loadingHandouts)}
+                          isDisabledButtons={isUpdateFormOpen || errors.loadingHandouts}
                         />
                       </div>
                       <DeleteModal

--- a/src/course-updates/CourseUpdates.jsx
+++ b/src/course-updates/CourseUpdates.jsx
@@ -118,7 +118,7 @@ const CourseUpdates = ({ courseId }) => {
           )}
           {errors.savingHandouts && (
             <AlertMessage
-              title={intl.formatMessage(messages.savingHandoutErrorTitle)}
+              title={intl.formatMessage(messages.savingHandoutsErrorTitle)}
               description={intl.formatMessage(messages.savingHandoutsErrorDescription)}
               variant="danger"
               icon={ErrorIcon}

--- a/src/course-updates/CourseUpdates.test.jsx
+++ b/src/course-updates/CourseUpdates.test.jsx
@@ -54,171 +54,319 @@ jest.mock('@edx/frontend-lib-content-components', () => ({
 
 const RootWrapper = () => (
   <AppProvider store={store}>
-    <IntlProvider locale="en">
+    <IntlProvider locale="es">
       <CourseUpdates courseId={courseId} />
     </IntlProvider>
   </AppProvider>
 );
 
 describe('<CourseUpdates />', () => {
-  beforeEach(() => {
-    initializeMockApp({
-      authenticatedUser: {
-        userId: 3,
-        username: 'abc123',
-        administrator: true,
-        roles: [],
-      },
+  describe('Successful API responses', () => {
+    beforeEach(() => {
+      initializeMockApp({
+        authenticatedUser: {
+          userId: 3,
+          username: 'abc123',
+          administrator: true,
+          roles: [],
+        },
+      });
+
+      store = initializeStore();
+      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+      axiosMock
+        .onGet(getCourseUpdatesApiUrl(courseId))
+        .reply(200, courseUpdatesMock);
+      axiosMock
+        .onGet(getCourseHandoutApiUrl(courseId))
+        .reply(200, courseHandoutsMock);
     });
 
-    store = initializeStore();
-    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    axiosMock
-      .onGet(getCourseUpdatesApiUrl(courseId))
-      .reply(200, courseUpdatesMock);
-    axiosMock
-      .onGet(getCourseHandoutApiUrl(courseId))
-      .reply(200, courseHandoutsMock);
-  });
+    it('render CourseUpdates component correctly', async () => {
+      const {
+        getByText, getAllByTestId, getByTestId, getByRole,
+      } = render(<RootWrapper />);
 
-  it('render CourseUpdates component correctly', async () => {
-    const {
-      getByText, getAllByTestId, getByTestId, getByRole,
-    } = render(<RootWrapper />);
-
-    await waitFor(() => {
-      expect(getByText(messages.headingTitle.defaultMessage)).toBeInTheDocument();
-      expect(getByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
-      expect(getByText(messages.sectionInfo.defaultMessage)).toBeInTheDocument();
-      expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeInTheDocument();
-      expect(getAllByTestId('course-update')).toHaveLength(3);
-      expect(getByTestId('course-handouts')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(getByText(messages.headingTitle.defaultMessage)).toBeInTheDocument();
+        expect(getByText(messages.headingSubtitle.defaultMessage)).toBeInTheDocument();
+        expect(getByText(messages.sectionInfo.defaultMessage)).toBeInTheDocument();
+        expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeInTheDocument();
+        expect(getAllByTestId('course-update')).toHaveLength(3);
+        expect(getByTestId('course-handouts')).toBeInTheDocument();
+      });
     });
-  });
 
-  it('should create course update', async () => {
-    const { getByText } = render(<RootWrapper />);
+    it('should create course update', async () => {
+      const { getByText } = render(<RootWrapper />);
 
-    const data = {
-      content: '<p>Some text</p>',
-      date: 'August 29, 2023',
-    };
+      const data = {
+        content: '<p>Some text</p>',
+        date: 'August 29, 2023',
+      };
 
-    axiosMock
-      .onPost(getCourseUpdatesApiUrl(courseId))
-      .reply(200, data);
+      axiosMock
+        .onPost(getCourseUpdatesApiUrl(courseId))
+        .reply(200, data);
 
-    await executeThunk(createCourseUpdateQuery(courseId, data), store.dispatch);
-    expect(getByText('Some text')).toBeInTheDocument();
-    expect(getByText(data.date)).toBeInTheDocument();
-  });
-
-  it('should edit course update', async () => {
-    const { getByText, queryByText } = render(<RootWrapper />);
-
-    const data = {
-      id: courseUpdatesMock[0].id,
-      content: '<p>Some text</p>',
-      date: 'August 29, 2023',
-    };
-
-    axiosMock
-      .onPut(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
-      .reply(200, data);
-
-    await executeThunk(editCourseUpdateQuery(courseId, data), store.dispatch);
-    expect(getByText('Some text')).toBeInTheDocument();
-    expect(getByText(data.date)).toBeInTheDocument();
-    expect(queryByText(courseUpdatesMock[0].date)).not.toBeInTheDocument();
-    expect(queryByText(courseUpdatesMock[0].content)).not.toBeInTheDocument();
-  });
-
-  it('should delete course update', async () => {
-    const { queryByText } = render(<RootWrapper />);
-
-    axiosMock
-      .onDelete(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
-      .reply(200);
-
-    await executeThunk(deleteCourseUpdateQuery(courseId, courseUpdatesMock[0].id), store.dispatch);
-    expect(queryByText(courseUpdatesMock[0].date)).not.toBeInTheDocument();
-    expect(queryByText(courseUpdatesMock[0].content)).not.toBeInTheDocument();
-  });
-
-  it('should edit course handouts', async () => {
-    const { getByText, queryByText } = render(<RootWrapper />);
-
-    const data = {
-      ...courseHandoutsMock,
-      data: '<p>Some handouts 1</p>',
-    };
-
-    axiosMock
-      .onPut(getCourseHandoutApiUrl(courseId))
-      .reply(200, data);
-
-    await executeThunk(editCourseHandoutsQuery(courseId, data), store.dispatch);
-    expect(getByText('Some handouts 1')).toBeInTheDocument();
-    expect(queryByText(courseHandoutsMock.data)).not.toBeInTheDocument();
-  });
-
-  it('Add new update form is visible after clicking "New update" button', async () => {
-    const { getByText, getByRole, getAllByTestId } = render(<RootWrapper />);
-
-    await waitFor(() => {
-      const editUpdateButtons = getAllByTestId('course-update-edit-button');
-      const deleteButtons = getAllByTestId('course-update-delete-button');
-      const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
-      const newUpdateButton = getByRole('button', { name: messages.newUpdateButton.defaultMessage });
-
-      fireEvent.click(newUpdateButton);
-
-      expect(newUpdateButton).toBeDisabled();
-      editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
-      editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
-      deleteButtons.forEach((button) => expect(button).toBeDisabled());
-      expect(getByText('Add new update')).toBeInTheDocument();
+      await executeThunk(createCourseUpdateQuery(courseId, data), store.dispatch);
+      expect(getByText('Some text')).toBeInTheDocument();
+      expect(getByText(data.date)).toBeInTheDocument();
     });
-  });
 
-  it('Edit handouts form is visible after clicking "Edit" button', async () => {
-    const { getByText, getByRole, getAllByTestId } = render(<RootWrapper />);
+    it('should edit course update', async () => {
+      const { getByText, queryByText } = render(<RootWrapper />);
 
-    await waitFor(() => {
-      const editUpdateButtons = getAllByTestId('course-update-edit-button');
-      const deleteButtons = getAllByTestId('course-update-delete-button');
-      const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
-      const editHandoutsButton = editHandoutsButtons[0];
+      const data = {
+        id: courseUpdatesMock[0].id,
+        content: '<p>Some text</p>',
+        date: 'August 29, 2023',
+      };
 
-      fireEvent.click(editHandoutsButton);
+      axiosMock
+        .onPut(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
+        .reply(200, data);
 
-      expect(editHandoutsButton).toBeDisabled();
-      expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeDisabled();
-      editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
-      editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
-      deleteButtons.forEach((button) => expect(button).toBeDisabled());
-      expect(getByText('Edit handouts')).toBeInTheDocument();
-    });
-  });
-
-  it('Edit update form is visible after clicking "Edit" button', async () => {
-    const {
-      getByText, getByRole, getAllByTestId, queryByText,
-    } = render(<RootWrapper />);
-
-    await waitFor(() => {
-      const editUpdateButtons = getAllByTestId('course-update-edit-button');
-      const deleteButtons = getAllByTestId('course-update-delete-button');
-      const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
-      const editUpdateFirstButton = editUpdateButtons[0];
-
-      fireEvent.click(editUpdateFirstButton);
-      expect(getByText('Edit update')).toBeInTheDocument();
-      expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeDisabled();
-      editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
-      editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
-      deleteButtons.forEach((button) => expect(button).toBeDisabled());
+      await executeThunk(editCourseUpdateQuery(courseId, data), store.dispatch);
+      expect(getByText('Some text')).toBeInTheDocument();
+      expect(getByText(data.date)).toBeInTheDocument();
+      expect(queryByText(courseUpdatesMock[0].date)).not.toBeInTheDocument();
       expect(queryByText(courseUpdatesMock[0].content)).not.toBeInTheDocument();
+    });
+
+    it('should delete course update', async () => {
+      const { queryByText } = render(<RootWrapper />);
+
+      axiosMock
+        .onDelete(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
+        .reply(200);
+
+      await executeThunk(deleteCourseUpdateQuery(courseId, courseUpdatesMock[0].id), store.dispatch);
+      expect(queryByText(courseUpdatesMock[0].date)).not.toBeInTheDocument();
+      expect(queryByText(courseUpdatesMock[0].content)).not.toBeInTheDocument();
+    });
+
+    it('should edit course handouts', async () => {
+      const { getByText, queryByText } = render(<RootWrapper />);
+
+      const data = {
+        ...courseHandoutsMock,
+        data: '<p>Some handouts 1</p>',
+      };
+
+      axiosMock
+        .onPut(getCourseHandoutApiUrl(courseId))
+        .reply(200, data);
+
+      await executeThunk(editCourseHandoutsQuery(courseId, data), store.dispatch);
+      expect(getByText('Some handouts 1')).toBeInTheDocument();
+      expect(queryByText(courseHandoutsMock.data)).not.toBeInTheDocument();
+    });
+
+    it('Add new update form is visible after clicking "New update" button', async () => {
+      const { getByText, getByRole, getAllByTestId } = render(<RootWrapper />);
+
+      await waitFor(() => {
+        const editUpdateButtons = getAllByTestId('course-update-edit-button');
+        const deleteButtons = getAllByTestId('course-update-delete-button');
+        const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
+        const newUpdateButton = getByRole('button', { name: messages.newUpdateButton.defaultMessage });
+
+        fireEvent.click(newUpdateButton);
+
+        expect(newUpdateButton).toBeDisabled();
+        editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
+        editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
+        deleteButtons.forEach((button) => expect(button).toBeDisabled());
+        expect(getByText('Add new update')).toBeInTheDocument();
+      });
+    });
+
+    it('Edit handouts form is visible after clicking "Edit" button', async () => {
+      const { getByText, getByRole, getAllByTestId } = render(<RootWrapper />);
+
+      await waitFor(() => {
+        const editUpdateButtons = getAllByTestId('course-update-edit-button');
+        const deleteButtons = getAllByTestId('course-update-delete-button');
+        const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
+        const editHandoutsButton = editHandoutsButtons[0];
+
+        fireEvent.click(editHandoutsButton);
+
+        expect(editHandoutsButton).toBeDisabled();
+        expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeDisabled();
+        editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
+        editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
+        deleteButtons.forEach((button) => expect(button).toBeDisabled());
+        expect(getByText('Edit handouts')).toBeInTheDocument();
+      });
+    });
+
+    it('Edit update form is visible after clicking "Edit" button', async () => {
+      const {
+        getByText, getByRole, getAllByTestId, queryByText,
+      } = render(<RootWrapper />);
+
+      await waitFor(() => {
+        const editUpdateButtons = getAllByTestId('course-update-edit-button');
+        const deleteButtons = getAllByTestId('course-update-delete-button');
+        const editHandoutsButtons = getAllByTestId('course-handouts-edit-button');
+        const editUpdateFirstButton = editUpdateButtons[0];
+
+        fireEvent.click(editUpdateFirstButton);
+        expect(getByText('Edit update')).toBeInTheDocument();
+        expect(getByRole('button', { name: messages.newUpdateButton.defaultMessage })).toBeDisabled();
+        editUpdateButtons.forEach((button) => expect(button).toBeDisabled());
+        editHandoutsButtons.forEach((button) => expect(button).toBeDisabled());
+        deleteButtons.forEach((button) => expect(button).toBeDisabled());
+        expect(queryByText(courseUpdatesMock[0].content)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('page load failure API responses', () => {
+    beforeEach(() => {
+      initializeMockApp({
+        authenticatedUser: {
+          userId: 3,
+          username: 'abc123',
+          administrator: true,
+          roles: [],
+        },
+      });
+
+      store = initializeStore();
+      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    });
+
+    it('Course updates fetch should show updates loading error', async () => {
+      axiosMock
+        .onGet(getCourseUpdatesApiUrl(courseId))
+        .reply(404);
+      axiosMock
+        .onGet(getCourseHandoutApiUrl(courseId))
+        .reply(200, courseHandoutsMock);
+
+      const {
+        getByText, queryByTestId, getByRole,
+      } = render(<RootWrapper />);
+
+      await waitFor(() => {
+        const newButton = getByRole('button', { name: messages.newUpdateButton.defaultMessage });
+        expect(getByText(messages.loadingUpdatesErrorTitle.defaultMessage));
+        expect(newButton).toBeDisabled();
+        expect(getByText(messages.noCourseUpdates.defaultMessage)).toBeVisible();
+        expect(queryByTestId('course-update')).toBeNull();
+      });
+    });
+
+    it('Course handouts fetch should show handouts loading error', async () => {
+      axiosMock
+        .onGet(getCourseUpdatesApiUrl(courseId))
+        .reply(200, courseUpdatesMock);
+      axiosMock
+        .onGet(getCourseHandoutApiUrl(courseId))
+        .reply(404);
+
+      const {
+        getByText, getByTestId,
+      } = render(<RootWrapper />);
+
+      await waitFor(() => {
+        expect(getByText(messages.loadingHandoutsErrorTitle.defaultMessage));
+        expect(getByTestId('course-handouts-edit-button')).toBeDisabled();
+      });
+    });
+  });
+
+  describe('saving failure API responses', () => {
+    beforeEach(() => {
+      initializeMockApp({
+        authenticatedUser: {
+          userId: 3,
+          username: 'abc123',
+          administrator: true,
+          roles: [],
+        },
+      });
+
+      store = initializeStore();
+      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+      axiosMock
+        .onGet(getCourseUpdatesApiUrl(courseId))
+        .reply(200, courseUpdatesMock);
+      axiosMock
+        .onGet(getCourseHandoutApiUrl(courseId))
+        .reply(200, courseHandoutsMock);
+    });
+    it('creating new update should show saving error alert', async () => {
+      const { getByText, queryByText } = render(<RootWrapper />);
+
+      const data = {
+        content: '<p>Some text</p>',
+        date: 'August 29, 2023',
+      };
+
+      axiosMock
+        .onPost(getCourseUpdatesApiUrl(courseId), data)
+        .reply(404);
+
+      await executeThunk(createCourseUpdateQuery(courseId, data), store.dispatch);
+      expect(getByText(messages.savingNewUpdateErrorAlertDescription.defaultMessage)).toBeVisible();
+      expect(queryByText('Some text')).toBeNull();
+      expect(queryByText(data.date)).toBeNull();
+    });
+
+    it('editing course update should show saving error alert', async () => {
+      const { getByText, queryByText } = render(<RootWrapper />);
+
+      const data = {
+        id: courseUpdatesMock[0].id,
+        content: '<p>Some text</p>',
+        date: 'August 29, 2023',
+      };
+
+      axiosMock
+        .onPut(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
+        .reply(404);
+
+      await executeThunk(editCourseUpdateQuery(courseId, data), store.dispatch);
+      expect(queryByText('Some text')).toBeNull();
+      expect(queryByText(data.date)).toBeNull();
+      expect(getByText(courseUpdatesMock[0].date)).toBeVisible();
+      expect(getByText(courseUpdatesMock[0].content)).toBeVisible();
+      expect(getByText(messages.savingUpdatesErrorDescription.defaultMessage)).toBeVisible();
+    });
+
+    it('deleting course update should show delete saving error alert', async () => {
+      const { getByText } = render(<RootWrapper />);
+
+      axiosMock
+        .onDelete(updateCourseUpdatesApiUrl(courseId, courseUpdatesMock[0].id))
+        .reply(404);
+
+      await executeThunk(deleteCourseUpdateQuery(courseId, courseUpdatesMock[0].id), store.dispatch);
+      expect(getByText(courseUpdatesMock[0].date)).toBeVisible();
+      expect(getByText(courseUpdatesMock[0].content)).toBeVisible();
+      expect(getByText(messages.deletingUpdatesErrorDescription.defaultMessage)).toBeVisible();
+    });
+
+    it('editing course handouts should show saving error alert', async () => {
+      const { getByText, queryByText } = render(<RootWrapper />);
+
+      const data = {
+        ...courseHandoutsMock,
+        data: '<p>Some handouts 1</p>',
+      };
+
+      axiosMock
+        .onPut(getCourseHandoutApiUrl(courseId))
+        .reply(404);
+
+      await executeThunk(editCourseHandoutsQuery(courseId, data), store.dispatch);
+      expect(queryByText('Some handouts 1')).toBeNull();
+      expect(getByText(courseHandoutsMock.data)).toBeVisible();
+      expect(getByText(messages.savingHandoutsErrorDescription.defaultMessage));
     });
   });
 });

--- a/src/course-updates/data/selectors.js
+++ b/src/course-updates/data/selectors.js
@@ -2,3 +2,4 @@ export const getCourseUpdates = (state) => state.courseUpdates.courseUpdates;
 export const getCourseHandouts = (state) => state.courseUpdates.courseHandouts;
 export const getSavingStatuses = (state) => state.courseUpdates.savingStatuses;
 export const getLoadingStatuses = (state) => state.courseUpdates.loadingStatuses;
+export const getErrors = (state) => state.courseUpdates.errors;

--- a/src/course-updates/data/slice.js
+++ b/src/course-updates/data/slice.js
@@ -16,10 +16,12 @@ const initialState = {
     fetchCourseHandoutsQuery: '',
   },
   errors: {
-    loadingUpdates: '',
-    loadingHandouts: '',
-    savingUpdates: '',
-    savingHandouts: '',
+    creatingUpdate: false,
+    deletingUpdates: false,
+    loadingUpdates: false,
+    loadingHandouts: false,
+    savingUpdates: false,
+    savingHandouts: false,
   },
 };
 
@@ -55,12 +57,12 @@ const slice = createSlice({
     },
     updateSavingStatuses: (state, { payload }) => {
       const { status, error } = payload;
-      state.errors = { ...state.errors, ...error };
+      state.errors = { ...initialState.errors, ...error };
       state.savingStatuses = { ...state.savingStatuses, ...status };
     },
     updateLoadingStatuses: (state, { payload }) => {
       const { status, error } = payload;
-      state.errors = { ...state.errors, ...error };
+      state.errors = { ...initialState.errors, ...error };
       state.loadingStatuses = { ...state.loadingStatuses, ...status };
     },
   },

--- a/src/course-updates/data/slice.js
+++ b/src/course-updates/data/slice.js
@@ -15,6 +15,12 @@ const initialState = {
     fetchCourseUpdatesQuery: '',
     fetchCourseHandoutsQuery: '',
   },
+  errors: {
+    loadingUpdates: '',
+    loadingHandouts: '',
+    savingUpdates: '',
+    savingHandouts: '',
+  },
 };
 
 const slice = createSlice({
@@ -48,10 +54,14 @@ const slice = createSlice({
       };
     },
     updateSavingStatuses: (state, { payload }) => {
-      state.savingStatuses = { ...state.savingStatuses, ...payload };
+      const { status, error } = payload;
+      state.errors = { ...state.errors, ...error };
+      state.savingStatuses = { ...state.savingStatuses, ...status };
     },
     updateLoadingStatuses: (state, { payload }) => {
-      state.loadingStatuses = { ...state.loadingStatuses, ...payload };
+      const { status, error } = payload;
+      state.errors = { ...state.errors, ...error };
+      state.loadingStatuses = { ...state.loadingStatuses, ...status };
     },
   },
 });

--- a/src/course-updates/data/thunk.js
+++ b/src/course-updates/data/thunk.js
@@ -23,12 +23,18 @@ import {
 export function fetchCourseUpdatesQuery(courseId) {
   return async (dispatch) => {
     try {
-      dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.IN_PROGRESS }));
+      dispatch(updateLoadingStatuses({ fetchCourseUpdatesQuery: RequestStatus.IN_PROGRESS }));
       const courseUpdates = await getCourseUpdates(courseId);
       dispatch(fetchCourseUpdatesSuccess(courseUpdates));
-      dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateLoadingStatuses({
+        status: { fetchCourseUpdatesQuery: RequestStatus.SUCCESSFUL },
+        error: { loadingUpdates: '' },
+      }));
     } catch (error) {
-      dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.FAILED }));
+      dispatch(updateLoadingStatuses({
+        status: { fetchCourseUpdatesQuery: RequestStatus.FAILED },
+        error: { loadingUpdates: `Failed to load course updates for ${courseId}.` },
+      }));
     }
   };
 }
@@ -41,10 +47,16 @@ export function createCourseUpdateQuery(courseId, data) {
       const courseUpdate = await createUpdate(courseId, data);
       dispatch(createCourseUpdate(courseUpdate));
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
+        error: { savingUpdates: '' },
+      }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.FAILED }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.FAILED },
+        error: { savingUpdates: 'Failed to save new course update.' },
+      }));
     }
   };
 }
@@ -57,10 +69,16 @@ export function editCourseUpdateQuery(courseId, data) {
       const courseUpdate = await editUpdate(courseId, data);
       dispatch(editCourseUpdate(courseUpdate));
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
+        error: { savingUpdates: '' },
+      }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.FAILED }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.FAILED },
+        error: { savingUpdates: 'Failed to save recent changes to course update.' },
+      }));
     }
   };
 }
@@ -73,10 +91,16 @@ export function deleteCourseUpdateQuery(courseId, updateId) {
       const courseUpdates = await deleteUpdate(courseId, updateId);
       dispatch(deleteCourseUpdate(courseUpdates));
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
+        error: { savingUpdates: '' },
+      }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.FAILED }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.FAILED },
+        error: { savingUpdates: 'Failed to delete selected course update.' },
+      }));
     }
   };
 }
@@ -87,9 +111,15 @@ export function fetchCourseHandoutsQuery(courseId) {
       dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.IN_PROGRESS }));
       const courseHandouts = await getCourseHandouts(courseId);
       dispatch(fetchCourseHandoutsSuccess(courseHandouts));
-      dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateLoadingStatuses({
+        status: { fetchCourseHandoutsQuery: RequestStatus.SUCCESSFUL },
+        error: { loadingHandouts: '' },
+      }));
     } catch (error) {
-      dispatch(updateLoadingStatuses({ fetchCourseHandoutsQuery: RequestStatus.FAILED }));
+      dispatch(updateLoadingStatuses({
+        status: { fetchCourseHandoutsQuery: RequestStatus.FAILED },
+        error: { loadingHandouts: `Failed to load course handouts for ${courseId}.` },
+      }));
     }
   };
 }
@@ -102,10 +132,16 @@ export function editCourseHandoutsQuery(courseId, data) {
       const courseHandouts = await editHandouts(courseId, data);
       dispatch(editCourseHandouts(courseHandouts));
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.SUCCESSFUL }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
+        error: { savingHandouts: '' },
+      }));
     } catch (error) {
       dispatch(hideProcessingNotification());
-      dispatch(updateSavingStatuses({ createCourseUpdateQuery: RequestStatus.FAILED }));
+      dispatch(updateSavingStatuses({
+        status: { createCourseUpdateQuery: RequestStatus.FAILED },
+        error: { savingHandouts: 'Failed to save recent changes to course handouts.' },
+      }));
     }
   };
 }

--- a/src/course-updates/data/thunk.js
+++ b/src/course-updates/data/thunk.js
@@ -28,12 +28,12 @@ export function fetchCourseUpdatesQuery(courseId) {
       dispatch(fetchCourseUpdatesSuccess(courseUpdates));
       dispatch(updateLoadingStatuses({
         status: { fetchCourseUpdatesQuery: RequestStatus.SUCCESSFUL },
-        error: { loadingUpdates: '' },
+        error: { loadingUpdates: false },
       }));
     } catch (error) {
       dispatch(updateLoadingStatuses({
         status: { fetchCourseUpdatesQuery: RequestStatus.FAILED },
-        error: { loadingUpdates: `Failed to load course updates for ${courseId}.` },
+        error: { loadingUpdates: true },
       }));
     }
   };
@@ -49,13 +49,13 @@ export function createCourseUpdateQuery(courseId, data) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
-        error: { savingUpdates: '' },
+        error: { creatingUpdate: false },
       }));
     } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
-        error: { savingUpdates: 'Failed to save new course update.' },
+        error: { creatingUpdate: true },
       }));
     }
   };
@@ -71,13 +71,13 @@ export function editCourseUpdateQuery(courseId, data) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
-        error: { savingUpdates: '' },
+        error: { savingUpdates: false },
       }));
     } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
-        error: { savingUpdates: 'Failed to save recent changes to course update.' },
+        error: { savingUpdates: true },
       }));
     }
   };
@@ -93,13 +93,13 @@ export function deleteCourseUpdateQuery(courseId, updateId) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
-        error: { savingUpdates: '' },
+        error: { deletingUpdates: false },
       }));
     } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
-        error: { savingUpdates: 'Failed to delete selected course update.' },
+        error: { deletingUpdates: true },
       }));
     }
   };
@@ -113,12 +113,12 @@ export function fetchCourseHandoutsQuery(courseId) {
       dispatch(fetchCourseHandoutsSuccess(courseHandouts));
       dispatch(updateLoadingStatuses({
         status: { fetchCourseHandoutsQuery: RequestStatus.SUCCESSFUL },
-        error: { loadingHandouts: '' },
+        error: { loadingHandouts: false },
       }));
     } catch (error) {
       dispatch(updateLoadingStatuses({
         status: { fetchCourseHandoutsQuery: RequestStatus.FAILED },
-        error: { loadingHandouts: `Failed to load course handouts for ${courseId}.` },
+        error: { loadingHandouts: true },
       }));
     }
   };
@@ -134,13 +134,13 @@ export function editCourseHandoutsQuery(courseId, data) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.SUCCESSFUL },
-        error: { savingHandouts: '' },
+        error: { savingHandouts: false },
       }));
     } catch (error) {
       dispatch(hideProcessingNotification());
       dispatch(updateSavingStatuses({
         status: { createCourseUpdateQuery: RequestStatus.FAILED },
-        error: { savingHandouts: 'Failed to save recent changes to course handouts.' },
+        error: { savingHandouts: true },
       }));
     }
   };

--- a/src/course-updates/hooks.jsx
+++ b/src/course-updates/hooks.jsx
@@ -98,7 +98,7 @@ const useCourseUpdates = ({ courseId }) => {
     courseHandouts,
     courseUpdatesInitialValues,
     isMainFormOpen: isUpdateFormOpen && requestType !== REQUEST_TYPES.edit_update,
-    isInnerFormOpen: (id) => isUpdateFormOpen && currentUpdate.id === id && requestType === REQUEST_TYPES.edit_update,
+    isInnerFormOpen: (id) => (isUpdateFormOpen && currentUpdate.id === id && requestType === REQUEST_TYPES.edit_update),
     isUpdateFormOpen,
     isDeleteModalOpen,
     closeUpdateForm,

--- a/src/course-updates/messages.js
+++ b/src/course-updates/messages.js
@@ -31,25 +31,60 @@ const messages = defineMessages({
     defaultMessage: 'You have not added any updates to this course yet.',
     description: 'Message to notify user that they do not have any existing course updates',
   },
-  loadingErrorAlertTitle: {
-    id: 'course-authoring.course-updates.actions.first-update-message',
-    defaultMessage: 'Failed to load course {errorType}',
-    description: 'Alert title for loading error alert',
+  loadingUpdatesErrorTitle: {
+    id: 'course-authoring.course-updates.error.loading-updates.title',
+    defaultMessage: 'Failed to load course updates',
+    description: 'Alert title for loading updates error alert',
   },
-  loadingErrorAlertDescription: {
-    id: 'course-authoring.course-updates.loading-error',
-    defaultMessage: '{message} Please try again later.',
-    description: 'Alert body message for loading course update and handout errors',
+  loadingUpdatesErrorDescription: {
+    id: 'course-authoring.course-updates.error.loading-updates.description',
+    defaultMessage: 'Failed to load course updates for {courseId}. Please try again later.',
+    description: 'Alert body message for loading course update errors',
   },
-  savingErrorAlertTitle: {
-    id: 'course-authoring.course-updates.saving-error.title',
-    defaultMessage: 'Failed to {actionType} course {errorType}',
-    description: 'Alert title for saving error alert',
+  loadingHandoutsErrorTitle: {
+    id: 'course-authoring.course-updates.error.loading-handouts.title',
+    defaultMessage: 'Failed to load course handouts',
+    description: 'Alert title for loading handouts error alert',
   },
-  savingErrorAlertDescription: {
-    id: 'course-authoring.course-updates.saving-error.description',
-    defaultMessage: '{message} Please try again later.',
-    description: 'Alert body message for saving course update and handout errors',
+  loadingHandoutsErrorDescription: {
+    id: 'course-authoring.course-updates.error.loading-handouts.description',
+    defaultMessage: 'Failed to load course updates for {courseId}. Please try again later.',
+    description: 'Alert body message for loading course handout errors',
+  },
+  savingUpdatesErrorTitle: {
+    id: 'course-authoring.course-updates.error.saving-updates.title',
+    defaultMessage: 'Failed to save course update',
+    description: 'Alert title for saving updates error alert',
+  },
+  savingUpdatesErrorDescription: {
+    id: 'course-authoring.course-updates.error.saving-updates.description',
+    defaultMessage: 'Failed to save recent changes to course update. Please try again later.',
+    description: 'Alert body message for saving edits to course update errors',
+  },
+  savingNewUpdateErrorAlertDescription: {
+    id: 'course-authoring.course-updates.error.saving-new-updates.description',
+    defaultMessage: 'Failed to save new course update. Please try again later.',
+    description: 'Alert body message for saving new course update errors',
+  },
+  savingHandoutErrorTitle: {
+    id: 'course-authoring.course-updates.error.saving-handouts.title',
+    defaultMessage: 'Failed to save course handouts',
+    description: 'Alert title for saving handouts error alert',
+  },
+  savingHandoutsErrorDescription: {
+    id: 'course-authoring.course-updates.error.saving-handouts.description',
+    defaultMessage: 'Failed to save recent changes to course handouts. Please try again later.',
+    description: 'Alert body message for saving course handout errors',
+  },
+  deletingUpdatesErrorTitle: {
+    id: 'course-authoring.course-updates.error.deleting-updates.title',
+    defaultMessage: 'Failed to delete course update',
+    description: 'Alert title for deleting update error alert',
+  },
+  deletingUpdatesErrorDescription: {
+    id: 'course-authoring.course-updates.error.deleting-updates.description',
+    defaultMessage: 'Failed to delete selected course update. Please try again later.',
+    description: 'Alert body message for deleting course update errors',
   },
 });
 

--- a/src/course-updates/messages.js
+++ b/src/course-updates/messages.js
@@ -4,18 +4,52 @@ const messages = defineMessages({
   headingTitle: {
     id: 'course-authoring.course-updates.header.title',
     defaultMessage: 'Course updates',
+    description: 'Title for page',
   },
   headingSubtitle: {
     id: 'course-authoring.course-updates.header.subtitle',
     defaultMessage: 'Content',
+    description: 'Subtitle for page',
   },
   sectionInfo: {
     id: 'course-authoring.course-updates.section-info',
     defaultMessage: 'Use course updates to notify students of important dates or exams, highlight particular discussions in the forums, announce schedule changes, and respond to student questions.',
+    description: 'Message describing the use of course updates in a course',
   },
   newUpdateButton: {
     id: 'course-authoring.course-updates.actions.new-update',
     defaultMessage: 'New update',
+    description: 'Button label for header button to add a new course update',
+  },
+  firstUpdateButton: {
+    id: 'course-authoring.course-updates.actions.first-update',
+    defaultMessage: 'Add first update',
+    description: 'Button label for button to add first course update',
+  },
+  noCourseUpdates: {
+    id: 'course-authoring.course-updates.actions.first-update-message',
+    defaultMessage: 'You have not added any updates to this course yet.',
+    description: 'Message to notify user that they do not have any existing course updates',
+  },
+  loadingErrorAlertTitle: {
+    id: 'course-authoring.course-updates.actions.first-update-message',
+    defaultMessage: 'Failed to load course {errorType}',
+    description: 'Alert title for loading error alert',
+  },
+  loadingErrorAlertDescription: {
+    id: 'course-authoring.course-updates.loading-error',
+    defaultMessage: '{message} Please try again later.',
+    description: 'Alert body message for loading course update and handout errors',
+  },
+  savingErrorAlertTitle: {
+    id: 'course-authoring.course-updates.saving-error.title',
+    defaultMessage: 'Failed to {actionType} course {errorType}',
+    description: 'Alert title for saving error alert',
+  },
+  savingErrorAlertDescription: {
+    id: 'course-authoring.course-updates.saving-error.description',
+    defaultMessage: '{message} Please try again later.',
+    description: 'Alert body message for saving course update and handout errors',
   },
 });
 

--- a/src/course-updates/messages.js
+++ b/src/course-updates/messages.js
@@ -66,7 +66,7 @@ const messages = defineMessages({
     defaultMessage: 'Failed to save new course update. Please try again later.',
     description: 'Alert body message for saving new course update errors',
   },
-  savingHandoutErrorTitle: {
+  savingHandoutsErrorTitle: {
     id: 'course-authoring.course-updates.error.saving-handouts.title',
     defaultMessage: 'Failed to save course handouts',
     description: 'Alert title for saving handouts error alert',

--- a/src/index.scss
+++ b/src/index.scss
@@ -51,3 +51,11 @@ div.xblock-highlight {
     box-shadow: unset;
   }
 }
+
+body {
+  background-color: $light-200;
+
+  .editor-page {
+    background-color: $light-100;
+  }
+}


### PR DESCRIPTION
## Description

The JIRA ticket noted below was the original issue of this PR, but was resolved with work surrounding the data/time converter. However, the logging of the error showed a need for better error messaging and callout when no updates are saved to a course. This change impacts Authors.

Before:
<img width="1422" alt="Screenshot 2024-05-21 at 1 55 45 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/42981026/4c130f49-5501-4a17-9abc-89e92a1981b3">

After:
<img width="1422" alt="Screenshot 2024-05-21 at 1 54 54 PM" src="https://github.com/openedx/frontend-app-course-authoring/assets/42981026/7be29a7d-16f9-4243-b738-29cbe5f48352">

## Supporting information

JIRA Ticket: [TNL-11572](https://2u-internal.atlassian.net/browse/TNL-11572)
> Reported that authors are unable to edit/change a link in their welcome page. Screenshot of the error message attached below.
![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/fe491162-634e-412d-9ebc-94528c4bb4eb)
![image](https://github.com/openedx/frontend-app-course-authoring/assets/42981026/b5a17987-f580-4873-9699-bcb05d3212e6)

## Testing instructions

1. Open a course and navigate to the Course Updates page
2. Confirm that page loads content as expected
3. If the course has updates, delete all.
4. Empty updates should show first time message with add button
5. Add first update
6. For each button click (adding, editing, deleting) force the api to throw an error
7. Confirm that for each action an error alert appears at the top of the page with correct message