### PR TITLE
feat: bump frontend-lib-content-components 2.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@edx/frontend-component-footer": "^13.0.2",
         "@edx/frontend-component-header": "^5.1.0",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
-        "@edx/frontend-lib-content-components": "^2.1.7",
+        "@edx/frontend-lib-content-components": "^2.1.9",
         "@edx/frontend-platform": "7.0.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2580,10 +2580,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.1.8.tgz",
-      "integrity": "sha512-toCgEQpuPwlwQxE42IXrrVTQxdbt2Vlpnsq8jlG2d22LsCmIHDg3LSyRSCHeaJxy57OVEtSh6qHZ8RtZ8EeKoQ==",
-      "license": "AGPL-3.0",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.1.9.tgz",
+      "integrity": "sha512-ACnW0w1bWBvzkC+EY83/SZHlNJ5bWpzAxMYlUSZV2CfOMQfZss48zOcCwo5WbDSw4I3q62u9qRiLLusB4Xynkw==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@edx/frontend-component-footer": "^13.0.2",
     "@edx/frontend-component-header": "^5.1.0",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
-    "@edx/frontend-lib-content-components": "^2.1.7",
+    "@edx/frontend-lib-content-components": "^2.1.9",
     "@edx/frontend-platform": "7.0.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
## Description

This PR upgrades @edx/frontend-lib-content-components to 2.1.9. This upgrade includes the following changes:


- [#477](https://github.com/openedx/frontend-lib-content-components/pull/477)
- [#438](https://github.com/openedx/frontend-lib-content-components/pull/438)