### PR TITLE
[FC-0042] Fix: Bug: Unusable "Languages" taxonomy appears in tagging drawer

### DIFF
--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -31,17 +31,19 @@ const TaxonomyList = ({ contentId }) => {
   if (isTaxonomyListLoaded && isContentTaxonomyTagsLoaded) {
     if (tagsByTaxonomy.length !== 0) {
       return (
-        tagsByTaxonomy.map((data) => (
-          <div key={`taxonomy-tags-collapsible-${data.id}`}>
-            <ContentTagsCollapsible
-              contentId={contentId}
-              taxonomyAndTagsData={data}
-              stagedContentTags={stagedContentTags[data.id] || []}
-              collapsibleState={collapsibleStates[data.id] || false}
-            />
-            <hr />
-          </div>
-        ))
+        <div>
+          { tagsByTaxonomy.map((data) => (
+            <div key={`taxonomy-tags-collapsible-${data.id}`}>
+              <ContentTagsCollapsible
+                contentId={contentId}
+                taxonomyAndTagsData={data}
+                stagedContentTags={stagedContentTags[data.id] || []}
+                collapsibleState={collapsibleStates[data.id] || false}
+              />
+              <hr />
+            </div>
+          ))}
+        </div>
       );
     }
 

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -8,8 +8,8 @@ import {
   Button,
   Toast,
 } from '@openedx/paragon';
-import { useIntl } from '@edx/frontend-platform/i18n';
-import { useParams } from 'react-router-dom';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useParams, useNavigate } from 'react-router-dom';
 import messages from './messages';
 import ContentTagsCollapsible from './ContentTagsCollapsible';
 import Loading from '../generic/Loading';
@@ -27,6 +27,7 @@ import { ContentTagsDrawerContext, ContentTagsDrawerSheetContext } from './commo
  */
 const ContentTagsDrawer = ({ id, onClose }) => {
   const intl = useIntl();
+  const navigate = useNavigate();
   // TODO: We can delete 'params' when the iframe is no longer used on edx-platform
   const params = useParams();
   const contentId = id ?? params.contentId;
@@ -90,6 +91,46 @@ const ContentTagsDrawer = ({ id, onClose }) => {
     setCollapsibleToInitalState();
   }, [isTaxonomyListLoaded, isContentTaxonomyTagsLoaded]);
 
+  const buildTaxonomies = () => {
+    if (isTaxonomyListLoaded && isContentTaxonomyTagsLoaded) {
+      if (tagsByTaxonomy.length !== 0) {
+        return (
+          tagsByTaxonomy.map((data) => (
+            <div key={`taxonomy-tags-collapsible-${data.id}`}>
+              <ContentTagsCollapsible
+                contentId={contentId}
+                taxonomyAndTagsData={data}
+                stagedContentTags={stagedContentTags[data.id] || []}
+                collapsibleState={collapsibleStates[data.id] || false}
+              />
+              <hr />
+            </div>
+          ))
+        );
+      }
+      return (
+        <FormattedMessage
+          {...messages.emptyDrawerContent}
+          values={{
+            link: (
+              <Button
+                tabIndex="0"
+                size="inline"
+                variant="link"
+                className="text-info-500 p-0 enable-taxonomies-button"
+                onClick={() => navigate('/taxonomies')}
+              >
+                { intl.formatMessage(messages.emptyDrawerContentLink) }
+              </Button>
+            ),
+          }}
+        />
+      );
+    }
+
+    return <Loading />;
+  };
+
   return (
     <ContentTagsDrawerContext.Provider value={context}>
       <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
@@ -110,19 +151,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
             <p className="h4 text-gray-500 font-weight-bold">
               {intl.formatMessage(messages.headerSubtitle)}
             </p>
-            { isTaxonomyListLoaded && isContentTaxonomyTagsLoaded
-              ? tagsByTaxonomy.map((data) => (
-                <div key={`taxonomy-tags-collapsible-${data.id}`}>
-                  <ContentTagsCollapsible
-                    contentId={contentId}
-                    taxonomyAndTagsData={data}
-                    stagedContentTags={stagedContentTags[data.id] || []}
-                    collapsibleState={collapsibleStates[data.id] || false}
-                  />
-                  <hr />
-                </div>
-              ))
-              : <Loading />}
+            {buildTaxonomies()}
             {otherTaxonomies.length !== 0 && (
               <div>
                 <p className="h4 text-gray-500 font-weight-bold">

--- a/src/content-tags-drawer/ContentTagsDrawer.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.jsx
@@ -16,6 +16,62 @@ import Loading from '../generic/Loading';
 import useContentTagsDrawerContext from './ContentTagsDrawerHelper';
 import { ContentTagsDrawerContext, ContentTagsDrawerSheetContext } from './common/context';
 
+const TaxonomyList = ({ contentId }) => {
+  const navigate = useNavigate();
+  const intl = useIntl();
+
+  const {
+    isTaxonomyListLoaded,
+    isContentTaxonomyTagsLoaded,
+    tagsByTaxonomy,
+    stagedContentTags,
+    collapsibleStates,
+  } = React.useContext(ContentTagsDrawerContext);
+
+  if (isTaxonomyListLoaded && isContentTaxonomyTagsLoaded) {
+    if (tagsByTaxonomy.length !== 0) {
+      return (
+        tagsByTaxonomy.map((data) => (
+          <div key={`taxonomy-tags-collapsible-${data.id}`}>
+            <ContentTagsCollapsible
+              contentId={contentId}
+              taxonomyAndTagsData={data}
+              stagedContentTags={stagedContentTags[data.id] || []}
+              collapsibleState={collapsibleStates[data.id] || false}
+            />
+            <hr />
+          </div>
+        ))
+      );
+    }
+
+    return (
+      <FormattedMessage
+        {...messages.emptyDrawerContent}
+        values={{
+          link: (
+            <Button
+              tabIndex="0"
+              size="inline"
+              variant="link"
+              className="text-info-500 p-0 enable-taxonomies-button"
+              onClick={() => navigate('/taxonomies')}
+            >
+              { intl.formatMessage(messages.emptyDrawerContentLink) }
+            </Button>
+          ),
+        }}
+      />
+    );
+  }
+
+  return <Loading />;
+};
+
+TaxonomyList.propTypes = {
+  contentId: PropTypes.string.isRequired,
+};
+
 /**
  * Drawer with the functionality to show and manage tags in a certain content.
  * It is used both in interfaces of this MFE and in edx-platform interfaces such as iframe.
@@ -27,7 +83,6 @@ import { ContentTagsDrawerContext, ContentTagsDrawerSheetContext } from './commo
  */
 const ContentTagsDrawer = ({ id, onClose }) => {
   const intl = useIntl();
-  const navigate = useNavigate();
   // TODO: We can delete 'params' when the iframe is no longer used on edx-platform
   const params = useParams();
   const contentId = id ?? params.contentId;
@@ -43,7 +98,6 @@ const ContentTagsDrawer = ({ id, onClose }) => {
     contentName,
     isTaxonomyListLoaded,
     isContentTaxonomyTagsLoaded,
-    tagsByTaxonomy,
     stagedContentTags,
     collapsibleStates,
     isEditMode,
@@ -91,46 +145,6 @@ const ContentTagsDrawer = ({ id, onClose }) => {
     setCollapsibleToInitalState();
   }, [isTaxonomyListLoaded, isContentTaxonomyTagsLoaded]);
 
-  const buildTaxonomies = () => {
-    if (isTaxonomyListLoaded && isContentTaxonomyTagsLoaded) {
-      if (tagsByTaxonomy.length !== 0) {
-        return (
-          tagsByTaxonomy.map((data) => (
-            <div key={`taxonomy-tags-collapsible-${data.id}`}>
-              <ContentTagsCollapsible
-                contentId={contentId}
-                taxonomyAndTagsData={data}
-                stagedContentTags={stagedContentTags[data.id] || []}
-                collapsibleState={collapsibleStates[data.id] || false}
-              />
-              <hr />
-            </div>
-          ))
-        );
-      }
-      return (
-        <FormattedMessage
-          {...messages.emptyDrawerContent}
-          values={{
-            link: (
-              <Button
-                tabIndex="0"
-                size="inline"
-                variant="link"
-                className="text-info-500 p-0 enable-taxonomies-button"
-                onClick={() => navigate('/taxonomies')}
-              >
-                { intl.formatMessage(messages.emptyDrawerContentLink) }
-              </Button>
-            ),
-          }}
-        />
-      );
-    }
-
-    return <Loading />;
-  };
-
   return (
     <ContentTagsDrawerContext.Provider value={context}>
       <div id="content-tags-drawer" className="mt-1 tags-drawer d-flex flex-column justify-content-between min-vh-100 pt-3">
@@ -151,7 +165,7 @@ const ContentTagsDrawer = ({ id, onClose }) => {
             <p className="h4 text-gray-500 font-weight-bold">
               {intl.formatMessage(messages.headerSubtitle)}
             </p>
-            {buildTaxonomies()}
+            <TaxonomyList contentId={contentId} />
             {otherTaxonomies.length !== 0 && (
               <div>
                 <p className="h4 text-gray-500 font-weight-bold">

--- a/src/content-tags-drawer/ContentTagsDrawer.scss
+++ b/src/content-tags-drawer/ContentTagsDrawer.scss
@@ -22,6 +22,11 @@
   .other-description {
     font-size: .9rem;
   }
+
+  .enable-taxonomies-button:not([disabled]):hover {
+    background-color: transparent;
+    color: $info-900 !important;
+  }
 }
 
 // Apply styles to sheet only if it has a child with a .tags-drawer class

--- a/src/content-tags-drawer/ContentTagsDrawer.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.test.jsx
@@ -32,6 +32,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({
     contentId,
   }),
+  useNavigate: jest.fn(),
 }));
 
 // FIXME: replace these mocks with API mocks
@@ -1148,5 +1149,29 @@ describe('<ContentTagsDrawer />', () => {
     expect(await screen.findByText('Taxonomy 1')).toBeInTheDocument();
 
     expect(screen.queryByText('Languages')).not.toBeInTheDocument();
+  });
+
+  it('should show empty drawer message', async () => {
+    useContentTaxonomyTagsData.mockReturnValue({
+      isSuccess: true,
+      data: {
+        taxonomies: [],
+      },
+    });
+    getTaxonomyListData.mockResolvedValue({
+      results: [],
+    });
+    useTaxonomyTagsData.mockReturnValue({
+      hasMorePages: false,
+      canAddTag: false,
+      tagPages: {
+        isLoading: false,
+        isError: false,
+        data: [],
+      },
+    });
+
+    render(<RootWrapper />);
+    expect(await screen.findByText(/to use tags, please or contact your administrator\./i)).toBeInTheDocument();
   });
 });

--- a/src/content-tags-drawer/ContentTagsDrawer.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.test.jsx
@@ -26,13 +26,14 @@ const contentId = 'block-v1:SampleTaxonomyOrg1+STC1+2023_1+type@vertical+block@7
 const mockOnClose = jest.fn();
 const mockMutate = jest.fn();
 const mockSetBlockingSheet = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({
     contentId,
   }),
-  useNavigate: jest.fn(),
+  useNavigate: () => mockNavigate,
 }));
 
 // FIXME: replace these mocks with API mocks
@@ -1173,5 +1174,10 @@ describe('<ContentTagsDrawer />', () => {
 
     render(<RootWrapper />);
     expect(await screen.findByText(/to use tags, please or contact your administrator\./i)).toBeInTheDocument();
+    const enableButton = screen.getByRole('button', {
+      name: /enable a taxonomy/i,
+    });
+    fireEvent.click(enableButton);
+    expect(mockNavigate).toHaveBeenCalledWith('/taxonomies');
   });
 });

--- a/src/content-tags-drawer/ContentTagsDrawer.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawer.test.jsx
@@ -20,6 +20,7 @@ import {
 import { getTaxonomyListData } from '../taxonomy/data/api';
 import messages from './messages';
 import { ContentTagsDrawerSheetContext } from './common/context';
+import { languageExportId } from './utils';
 
 const contentId = 'block-v1:SampleTaxonomyOrg1+STC1+2023_1+type@vertical+block@7f47fe2dbcaf47c5a071671c741fe1ab';
 const mockOnClose = jest.fn();
@@ -248,6 +249,83 @@ describe('<ContentTagsDrawer />', () => {
           depth: 0,
           parentValue: null,
           id: 12347,
+          subTagsUrl: null,
+          canChangeTag: false,
+          canDeleteTag: false,
+        }],
+      },
+    });
+  };
+
+  const setupMockDataLanguageTaxonomyTestings = (hasTags) => {
+    useContentTaxonomyTagsData.mockReturnValue({
+      isSuccess: true,
+      data: {
+        taxonomies: [
+          {
+            name: 'Languages',
+            taxonomyId: 123,
+            exportId: languageExportId,
+            canTagObject: true,
+            tags: hasTags ? [
+              {
+                value: 'Tag 1',
+                lineage: ['Tag 1'],
+                canDeleteObjecttag: true,
+              },
+            ] : [],
+          },
+          {
+            name: 'Taxonomy 1',
+            taxonomyId: 1234,
+            canTagObject: true,
+            tags: [
+              {
+                value: 'Tag 1',
+                lineage: ['Tag 1'],
+                canDeleteObjecttag: true,
+              },
+              {
+                value: 'Tag 2',
+                lineage: ['Tag 2'],
+                canDeleteObjecttag: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    getTaxonomyListData.mockResolvedValue({
+      results: [
+        {
+          id: 123,
+          name: 'Languages',
+          description: 'This is a description 1',
+          exportId: languageExportId,
+          canTagObject: true,
+        },
+        {
+          id: 1234,
+          name: 'Taxonomy 1',
+          description: 'This is a description 2',
+          canTagObject: true,
+        },
+      ],
+    });
+
+    useTaxonomyTagsData.mockReturnValue({
+      hasMorePages: false,
+      canAddTag: false,
+      tagPages: {
+        isLoading: false,
+        isError: false,
+        data: [{
+          value: 'Tag 1',
+          externalId: null,
+          childCount: 0,
+          depth: 0,
+          parentValue: null,
+          id: 12345,
           subTagsUrl: null,
           canChangeTag: false,
           canDeleteTag: false,
@@ -1056,5 +1134,19 @@ describe('<ContentTagsDrawer />', () => {
     fireEvent.click(cancelButton);
 
     expect(screen.getByText(/tag 3/i)).toBeInTheDocument();
+  });
+
+  it('should show Language Taxonomy', async () => {
+    setupMockDataLanguageTaxonomyTestings(true);
+    render(<RootWrapper />);
+    expect(await screen.findByText('Languages')).toBeInTheDocument();
+  });
+
+  it('should hide Language Taxonomy', async () => {
+    setupMockDataLanguageTaxonomyTestings(false);
+    render(<RootWrapper />);
+    expect(await screen.findByText('Taxonomy 1')).toBeInTheDocument();
+
+    expect(screen.queryByText('Languages')).not.toBeInTheDocument();
   });
 });

--- a/src/content-tags-drawer/ContentTagsDrawerHelper.jsx
+++ b/src/content-tags-drawer/ContentTagsDrawerHelper.jsx
@@ -4,7 +4,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { cloneDeep } from 'lodash';
 import { useContentData, useContentTaxonomyTagsData, useContentTaxonomyTagsUpdater } from './data/apiHooks';
 import { useTaxonomyList } from '../taxonomy/data/apiHooks';
-import { extractOrgFromContentId } from './utils';
+import { extractOrgFromContentId, languageExportId } from './utils';
 import messages from './messages';
 import { ContentTagsDrawerSheetContext } from './common/context';
 
@@ -142,8 +142,14 @@ const useContentTagsDrawerContext = (contentId) => {
         }
       });
 
+      // Delete Language taxonomy if is empty
+      const filteredTaxonomies = taxonomiesList.filter(
+        (taxonomy) => taxonomy.exportId !== languageExportId
+          || taxonomy.contentTags.length !== 0,
+      );
+
       return {
-        fechedTaxonomies: sortTaxonomies(taxonomiesList),
+        fechedTaxonomies: sortTaxonomies(filteredTaxonomies),
         fechedOtherTaxonomies: otherTaxonomiesList,
       };
     }

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.jsx
@@ -323,7 +323,9 @@ const ContentTagsDropDownSelector = ({
 
       { tagPages.data.length === 0 && !tagPages.isLoading && (
         <div className="d-flex justify-content-center muted-text">
-          <FormattedMessage {...messages.noTagsFoundMessage} values={{ searchTerm }} />
+          { searchTerm
+            ? <FormattedMessage {...messages.noTagsFoundMessage} values={{ searchTerm }} />
+            : <FormattedMessage {...messages.noTagsInTaxonomyMessage} />}
         </div>
       )}
 

--- a/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
+++ b/src/content-tags-drawer/ContentTagsDropDownSelector.test.jsx
@@ -282,4 +282,28 @@ describe('<ContentTagsDropDownSelector />', () => {
       expect(getByText(message)).toBeInTheDocument();
     });
   });
+
+  it('should render "noTagsInTaxonomy" message if taxonomy is empty', async () => {
+    useTaxonomyTagsData.mockReturnValueOnce({
+      hasMorePages: false,
+      tagPages: {
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        data: [],
+      },
+    });
+
+    const searchTerm = '';
+    await act(async () => {
+      const { getByText } = await getComponent({ ...data, searchTerm });
+
+      await waitFor(() => {
+        expect(useTaxonomyTagsData).toBeCalledWith(data.taxonomyId, null, 1, searchTerm);
+      });
+
+      const message = 'No tags in this taxonomy yet';
+      expect(getByText(message)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -129,6 +129,16 @@ const messages = defineMessages({
     defaultMessage: 'These tags are already applied, but you can\'t add new ones as you don\'t have access to their taxonomies.',
     description: 'Description of "Other tags" subsection in tags drawer',
   },
+  emptyDrawerContent: {
+    id: 'course-authoring.content-tags-drawer.empty',
+    defaultMessage: 'To use tags, please {link} or contact your administrator.',
+    description: 'Message when there are no taxonomies.',
+  },
+  emptyDrawerContentLink: {
+    id: 'course-authoring.content-tags-drawer.empty-link',
+    defaultMessage: 'enable a taxonomy',
+    description: 'Message of the link used in empty drawer message.',
+  },
 });
 
 export default messages;

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -25,6 +25,11 @@ const messages = defineMessages({
     id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.no-tags-found',
     defaultMessage: 'No tags found with the search term "{searchTerm}"',
   },
+  noTagsInTaxonomyMessage: {
+    id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.no-tags-in-taxonomy',
+    defaultMessage: 'No tags in this taxonomy yet',
+    description: 'Message when the user uses the tags dropdown selector of an empty taxonomy',
+  },
   taxonomyTagChecked: {
     id: 'course-authoring.content-tags-drawer.tags-dropdown-selector.tag-checked',
     defaultMessage: 'Checked',

--- a/src/content-tags-drawer/utils.js
+++ b/src/content-tags-drawer/utils.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const extractOrgFromContentId = (contentId) => contentId.split('+')[0].split(':')[1];
+export const languageExportId = 'languages-v1';


### PR DESCRIPTION
## Description

- feat: Hide language taxonomy when is empty
- feat: New message on search result when taxonomy is empty
- feat: Empty taxonomies message added in drawer

## Supporting information

- Closes https://github.com/openedx/modular-learning/issues/219
- Internal ticket: [FAL-3741](https://tasks.opencraft.com/browse/FAL-3741)

## Testing instructions

- Enable `content_tagging.auto` waffle flag.
- Make sure you have Taxonomy/Tags data setup locally and verify that the command runs well: https://github.com/open-craft/taxonomy-sample-data/
- Create a new course.
- Go to the course -> Manage tags drawer. Verify that you can see the `Languages` taxonomy
- Disable `content_tagging.auto` waffle flag.
- Create a new course.
- Go to the course -> Manage tags drawer. Verify that you can't see the `Languages` taxonomy.
- Go to [taxonomy list](http://localhost:2001/taxonomies) and import an empty taxonomy (you can use the template but empty).
- Go to `Manage Organizations` of the empty taxonomy and assign it to all organizations.
- Go to any course -> Manage tags drawer -> Edit tags. Click on search bar of the empty taxonomy. Verify that says `No tags in this taxonomy yet`.
- Go to [taxonomy list](http://localhost:2001/taxonomies) and unassing all taxonomies for any organization (or delete all taxonomies).
- Create a course with any organization (or a new).
- Got to the new course -> Manage tags drawer. Verify that says `To use tags, please enable a taxonomy or contact your administrator.`
- Click on `enable a taxonomy` and verify that redirects to taxonomy list page
