### PR TITLE
fix: update date using utc timezone instead of local

### DIFF
--- a/src/course-updates/hooks.jsx
+++ b/src/course-updates/hooks.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useToggle } from '@openedx/paragon';
 
 import { COMMA_SEPARATED_DATE_FORMAT } from '../constants';
+import { convertToDateFromString, convertToStringFromDate } from '../utils';
 import { getCourseHandouts, getCourseUpdates } from './data/selectors';
 import { REQUEST_TYPES } from './constants';
 import {
@@ -55,9 +56,10 @@ const useCourseUpdates = ({ courseId }) => {
   };
 
   const handleUpdatesSubmit = (data) => {
+    const dateWithoutTimezone = convertToDateFromString(data.date);
     const dataToSend = {
       ...data,
-      date: moment(data.date).format(COMMA_SEPARATED_DATE_FORMAT),
+      date: moment(dateWithoutTimezone).format(COMMA_SEPARATED_DATE_FORMAT),
     };
     const { id, date, content } = dataToSend;
 


### PR DESCRIPTION
## Description

This PR fixes the date for Updates using the UTC timezone for formatting the date. When using UTC, the date can possibly change on one that the user did not select depending on their local timezone. Now the date is updated to be in the user' local timezone before saving the date to ensure that the date remains as the user input it. This change impact Authors.

## Supporting information

JIRA Ticket: [TNL-11614](https://2u-internal.atlassian.net/browse/TNL-11614)
> The date does not update as expected to the entered date. If you enter one day in the future from the existing provided date, you will see no change. If you enter many days into the future, you will see that date minus 1. So, instead of May 15, you will see May 14. Instead of May 16, you will see May 15. And so on.

## Testing instructions

1. Go to a test course
2. Go to the “Content” menu dropdown and select “Updates”
3. Find an existing Updates post.
4. Adjust the date to a future date. 
   You might try entering one date after the current Updates post’s listed date.
5. Save your changes.
6. Saved date should match the date that you entered
