### PR TITLE
fix: wrong lock status update message

### DIFF
--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -165,12 +165,13 @@ export function updateAssetLock({ assetId, courseId, locked }) {
 
     try {
       await updateLockStatus({ assetId, courseId, locked });
+      const lockStatus = locked ? 'locked' : 'public';
       dispatch(updateModel({
         modelType: 'assets',
         model: {
           id: assetId,
           locked,
-          lockStatus: locked,
+          lockStatus,
         },
       }));
       dispatch(updateEditStatus({ editType: 'lock', status: RequestStatus.SUCCESSFUL }));


### PR DESCRIPTION
## Description

This PR resolves the issue with the locked filter not working on the Files page. The lock status was not given the correct string value for the filter matching as a result all files were marked as unlocked for the purpose of filtering, but the actual locked value was properly saved to the backend. Now the lock status properly updates to match the expected filtering values. This change impact Authors.

## Supporting information

Issue [#1029](https://github.com/openedx/frontend-app-course-authoring/issues/1029)

## Testing instructions

1. Navigate to the File page
2. Click Sort and Filter
3. Click "Locked"
4. Click "Apply"
5. Confirm that the expect files appear
6. Click "Clear filters"
7. Click ••• on one of the files
8. Click "Lock"
9. Click Sort and Filter
10. Click "Locked"
11. Click "Apply"
12. Confirm that the newly locked file is listed
13. Click "Clear filters"
14. Click ••• on the file that was just locked
15. Click "Unlock"
16. Click Sort and Filter
17. Click "Locked"
18. Click "Apply"
19. Confirm that the previously locked file is no longer listed
