### PR TITLE
[backport] fix: wrong lock status update message

### DIFF
--- a/src/files-and-videos/files-page/data/thunks.js
+++ b/src/files-and-videos/files-page/data/thunks.js
@@ -165,12 +165,13 @@ export function updateAssetLock({ assetId, courseId, locked }) {
 
     try {
       await updateLockStatus({ assetId, courseId, locked });
+      const lockStatus = locked ? 'locked' : 'public';
       dispatch(updateModel({
         modelType: 'assets',
         model: {
           id: assetId,
           locked,
-          lockStatus: locked,
+          lockStatus,
         },
       }));
       dispatch(updateEditStatus({ editType: 'lock', status: RequestStatus.SUCCESSFUL }));


### PR DESCRIPTION
## Description
This is a backport of the fix to Redwood branch.

Original PR to master - https://github.com/openedx/frontend-app-course-authoring/pull/1053

BTR issue for Redwood release - https://github.com/openedx/wg-build-test-release/issues/359 