### PR TITLE
[Backport] fix: update date using utc timezone instead of local (#1043)

### DIFF
--- a/src/course-updates/hooks.jsx
+++ b/src/course-updates/hooks.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useToggle } from '@openedx/paragon';
 
 import { COMMA_SEPARATED_DATE_FORMAT } from '../constants';
+import { convertToDateFromString } from '../utils';
 import { getCourseHandouts, getCourseUpdates } from './data/selectors';
 import { REQUEST_TYPES } from './constants';
 import {
@@ -55,9 +56,10 @@ const useCourseUpdates = ({ courseId }) => {
   };
 
   const handleUpdatesSubmit = (data) => {
+    const dateWithoutTimezone = convertToDateFromString(data.date);
     const dataToSend = {
       ...data,
-      date: moment(data.date).format(COMMA_SEPARATED_DATE_FORMAT),
+      date: moment(dateWithoutTimezone).format(COMMA_SEPARATED_DATE_FORMAT),
     };
     const { id, date, content } = dataToSend;
 


### PR DESCRIPTION
## Description

This is a backport of the fix to Redwood branch.

Original PR to master - https://github.com/openedx/frontend-app-course-authoring/pull/1043