### PR TITLE
fix: warnings about Duplicate message id

### DIFF
--- a/src/accessibility-page/messages.js
+++ b/src/accessibility-page/messages.js
@@ -2,7 +2,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
   pageTitle: {
-    id: 'course-authoring.import.page.title',
+    id: 'course-authoring.accessibility.page.title',
     defaultMessage: 'Studio Accessibility Policy| {siteName}',
   },
 });

--- a/src/content-tags-drawer/messages.js
+++ b/src/content-tags-drawer/messages.js
@@ -64,7 +64,7 @@ const messages = defineMessages({
     defaultMessage: 'Add a tag',
   },
   collapsibleNoTagsAddedText: {
-    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.placeholder-text',
+    id: 'course-authoring.content-tags-drawer.content-tags-collapsible.custom-menu.no-tags-added-text',
     defaultMessage: 'No tags added yet.',
   },
   collapsibleAddStagedTagsButtonText: {

--- a/src/course-outline/card-header/messages.js
+++ b/src/course-outline/card-header/messages.js
@@ -58,7 +58,7 @@ const messages = defineMessages({
     defaultMessage: 'Delete',
   },
   menuCopy: {
-    id: 'course-authoring.course-outline.card.menu.delete',
+    id: 'course-authoring.course-outline.card.menu.copy',
     defaultMessage: 'Copy to clipboard',
   },
   menuProctoringLinkText: {

--- a/src/course-outline/page-alerts/messages.js
+++ b/src/course-outline/page-alerts/messages.js
@@ -22,7 +22,7 @@ const messages = defineMessages({
     description: 'Learn more link in upgraded discussion notification alert',
   },
   discussionNotificationFeedback: {
-    id: 'course-authoring.course-outline.page-alerts.discussionNotificationLearnMore',
+    id: 'course-authoring.course-outline.page-alerts.discussionNotificationFeedback',
     defaultMessage: 'Share feedback',
     description: 'Share feedback link in upgraded discussion notification alert',
   },

--- a/src/course-outline/status-bar/messages.js
+++ b/src/course-outline/status-bar/messages.js
@@ -56,7 +56,7 @@ const messages = defineMessages({
     defaultMessage: 'Video Sharing',
   },
   videoSharingLink: {
-    id: 'course-authoring.course-outline.status-bar.video-sharing.title',
+    id: 'course-authoring.course-outline.status-bar.video-sharing.link',
     defaultMessage: 'Learn more',
   },
   videoSharingPerVideoText: {

--- a/src/course-outline/subsection-card/messages.js
+++ b/src/course-outline/subsection-card/messages.js
@@ -6,7 +6,7 @@ const messages = defineMessages({
     defaultMessage: 'New unit',
   },
   pasteButton: {
-    id: 'course-authoring.course-outline.subsection.button.new-unit',
+    id: 'course-authoring.course-outline.subsection.button.paste-unit',
     defaultMessage: 'Paste unit',
   },
 });

--- a/src/course-team/course-team-member/messages.js
+++ b/src/course-team/course-team-member/messages.js
@@ -22,7 +22,7 @@ const messages = defineMessages({
     defaultMessage: 'Add admin access',
   },
   removeButton: {
-    id: 'course-authoring.course-team.member.button.remove',
+    id: 'course-authoring.course-team.member.button.remove-admin-access',
     defaultMessage: 'Remove admin access',
   },
   deleteUserButton: {

--- a/src/files-and-videos/files-page/messages.js
+++ b/src/files-and-videos/files-page/messages.js
@@ -47,12 +47,12 @@ const messages = defineMessages({
     description: 'Label for lock file checkbox in info modal',
   },
   activeCheckboxLabel: {
-    id: 'course-authoring.files-and-videos.sort-and-filter.modal.filter.activeCheckbox.label',
+    id: 'course-authoring.files-and-videos.file-info.activeCheckbox.label',
     defaultMessage: 'Active',
     description: 'Label for active checkbox in filter section of sort and filter modal',
   },
   inactiveCheckboxLabel: {
-    id: 'course-authoring.files-and-videos.sort-and-filter.modal.filter.inactiveCheckbox.label',
+    id: 'course-authoring.files-and-videos.file-info.inactiveCheckbox.label',
     defaultMessage: 'Inactive',
     description: 'Label for inactive checkbox in filter section of sort and filter modal',
   },

--- a/src/files-and-videos/generic/messages.js
+++ b/src/files-and-videos/generic/messages.js
@@ -126,12 +126,12 @@ const messages = defineMessages({
     description: 'Label for delete button in card menu dropdown',
   },
   deleteConfirmationTitle: {
-    id: 'course-authoring.files-and-uploads..deleteConfirmation.title',
+    id: 'course-authoring.files-and-uploads.deleteConfirmation.title',
     defaultMessage: 'Delete {fileNumber, plural, one {{fileName}} other {{fileNumber} {fileType}s}}',
     description: 'Title for delete confirmation modal',
   },
   deleteConfirmationMessage: {
-    id: 'course-authoring.files-and-uploads..deleteConfirmation.message',
+    id: 'course-authoring.files-and-uploads.deleteConfirmation.message',
     defaultMessage: `
       Are you sure you want to delete {fileNumber, plural, one {{fileName}} other {{fileNumber} {fileType}s}}?
       This action cannot be undone and may break your course if the {fileNumber, plural, one {{fileType} is} other {{fileType}s are}}
@@ -140,7 +140,7 @@ const messages = defineMessages({
     description: 'Message presented to user listing the number of files they are attempting to delete in the delete confirmation modal',
   },
   deleteConfirmationUsageMessage: {
-    id: 'course-authoring.files-and-uploads..deleteConfirmation.message',
+    id: 'course-authoring.files-and-uploads.deleteConfirmation.usage-message',
     defaultMessage: 'The following {fileNumber, plural, one {{fileType} is} other {{fileType}s are}} used in course content. Consider updating the content before deleting.',
     description: 'Message listing where the files the user is attempting to delete are used in the course',
   },

--- a/src/files-and-videos/generic/table-components/table-custom-columns/ActiveColumn.jsx
+++ b/src/files-and-videos/generic/table-components/table-custom-columns/ActiveColumn.jsx
@@ -1,29 +1,16 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { isNil } from 'lodash';
-import { injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Icon, Spinner } from '@openedx/paragon';
+import { injectIntl } from '@edx/frontend-platform/i18n';
+import { Icon } from '@openedx/paragon';
 import { Check } from '@openedx/paragon/icons';
 import { RequestStatus } from '../../../../data/constants';
+import { LoadingSpinner } from '../../../../generic/Loading';
 
 const ActiveColumn = ({ row, pageLoadStatus }) => {
   const { usageLocations } = row.original;
   if (isNil(usageLocations) || pageLoadStatus !== RequestStatus.SUCCESSFUL) {
-    return (
-      <Spinner
-        animation="border"
-        role="status"
-        variant="primary"
-        size="sm"
-        screenReaderText={(
-          <FormattedMessage
-            id="authoring.loading"
-            defaultMessage="Loading..."
-            description="Screen-reader message for when a active column is loading."
-          />
-        )}
-      />
-    );
+    return <LoadingSpinner size="sm" />;
   }
   const numOfUsageLocations = usageLocations.length;
   return numOfUsageLocations > 0 ? <Icon src={Check} /> : null;

--- a/src/generic/ConnectionErrorAlert.jsx
+++ b/src/generic/ConnectionErrorAlert.jsx
@@ -8,8 +8,7 @@ import messages from '../messages';
 const ConnectionErrorAlert = ({ intl }) => (
   <Alert variant="danger" data-testid="connectionErrorAlert">
     <FormattedMessage
-      id="authoring.alert.error.connection"
-      defaultMessage="We encountered a technical error when loading this page. This might be a temporary issue, so please try again in a few minutes. If the problem persists, please go to the {supportLink} for help."
+      {...messages.connectionError}
       values={{
         supportLink: (
           <Alert.Link href={getConfig().SUPPORT_URL}>

--- a/src/generic/configure-modal/messages.js
+++ b/src/generic/configure-modal/messages.js
@@ -196,7 +196,7 @@ const messages = defineMessages({
     defaultMessage: 'Proctored',
   },
   proctoredExamDescription: {
-    id: 'course-authoring.course-outline.configure-modal.advanced-tab.timed-description',
+    id: 'course-authoring.course-outline.configure-modal.advanced-tab.proctored-exam-description',
     defaultMessage: 'Proctored exams are timed and they record video of each learner taking the exam. The videos are then reviewed to ensure that learners follow all examination rules. Please note that setting this exam as proctored will change the visibility settings to "Hide content after due date."',
   },
   onboardingExam: {
@@ -204,7 +204,7 @@ const messages = defineMessages({
     defaultMessage: 'Onboarding',
   },
   onboardingExamDescription: {
-    id: 'course-authoring.course-outline.configure-modal.advanced-tab.timed-description',
+    id: 'course-authoring.course-outline.configure-modal.advanced-tab.onboarding-exam-description',
     defaultMessage: 'Use Onboarding to introduce learners to proctoring, verify their identity, and create an onboarding profile. Learners must complete the onboarding profile step prior to taking a proctored exam. Profile reviews take 2+ business days.',
   },
   practiceExam: {
@@ -212,7 +212,7 @@ const messages = defineMessages({
     defaultMessage: 'Practice proctored',
   },
   practiceExamDescription: {
-    id: 'course-authoring.course-outline.configure-modal.advanced-tab.timed-description',
+    id: 'course-authoring.course-outline.configure-modal.advanced-tab.practice-exam-description',
     defaultMessage: 'Use a practice proctored exam to introduce learners to the proctoring tools and processes. Results of a practice exam do not affect a learner\'s grade.',
   },
   advancedTabTitle: {

--- a/src/import-page/import-stepper/messages.js
+++ b/src/import-page/import-stepper/messages.js
@@ -50,7 +50,7 @@ const messages = defineMessages({
     defaultMessage: 'Error importing course',
   },
   stepperHeaderTitle: {
-    id: 'course-authoring.export.stepper.header.title',
+    id: 'course-authoring.import.stepper.header.title',
     defaultMessage: 'Course import status',
   },
 });


### PR DESCRIPTION
## Description

This PR fixes warnings about "duplicate message IDs", which seem to have been made by copy-paste errors.

It's important that message IDs are unique -- they're used to identify translated messages.

A side-effect of this change is to introduce new messages into Transifex that need to be translated. Until they are translated, course authors may see some untranslated text.

## Supporting information

Private-ref: [FAL-3750](https://tasks.opencraft.com/browse/FAL-3750)

## Testing instructions

Manual testing shouldn't be needed -- CI passing with no "duplicate message" warnings in the logs is enough.