### PR TITLE
fix: allow grace period minutes only

### DIFF
--- a/src/grading-settings/deadline-section/DeadlineSection.test.jsx
+++ b/src/grading-settings/deadline-section/DeadlineSection.test.jsx
@@ -48,6 +48,26 @@ describe('<DeadlineSection />', () => {
       expect(testObj.gracePeriod.minutes).toBe(13);
     });
   });
+  it('checking deadline input value if grace Period has no hours', async () => {
+    const { getByTestId } = render(<RootWrapper
+      gracePeriod={{ hours: 0, minutes: 13 }}
+      setGradingData={setGradingData}
+    />);
+    await waitFor(() => {
+      const inputElement = getByTestId('deadline-period-input');
+      expect(inputElement.value).toBe('00:13');
+    });
+  });
+  it('checking deadline input value if grace Period has no minutes', async () => {
+    const { getByTestId } = render(<RootWrapper
+      gracePeriod={{ hours: 13, minutes: 0 }}
+      setGradingData={setGradingData}
+    />);
+    await waitFor(() => {
+      const inputElement = getByTestId('deadline-period-input');
+      expect(inputElement.value).toBe('13:00');
+    });
+  });
   it('checking deadline input value if grace Period equal null', async () => {
     const { getByTestId } = render(<RootWrapper gracePeriod={null} setGradingData={setGradingData} />);
     await waitFor(() => {

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -12,7 +12,7 @@ const DeadlineSection = ({
   intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert,
 }) => {
   const timeStampValue = gracePeriod
-    ? gracePeriod.minutes && `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`
+    ? `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`
     : DEFAULT_TIME_STAMP;
   const [newDeadlineValue, setNewDeadlineValue] = useState(timeStampValue);
   const [isError, setIsError] = useState(false);

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -22,7 +22,7 @@ const DeadlineSection = ({
   }, [gracePeriod]);
 
   const handleDeadlineChange = (e) => {
-    let { value } = e.target;
+    const { value } = e.target;
     const [hours, minutes] = value.split(':');
 
     setNewDeadlineValue(value);

--- a/src/grading-settings/deadline-section/index.jsx
+++ b/src/grading-settings/deadline-section/index.jsx
@@ -12,7 +12,7 @@ const DeadlineSection = ({
   intl, setShowSavePrompt, gracePeriod, setGradingData, setShowSuccessAlert,
 }) => {
   const timeStampValue = gracePeriod
-    ? gracePeriod.hours && `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`
+    ? gracePeriod.minutes && `${formatTime(gracePeriod.hours)}:${formatTime(gracePeriod.minutes)}`
     : DEFAULT_TIME_STAMP;
   const [newDeadlineValue, setNewDeadlineValue] = useState(timeStampValue);
   const [isError, setIsError] = useState(false);
@@ -22,7 +22,7 @@ const DeadlineSection = ({
   }, [gracePeriod]);
 
   const handleDeadlineChange = (e) => {
-    const { value } = e.target;
+    let { value } = e.target;
     const [hours, minutes] = value.split(':');
 
     setNewDeadlineValue(value);


### PR DESCRIPTION
## Description

This PR resolves the bug that prevented users from entering a minutes only grace period. This change impacts Course Authors.

## Supporting information

Issue #1063

## Testing instructions

1. Open a course's grading page
2. Update the grace period to a value less than one hour
3. Should continue to display minutes value
6. Update the grace period to one hour
7. Should continue to display one hour
8. Update the grace period to greater than one hour
9. Should continue to display value greater than one hour