### PR TITLE
fix: info icon shrinking on advanced settings page

### DIFF
--- a/src/advanced-settings/setting-card/SettingCard.jsx
+++ b/src/advanced-settings/setting-card/SettingCard.jsx
@@ -71,7 +71,7 @@ const SettingCard = ({
                   iconAs={Icon}
                   alt={intl.formatMessage(messages.helpButtonText)}
                   variant="primary"
-                  className=" ml-1 mr-2"
+                  className="flex-shrink-0 ml-1 mr-2"
                 />
                 <ModalPopup
                   hasArrow


### PR DESCRIPTION
## Backport
- https://github.com/openedx/frontend-app-course-authoring/pull/984

## Description
This Pull Request contains small fixes of the info icon shrinking with a long field name on the Advanced settings page.

## Screenshots before
| <img width="1231" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/7261dbe9-8ffb-4417-8179-b276b4f31d8d"> | <img width="1229" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/9b3458e8-8ead-4d50-b197-df08922a1e42"> |
|---|---|

## Screenshots after
| <img width="1724" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/f838e8dd-dc54-415d-a462-b366dfd2e2f6"> | <img width="1722" alt="image" src="https://github.com/openedx/frontend-app-course-authoring/assets/17108583/4a500632-80ea-4419-ae9d-07f39f0720d8"> |
|---|---|