### PR TITLE
fix: handle null displayname

### DIFF
--- a/src/course-unit/add-component/add-component-modals/ComponentModalView.jsx
+++ b/src/course-unit/add-component/add-component-modals/ComponentModalView.jsx
@@ -42,7 +42,7 @@ const ComponentModalView = ({
       <ModalContainer
         isOpen={isOpen}
         close={close}
-        title={intl.formatMessage(messages.modalContainerTitle, { componentTitle: displayName.toLowerCase() })}
+        title={intl.formatMessage(messages.modalContainerTitle, { componentTitle: (displayName ?? '').toLowerCase() })}
         btnText={intl.formatMessage(messages.modalBtnText)}
         onSubmit={handleSubmit}
         resetDisabled={() => setModuleTitle('')}

--- a/src/studio-home/card-item/index.jsx
+++ b/src/studio-home/card-item/index.jsx
@@ -41,7 +41,7 @@ const CardItem = ({
   const isShowRerunLink = allowCourseReruns
     && rerunCreatorStatus
     && courseCreatorStatus === COURSE_CREATOR_STATES.granted;
-  const hasDisplayName = displayName.trim().length ? displayName : courseKey;
+  const hasDisplayName = (displayName ?? '').trim().length ? displayName : courseKey;
 
   return (
     <Card className="card-item">

--- a/src/studio-home/tabs-section/utils.js
+++ b/src/studio-home/tabs-section/utils.js
@@ -5,8 +5,11 @@
  * @returns {array} - An array of alphabetically sorted courses or libraries.
  */
 const sortAlphabeticallyArray = (arr) => [...arr]
-  .sort((firstArrayData, secondArrayData) => firstArrayData
-    .displayName.localeCompare(secondArrayData.displayName));
+  .sort((firstArrayData, secondArrayData) => {
+    const firstDisplayName = firstArrayData.displayName ?? '';
+    const secondDisplayName = secondArrayData.displayName ?? '';
+    return firstDisplayName.localeCompare(secondDisplayName);
+  });
 
 // eslint-disable-next-line import/prefer-default-export
 export { sortAlphabeticallyArray };


### PR DESCRIPTION
## Description

We get an error when loading courses if `displayName` is `null`. This is unlikely to happen but this PR will treat `null` `displayName`s as `''`.

## Supporting information

https://2u-internal.atlassian.net/browse/TNL-11654

## Testing

1. Import a course with no name and organization edX.
2. Without this PR, on the course authoring home page, when searching for courses, there will be an error.
3. With this PR, the courses should display without error.