### PR TITLE
Revert "feat: flcc to 2.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@edx/frontend-component-footer": "^13.0.2",
         "@edx/frontend-component-header": "^5.1.0",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
-        "@edx/frontend-lib-content-components": "^2.2.0",
+        "@edx/frontend-lib-content-components": "^2.1.11",
         "@edx/frontend-platform": "7.0.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2580,9 +2580,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.2.0.tgz",
-      "integrity": "sha512-lbwGKCHj3yED5pjfWlGJAKf0zofW4CKcIHTlZUInGiXjDGA5dgRrPHbGymKZZmgimt6qDO7koQxsy+DVsqUMLw==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.1.11.tgz",
+      "integrity": "sha512-vzDpneZIXmjFo5sZxxZiVjt1zgczfEkJhT2h/sg2mcJ0m7Zuo9dPJeilATqB0pSTjZnNsIbX+NfT/Dx/mSJciQ==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -2621,7 +2621,7 @@
         "xmlchecker": "^0.1.0"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^7.0.1 || ^8.0.0",
+        "@edx/frontend-platform": "^7.0.1",
         "@openedx/paragon": "^21.5.7 || ^22.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.14.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@edx/frontend-component-footer": "^13.0.2",
     "@edx/frontend-component-header": "^5.1.0",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
-    "@edx/frontend-lib-content-components": "^2.2.0",
+    "@edx/frontend-lib-content-components": "^2.1.11",
     "@edx/frontend-platform": "7.0.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
Reverts openedx/frontend-app-course-authoring#1106

The reason is that the pipeline to deploy to stage broke. This commit is probably the reason.

The revert is temporary until the pipeline problem is solved.