### PR TITLE
feat: Include org filter when requesting LTI providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ validate:
 	npm run i18n_extract
 	npm run lint -- --max-warnings 0
 	npm run types
-	npm run test
+	npm run test:ci
 	npm run build
 
 .PHONY: validate.ci

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
+    "test:ci": "TZ=UTC fedx-scripts jest --silent --coverage --passWithNoTests",
     "types": "tsc --noEmit"
   },
   "husky": {

--- a/plugins/course-apps/proctoring/Settings.jsx
+++ b/plugins/course-apps/proctoring/Settings.jsx
@@ -64,6 +64,8 @@ const ProctoringSettings = ({ intl, onClose }) => {
   }
 
   const { courseId } = useContext(PagesAndResourcesContext);
+  const courseDetails = useModel('courseDetails', courseId);
+  const org = courseDetails?.org;
   const appInfo = useModel('courseApps', 'proctoring');
   const alertRef = React.createRef();
   const saveStatusAlertRef = React.createRef();
@@ -490,7 +492,7 @@ const ProctoringSettings = ({ intl, onClose }) => {
     Promise.all([
       StudioApiService.getProctoredExamSettingsData(courseId),
       ExamsApiService.isAvailable() ? ExamsApiService.getCourseExamConfiguration(courseId) : Promise.resolve(),
-      ExamsApiService.isAvailable() ? ExamsApiService.getAvailableProviders() : Promise.resolve(),
+      ExamsApiService.isAvailable() ? ExamsApiService.getAvailableProviders(org) : Promise.resolve(),
     ])
       .then(
         ([settingsResponse, examConfigResponse, ltiProvidersResponse]) => {

--- a/src/data/services/ExamsApiService.js
+++ b/src/data/services/ExamsApiService.js
@@ -15,9 +15,9 @@ class ExamsApiService {
     return `${ExamsApiService.getExamsBaseUrl()}/api/v1/configs/course_id/${courseId}`;
   }
 
-  static getAvailableProviders() {
+  static getAvailableProviders(org) {
     const apiClient = getAuthenticatedHttpClient();
-    const providersUrl = `${ExamsApiService.getExamsBaseUrl()}/api/v1/providers`;
+    const providersUrl = `${ExamsApiService.getExamsBaseUrl()}/api/v1/providers${org ? `?org=${org}` : ''}`;
     return apiClient.get(providersUrl);
   }
 


### PR DESCRIPTION
## Description

Passes on the organization to the LTI providers endpoint for use to filter.

### Added quality of life change
Updated the CI tests to be silent (hides console output). The change reduced CI test generated logs from `35MB` to `298KB`.