### PR TITLE
[FC-0059] refactor: Change lib v2 code to TS

### DIFF
--- a/src/studio-home/data/api.js
+++ b/src/studio-home/data/api.js
@@ -56,6 +56,8 @@ export async function getStudioHomeLibrariesV2(customParams) {
     page: customParams.page || 1,
     pageSize: customParams.pageSize || 50,
     pagination: customParams.pagination !== undefined ? customParams.pagination : true,
+    order: customParams.order,
+    textSearch: customParams.search,
   };
   const customParamsFormat = snakeCaseObject(customParamsDefaults);
   const { data } = await getAuthenticatedHttpClient().get(`${getApiBaseUrl()}/api/libraries/v2/`, { params: customParamsFormat });

--- a/src/studio-home/data/api.js
+++ b/src/studio-home/data/api.js
@@ -58,7 +58,7 @@ export async function getStudioHomeLibrariesV2(customParams) {
     page: customParams.page || 1,
     pageSize: customParams.pageSize || 50,
     pagination: customParams.pagination !== undefined ? customParams.pagination : true,
-    order: customParams.order,
+    order: customParams.order || 'title',
     textSearch: customParams.search,
   };
   const customParamsFormat = snakeCaseObject(customParamsDefaults);

--- a/src/studio-home/data/api.js
+++ b/src/studio-home/data/api.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { camelCaseObject, snakeCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
@@ -8,7 +9,6 @@ export const getCourseNotificationUrl = (url) => new URL(url, getApiBaseUrl()).h
 
 /**
  * Get's studio home data.
- * @param {string} search
  * @returns {Promise<Object>}
  */
 export async function getStudioHomeData() {
@@ -47,7 +47,9 @@ export async function getStudioHomeLibraries() {
  * @param {number} [customParams.page] - (optional) Page number of results
  * @param {number} [customParams.pageSize] - (optional) The number of results on each page, default `50`
  * @param {boolean} [customParams.pagination] - (optional) Whether pagination is supported, default `true`
- * @returns {Promise<Object>} - A Promise that resolves to the response data container the studio home v2 libraries.
+ * @param {string} [customParams.order] - (optional) Library field to order results by. Prefix with '-' for descending
+ * @param {string} [customParams.search] - (optional) Search query to filter v2 Libraries by
+ * @returns {Promise<import("./types.mjs").LibrariesV2Response>} - Promise that resolves to v2 libraries response data
  */
 export async function getStudioHomeLibrariesV2(customParams) {
   // Set default params if not passed in

--- a/src/studio-home/data/apiHooks.ts
+++ b/src/studio-home/data/apiHooks.ts
@@ -2,10 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getStudioHomeLibrariesV2 } from './api';
 
+interface CustomParams {
+  type?: string,
+  page?: number,
+  pageSize?: number,
+  pagination?: boolean,
+  order?: string,
+  saerch?: string,
+}
+
 /**
  * Builds the query to fetch list of V2 Libraries
  */
-const useListStudioHomeV2Libraries = (customParams) => (
+const useListStudioHomeV2Libraries = (customParams: CustomParams) => (
   useQuery({
     queryKey: ['listV2Libraries', customParams],
     queryFn: () => getStudioHomeLibrariesV2(customParams),

--- a/src/studio-home/data/types.mjs
+++ b/src/studio-home/data/types.mjs
@@ -1,0 +1,31 @@
+// @ts-check
+
+/**
+ * @typedef {Object} LibraryV2
+ * @property {string} id - The ID of the v2 library.
+ * @property {string} type - The type of the v2 library.
+ * @property {string} org - The organization associated with the v2 library.
+ * @property {string} slug - The slug for the v2 library.
+ * @property {string} title - The title of the v2 library.
+ * @property {string} description - The description of the v2 library.
+ * @property {number} numBlocks - The number of blocks in the v2 library.
+ * @property {number} version - The version of the v2 library.
+ * @property {string|null} lastPublished - The date when the v2 library was last published.
+ * @property {boolean} allowLti - Indicates if LTI is allowed.
+ * @property {boolean} allowPublicLearning - Indicates if public learning is allowed.
+ * @property {boolean} allowPublicRead - Indicates if public read is allowed.
+ * @property {boolean} hasUnpublishedChanges - Indicates if there are unpublished changes.
+ * @property {boolean} hasUnpublishedDeletes - Indicates if there are unpublished deletes.
+ * @property {string} license - The license of the v2 library.
+ */
+
+/**
+ * @typedef {Object} LibrariesV2Response
+ * @property {string|null} next - The URL for the next page of results, or null if there is no next page.
+ * @property {string|null} previous - The URL for the previous page of results, or null if there is no previous page.
+ * @property {number} count - The total number of v2 libraries.
+ * @property {number} numPages - The total number of pages.
+ * @property {number} currentPage - The current page number.
+ * @property {number} start - The starting index of the results.
+ * @property {LibraryV2[]} results - An array of library objects.
+ */

--- a/src/studio-home/tabs-section/libraries-v2-tab/index.tsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/index.tsx
@@ -62,7 +62,7 @@ const LibrariesV2Tab = ({
       : `${window.location.origin}${getPath(getConfig().PUBLIC_PATH)}library/${id}`
   );
 
-  const hasV2Libraries = (data?.results?.length || 0) > 0;
+  const hasV2Libraries = !isLoading && ((data!.results.length || 0) > 0);
 
   return (
     isError ? (
@@ -90,15 +90,15 @@ const LibrariesV2Tab = ({
           && (
             <p data-testid="pagination-info">
               {intl.formatMessage(messages.coursesPaginationInfo, {
-                length: data.results.length,
-                total: data.count,
+                length: data!.results.length,
+                total: data!.count,
               })}
             </p>
           )}
         </div>
 
         { hasV2Libraries
-          ? data?.results.map(({
+          ? data!.results.map(({
             id, org, slug, title,
           }) => (
             <CardItem
@@ -124,12 +124,12 @@ const LibrariesV2Tab = ({
           )}
 
         {
-          (data?.numPages || 0) > 1
+          hasV2Libraries && (data!.numPages || 0) > 1
           && (
             <Pagination
               className="d-flex justify-content-center"
               paginationLabel="pagination navigation"
-              pageCount={data?.numPages}
+              pageCount={data!.numPages}
               currentPage={currentPage}
               onPageSelect={handlePageSelect}
             />

--- a/src/studio-home/tabs-section/libraries-v2-tab/index.tsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/index.tsx
@@ -62,7 +62,7 @@ const LibrariesV2Tab = ({
       : `${window.location.origin}${getPath(getConfig().PUBLIC_PATH)}library/${id}`
   );
 
-  const hasV2Libraries = data?.results?.length > 0;
+  const hasV2Libraries = (data?.results?.length || 0) > 0;
 
   return (
     isError ? (
@@ -98,7 +98,7 @@ const LibrariesV2Tab = ({
         </div>
 
         { hasV2Libraries
-          ? data.results.map(({
+          ? data?.results.map(({
             id, org, slug, title,
           }) => (
             <CardItem
@@ -124,12 +124,12 @@ const LibrariesV2Tab = ({
           )}
 
         {
-          data?.numPages > 1
+          (data?.numPages || 0) > 1
           && (
             <Pagination
               className="d-flex justify-content-center"
               paginationLabel="pagination navigation"
-              pageCount={data.numPages}
+              pageCount={data?.numPages}
               currentPage={currentPage}
               onPageSelect={handlePageSelect}
             />

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.jsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.jsx
@@ -1,0 +1,123 @@
+import { useState, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { SearchField } from '@openedx/paragon';
+import { debounce } from 'lodash';
+
+import { LoadingSpinner } from '../../../../generic/Loading';
+import LibrariesV2OrderFilterMenu from './libraries-v2-order-filter-menu';
+
+/* regex to check if a string has only whitespace
+  example "    "
+*/
+const regexOnlyWhiteSpaces = /^\s+$/;
+
+const LibrariesV2Filters = ({
+  isLoading,
+  isFiltered,
+  setIsFiltered,
+  setFilterParams,
+  setCurrentPage,
+}) => {
+  const [search, setSearch] = useState('');
+  const [order, setOrder] = useState('title');
+
+  // Reset search & order when filters cleared
+  useEffect(() => {
+    if (!isFiltered) {
+      setSearch('');
+      setOrder('title');
+    }
+  }, [isFiltered, setSearch, setOrder]);
+
+  const getOrderFromFilterType = (filterType) => {
+    const orders = {
+      azLibrariesV2: 'title',
+      zaLibrariesV2: '-title',
+      newestLibrariesV2: '-created',
+      oldestLibrariesV2: 'created',
+    };
+
+    // Default to 'A-Z` if invalid filtertype
+    return orders[filterType] || 'title';
+  };
+
+  const getFilterTypeData = (baseFilters) => ({
+    azLibrariesV2: { ...baseFilters, order: 'title' },
+    zaLibrariesV2: { ...baseFilters, order: '-title' },
+    newestLibrariesV2: { ...baseFilters, order: '-created' },
+    oldestLibrariesV2: { ...baseFilters, order: 'created' },
+  });
+
+  const handleMenuFilterItemSelected = (filterType) => {
+    setOrder(getOrderFromFilterType(filterType));
+    setIsFiltered(true);
+
+    const baseFilters = {
+      search,
+      order,
+    };
+
+    const filterParams = getFilterTypeData(baseFilters);
+    const filterParamsFormat = filterParams[filterType] || baseFilters;
+
+    setFilterParams(filterParamsFormat);
+    setCurrentPage(1);
+  };
+
+  const handleSearchLibrariesV2 = (searchValueDebounced) => {
+    const valueFormatted = searchValueDebounced.trim();
+    const filterParams = {
+      search: valueFormatted.length > 0 ? valueFormatted : undefined,
+      order,
+    };
+    const hasOnlySpaces = regexOnlyWhiteSpaces.test(searchValueDebounced);
+    if (valueFormatted !== search && !hasOnlySpaces) {
+      setIsFiltered(true);
+      setSearch(valueFormatted);
+      setFilterParams(filterParams);
+      setCurrentPage(1);
+    }
+  };
+
+  const handleSearchLibrariesV2Debounced = useCallback(
+    debounce((value) => handleSearchLibrariesV2(value), 400),
+    [order, search],
+  );
+
+  return (
+    <div className="d-flex">
+      <div className="d-flex flex-row">
+        <SearchField
+          onSubmit={() => {}}
+          onChange={handleSearchLibrariesV2Debounced}
+          value={search}
+          className="mr-4"
+          data-testid="input-filter-libraries-v2-search"
+          placeholder="Search"
+        />
+        {isLoading && (
+          <span className="search-field-loading" data-testid="loading-search-spinner">
+            <LoadingSpinner size="sm" />
+          </span>
+        )}
+      </div>
+
+      <LibrariesV2OrderFilterMenu onItemMenuSelected={handleMenuFilterItemSelected} isFiltered={isFiltered} />
+    </div>
+  );
+};
+
+LibrariesV2Filters.defaultProps = {
+  isLoading: false,
+  isFiltered: false,
+};
+
+LibrariesV2Filters.propTypes = {
+  isLoading: PropTypes.bool,
+  isFiltered: PropTypes.bool,
+  setIsFiltered: PropTypes.func.isRequired,
+  setFilterParams: PropTypes.func.isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
+};
+
+export default LibrariesV2Filters;

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.test.jsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/index.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import {
+  screen, fireEvent, render, waitFor,
+} from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import LibrariesV2Filters from '.';
+
+describe('LibrariesV2Filters', () => {
+  const setIsFilteredMock = jest.fn();
+  const setFilterParamsMock = jest.fn();
+  const setCurrentPageMock = jest.fn();
+
+  // eslint-disable-next-line react/prop-types
+  const IntlProviderWrapper = ({ children }) => (
+    <IntlProvider locale="en" messages={{}}>
+      {children}
+    </IntlProvider>
+  );
+
+  const renderComponent = (overrideProps = {}) => render(
+    <IntlProviderWrapper>
+      <LibrariesV2Filters
+        setIsFiltered={setIsFilteredMock}
+        setFilterParams={setFilterParamsMock}
+        setCurrentPage={setCurrentPageMock}
+        {...overrideProps}
+      />
+    </IntlProviderWrapper>,
+
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render search field and order filter', () => {
+    renderComponent();
+    const searchInput = screen.getByTestId('input-filter-libraries-v2-search');
+    expect(searchInput).toBeInTheDocument();
+    const orderFilter = screen.getByTestId('dropdown-toggle-libraries-v2-order-menu');
+    expect(orderFilter).toBeInTheDocument();
+  });
+
+  it('should call setIsFiltered, setFilterParams, setCurrentPage when search input changes', async () => {
+    renderComponent();
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    await waitFor(() => expect(setIsFilteredMock).toHaveBeenCalled());
+    await waitFor(() => expect(setFilterParamsMock).toHaveBeenCalled());
+    await waitFor(() => expect(setCurrentPageMock).toHaveBeenCalled());
+  });
+
+  it('should call setIsFiltered, setFilterParams, setCurrentPage when a menu item order menu is selected', () => {
+    renderComponent();
+    const libraryV2OrderMenuFilter = screen.getByTestId('dropdown-toggle-libraries-v2-order-menu');
+    fireEvent.click(libraryV2OrderMenuFilter);
+    const newestLibV2sMenuItem = screen.getByTestId('item-menu-newest-libraries-v2');
+    fireEvent.click(newestLibV2sMenuItem);
+    expect(setIsFilteredMock).toHaveBeenCalled();
+    expect(setFilterParamsMock).toHaveBeenCalled();
+    expect(setCurrentPageMock).toHaveBeenCalled();
+  });
+
+  it('should clear the search input when filters cleared', async () => {
+    const { rerender } = renderComponent({ isFiltered: true });
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    await waitFor(() => expect(setIsFilteredMock).toHaveBeenCalled());
+    await waitFor(() => expect(setFilterParamsMock).toHaveBeenCalled());
+    await waitFor(() => expect(setCurrentPageMock).toHaveBeenCalled());
+
+    rerender(
+      <IntlProviderWrapper>
+        <LibrariesV2Filters
+          isFiltered={false}
+          setIsFiltered={setIsFilteredMock}
+          setFilterParams={setFilterParamsMock}
+          setCurrentPage={setCurrentPageMock}
+        />
+      </IntlProviderWrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByRole('searchbox').value).toBe(''));
+  });
+
+  it('should update states with the correct parameters when a order menu item is selected', () => {
+    renderComponent();
+    const libraryV2OrderMenuFilter = screen.getByTestId('dropdown-toggle-libraries-v2-order-menu');
+    fireEvent.click(libraryV2OrderMenuFilter);
+    const oldestLibV2sMenuItem = screen.getByTestId('item-menu-oldest-libraries-v2');
+    fireEvent.click(oldestLibV2sMenuItem);
+
+    // Check that setIsFiltered is called with `true`
+    expect(setIsFilteredMock).toHaveBeenCalledWith(true);
+
+    // Check that setFilterParams is called with the correct payload
+    expect(setFilterParamsMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      search: '',
+      order: 'created',
+    }));
+
+    // Check that setCurrentPage is called with `1`
+    expect(setCurrentPageMock).toHaveBeenCalledWith(1);
+  });
+
+  it('should call setFilterParams after debounce delay when the search input changes', async () => {
+    renderComponent();
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    await waitFor(() => expect(setFilterParamsMock).toHaveBeenCalled(), { timeout: 500 });
+    expect(setFilterParamsMock).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('should not call setFilterParams when search only spaces', async () => {
+    renderComponent();
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: '   ' } });
+    await waitFor(() => expect(setFilterParamsMock).not.toHaveBeenCalled(), { timeout: 500 });
+    expect(setFilterParamsMock).not.toHaveBeenCalled();
+  });
+
+  it('should display the loading spinner when isLoading is true', () => {
+    renderComponent({ isLoading: true });
+    const spinner = screen.getByTestId('loading-search-spinner');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('should not display the loading spinner when isLoading is false', () => {
+    renderComponent({ isLoading: false });
+    const spinner = screen.queryByTestId('loading-search-spinner');
+    expect(spinner).not.toBeInTheDocument();
+  });
+
+  it('should clear the search input and call dispatch when the reset button is clicked', async () => {
+    renderComponent();
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    const form = searchInput.closest('form');
+    const resetButton = form.querySelector('button[type="reset"]');
+    fireEvent.click(resetButton);
+    expect(searchInput.value).toBe('');
+  });
+});

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-filter-menu/index.jsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-filter-menu/index.jsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Icon, Dropdown } from '@openedx/paragon';
+import { Check } from '@openedx/paragon/icons';
+
+const LibrariesV2FilterMenu = ({
+  id: idProp,
+  menuItems,
+  onItemMenuSelected,
+  defaultItemSelectedText,
+  isFiltered,
+}) => {
+  const [itemMenuSelected, setItemMenuSelected] = useState(defaultItemSelectedText);
+  const handleCourseTypeSelected = (name, value) => {
+    setItemMenuSelected(name);
+    onItemMenuSelected(value);
+  };
+
+  const libraryV2TypeSelectedIcon = (itemValue) => (itemValue === itemMenuSelected ? (
+    <Icon src={Check} className="ml-2" data-testid="menu-item-icon" />
+  ) : null);
+
+  useEffect(() => {
+    if (!isFiltered) {
+      setItemMenuSelected(defaultItemSelectedText);
+    }
+  }, [isFiltered]);
+
+  return (
+    <Dropdown id={`dropdown-toggle-${idProp}`}>
+      <Dropdown.Toggle
+        alt="dropdown-toggle-menu-items"
+        id={idProp}
+        variant="none"
+        className="dropdown-toggle-menu-items"
+        data-testid={idProp}
+      >
+        {itemMenuSelected}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        {menuItems.map(({ id, name, value }) => (
+          <Dropdown.Item
+            key={id}
+            onClick={() => handleCourseTypeSelected(name, value)}
+            data-testid={`item-menu-${id}`}
+          >
+            {name} {libraryV2TypeSelectedIcon(name)}
+          </Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+LibrariesV2FilterMenu.defaultProps = {
+  defaultItemSelectedText: '',
+  menuItems: [],
+};
+
+LibrariesV2FilterMenu.propTypes = {
+  onItemMenuSelected: PropTypes.func.isRequired,
+  defaultItemSelectedText: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }),
+  ),
+  isFiltered: PropTypes.bool.isRequired,
+};
+
+export default LibrariesV2FilterMenu;

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-order-filter-menu/index.jsx
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-order-filter-menu/index.jsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from './messages';
+
+import LibrariesV2FilterMenu from '../libraries-v2-filter-menu';
+
+const LibrariesV2OrderFilterMenu = ({ onItemMenuSelected, isFiltered }) => {
+  const intl = useIntl();
+
+  const libraryV2Orders = useMemo(
+    () => [
+      {
+        id: 'az-libraries-v2',
+        name: intl.formatMessage(messages.librariesV2OrderFilterMenuAscendantLibrariesV2),
+        value: 'azLibrariesV2',
+      },
+      {
+        id: 'za-libraries-v2',
+        name: intl.formatMessage(messages.librariesV2OrderFilterMenuDescendantLibrariesV2),
+        value: 'zaLibrariesV2',
+      },
+      {
+        id: 'newest-libraries-v2',
+        name: intl.formatMessage(messages.librariesV2OrderFilterMenuNewestLibrariesV2),
+        value: 'newestLibrariesV2',
+      },
+      {
+        id: 'oldest-libraries-v2',
+        name: intl.formatMessage(messages.librariesV2OrderFilterMenuOldestLibrariesV2),
+        value: 'oldestLibrariesV2',
+      },
+    ],
+    [intl],
+  );
+
+  const handleLibraryV2OrderSelected = (libraryV2Order) => {
+    onItemMenuSelected(libraryV2Order);
+  };
+
+  return (
+    <LibrariesV2FilterMenu
+      id="dropdown-toggle-libraries-v2-order-menu"
+      menuItems={libraryV2Orders}
+      onItemMenuSelected={handleLibraryV2OrderSelected}
+      defaultItemSelectedText={intl.formatMessage(messages.librariesV2OrderFilterMenuAscendantLibrariesV2)}
+      isFiltered={isFiltered}
+    />
+  );
+};
+
+LibrariesV2OrderFilterMenu.propTypes = {
+  onItemMenuSelected: PropTypes.func.isRequired,
+  isFiltered: PropTypes.bool.isRequired,
+};
+
+export default LibrariesV2OrderFilterMenu;

--- a/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-order-filter-menu/messages.js
+++ b/src/studio-home/tabs-section/libraries-v2-tab/libraries-v2-filters/libraries-v2-order-filter-menu/messages.js
@@ -1,0 +1,22 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  librariesV2OrderFilterMenuAscendantLibrariesV2: {
+    id: 'course-authoring.studio-home.libraries.tab.order-filter-menu.ascendant-librariesv2',
+    defaultMessage: 'Name A-Z',
+  },
+  librariesV2OrderFilterMenuDescendantLibrariesV2: {
+    id: 'course-authoring.studio-home.libraries.tab.order-filter-menu.descendant-librariesv2',
+    defaultMessage: 'Name Z-A',
+  },
+  librariesV2OrderFilterMenuNewestLibrariesV2: {
+    id: 'course-authoring.studio-home.libraries.tab.order-filter-menu.newest-librariesv2',
+    defaultMessage: 'Newest',
+  },
+  librariesV2OrderFilterMenuOldestLibrariesV2: {
+    id: 'course-authoring.studio-home.libraries.tab.order-filter-menu.oldest-librariesv2',
+    defaultMessage: 'Oldest',
+  },
+});
+
+export default messages;

--- a/src/studio-home/tabs-section/messages.js
+++ b/src/studio-home/tabs-section/messages.js
@@ -58,6 +58,14 @@ const messages = defineMessages({
     id: 'course-authoring.studio-home.libraries.placeholder.body',
     defaultMessage: 'This is a placeholder page, as the Library Authoring MFE is not enabled.',
   },
+  librariesV2TabLibraryNotFoundAlertTitle: {
+    id: 'course-authoring.studio-home.libraries.tab.library.not.found.alert.title',
+    defaultMessage: 'We could not find any result',
+  },
+  librariesV2TabLibraryNotFoundAlertMessage: {
+    id: 'course-authoring.studio-home.libraries.tab.library.not.found.alert.message',
+    defaultMessage: 'There are no libraries with the current filters.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

This PR swaps back the new changes related to v2/legacy Libraries from `js -> ts` and `jsx -> tsx`. They were initially removed from https://github.com/openedx/frontend-app-course-authoring/pull/1050/ as it was merged before https://github.com/openedx/frontend-app-course-authoring/pull/1052 was completed. 

It's based off https://github.com/openedx/frontend-app-course-authoring/pull/1117 as further changes were made there.

## Supporting information

- Related to: https://github.com/openedx/frontend-app-course-authoring/pull/1050
- Based off of: https://github.com/openedx/frontend-app-course-authoring/pull/1117
- Closes: https://github.com/openedx/frontend-app-course-authoring/issues/1033

## Testing instructions

Make sure linting/typing checking passes and confirm that its is still functional. You can follow the testing steps in https://github.com/openedx/frontend-app-course-authoring/pull/1050/

---
Private-ref: [FAL-3751](https://tasks.opencraft.com/browse/FAL-3751)