### PR TITLE
fix: progress bar display for uploads

### DIFF
--- a/src/files-and-videos/generic/FileTable.jsx
+++ b/src/files-and-videos/generic/FileTable.jsx
@@ -243,14 +243,16 @@ const FileTable = ({
           fileType={fileType}
         />
 
-        <ApiStatusToast
-          actionType={intl.formatMessage(messages.apiStatusAddingAction)}
-          selectedRowCount={selectedRows.length}
-          isOpen={isAddOpen}
-          setClose={setAddClose}
-          setSelectedRows={setSelectedRows}
-          fileType={fileType}
-        />
+        {fileType === 'files' && (
+          <ApiStatusToast
+            actionType={intl.formatMessage(messages.apiStatusAddingAction)}
+            selectedRowCount={selectedRows.length}
+            isOpen={isAddOpen}
+            setClose={setAddClose}
+            setSelectedRows={setSelectedRows}
+            fileType={fileType}
+          />
+        )}
 
         <ApiStatusToast
           actionType={intl.formatMessage(messages.apiStatusDownloadingAction)}

--- a/src/files-and-videos/videos-page/VideosPage.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.jsx
@@ -92,10 +92,19 @@ const VideosPage = ({
       }
       return undefined;
     };
-    if (addVideoStatus === RequestStatus.IN_PROGRESS) {
-      openUploadTracker();
-    } else {
-      closeUploadTracker();
+    switch (addVideoStatus) {
+      case RequestStatus.IN_PROGRESS:
+        openUploadTracker();
+        break;
+      case RequestStatus.SUCCESSFUL:
+        setTimeout(() => closeUploadTracker(), 500);
+        break;
+      case RequestStatus.FAILED:
+        setTimeout(() => closeUploadTracker(), 500);
+        break;
+      default:
+        closeUploadTracker();
+        break;
     }
   }, [addVideoStatus]);
 
@@ -298,6 +307,7 @@ const VideosPage = ({
             isUploadTrackerOpen,
             currentUploadingIdsRef: uploadingIdsRef.current,
             handleUploadCancel,
+            addVideoStatus,
           }}
         />
       </Container>

--- a/src/files-and-videos/videos-page/VideosPage.test.jsx
+++ b/src/files-and-videos/videos-page/VideosPage.test.jsx
@@ -685,7 +685,6 @@ describe('Videos page', () => {
           expect(screen.queryByText('Delete mOckID1.mp4')).toBeNull();
         });
 
-        await executeThunk(deleteVideoFile(courseId, 'mOckID1', 5), store.dispatch);
         await waitFor(() => {
           const deleteStatus = store.getState().videos.deletingStatus;
           expect(deleteStatus).toEqual(RequestStatus.FAILED);

--- a/src/files-and-videos/videos-page/data/thunks.test.js
+++ b/src/files-and-videos/videos-page/data/thunks.test.js
@@ -7,8 +7,8 @@ describe('addVideoFile', () => {
   const courseId = 'course-123';
   const mockFile = {
     name: 'mockName',
-
   };
+  const uploadingIdsRef = { current: { uploadData: {} } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -18,7 +18,7 @@ describe('addVideoFile', () => {
       status: 404,
     });
 
-    await addVideoFile(courseId, [mockFile], undefined, { current: [] })(dispatch, getState);
+    await addVideoFile(courseId, [mockFile], undefined, uploadingIdsRef)(dispatch, getState);
 
     expect(dispatch).toHaveBeenCalledWith({
       payload: {
@@ -43,7 +43,7 @@ describe('addVideoFile', () => {
     jest.spyOn(api, 'uploadVideo').mockResolvedValue({
       status: 404,
     });
-    await addVideoFile(courseId, [mockFile], undefined, { current: [] })(dispatch, getState);
+    await addVideoFile(courseId, [mockFile], undefined, uploadingIdsRef)(dispatch, getState);
     expect(videoStatusMock).toHaveBeenCalledWith(courseId, mockEdxVideoId, 'Upload failed', 'upload_failed');
     expect(dispatch).toHaveBeenCalledWith({
       payload: {
@@ -70,7 +70,7 @@ describe('addVideoFile', () => {
     jest.spyOn(api, 'uploadVideo').mockResolvedValue({
       status: 200,
     });
-    await addVideoFile(courseId, [mockFile], undefined, { current: [] })(dispatch, getState);
+    await addVideoFile(courseId, [mockFile], undefined, uploadingIdsRef)(dispatch, getState);
     expect(videoStatusMock).toHaveBeenCalledWith(courseId, mockEdxVideoId, 'Upload completed', 'upload_completed');
   });
 });

--- a/src/files-and-videos/videos-page/upload-modal/UploadModal.jsx
+++ b/src/files-and-videos/videos-page/upload-modal/UploadModal.jsx
@@ -12,15 +12,18 @@ import {
 import { WarningFilled } from '@openedx/paragon/icons';
 import messages from '../messages';
 import UploadProgressList from './UploadProgressList';
+import { RequestStatus } from '../../../data/constants';
 
 const UploadModal = ({
   isUploadTrackerOpen,
   handleUploadCancel,
   currentUploadingIdsRef,
+  addVideoStatus,
 }) => {
   const intl = useIntl();
   const videosPagePath = '';
   const { uploadData, uploadCount } = currentUploadingIdsRef;
+  const cancelIsDisabled = addVideoStatus === RequestStatus.FAILED || addVideoStatus === RequestStatus.SUCCESSFUL;
 
   return (
     <ModalDialog
@@ -69,7 +72,7 @@ const UploadModal = ({
       </Scrollable>
       <ModalDialog.Footer>
         <ActionRow>
-          <Button onClick={handleUploadCancel}>
+          <Button onClick={handleUploadCancel} disabled={cancelIsDisabled}>
             {intl.formatMessage(messages.videoUploadTrackerAlertCancelLabel)}
           </Button>
         </ActionRow>
@@ -89,6 +92,7 @@ UploadModal.propTypes = {
     }).isRequired,
     uploadCount: PropTypes.number.isRequired,
   }).isRequired,
+  addVideoStatus: PropTypes.string.isRequired,
 };
 
 export default UploadModal;


### PR DESCRIPTION
## Description

This PR fixes when the upload progress bar appears in the upload modal. The current behaviors displays  list of videos and their progress bar after the video has been uploaded to edxval. This may be confusing to the user as they would expect their video(s) to be listed right away. This PR fixes this so that video list and progress bars are displayed as soon as the dialog opens.This change impacts the Course Author.

## Testing instructions

1. Open the videos page
2. Click "+ Add videos"
3. Select a video
4. Confirm that the video is listed without delay
5.  Click "+ Add videos"
6. Select multiple videos
7. Confirm that the videos are listed without delay
