### PR TITLE
fix: source map warning seen during build

### DIFF
--- a/src/grading-settings/grading-scale/react-ranger.js
+++ b/src/grading-settings/grading-scale/react-ranger.js
@@ -356,4 +356,3 @@ function useRanger(_ref) {
 }
 
 export { useRanger };
-// # sourceMappingURL=react-ranger.mjs.map


### PR DESCRIPTION
## Description

We include a file (`react-ranger.js`) that is already sort of transpiled, minified, etc. It references a source map that doesn't exist, resulting in this warning seen during `npm run build`:

```
WARNING in ./src/grading-settings/grading-scale/react-ranger.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from 'frontend-app-course-authoring/src/grading-settings/grading-scale/react-ranger.mjs.map' file: Error: ENOENT: no such file or directory, open 'frontend-app-course-authoring/src/grading-settings/grading-scale/react-ranger.mjs.map'
 @ ./src/grading-settings/grading-scale/GradingScale.jsx 11:0-43 152:6-15
 @ ./src/grading-settings/GradingSettings.jsx 21:0-56 160:46-58
 @ ./src/grading-settings/index.js 2:0-63 2:0-63
 @ ./src/CourseAuthoringRoutes.jsx 15:0-53 129:38-53
 @ ./src/index.jsx 12:0-60 55:33-54
```

This is not a big problem, but it's nice to get rid of these sort of warnings if we can.