### PR TITLE
fix(deps): upgrade dependency @edx/frontend-lib-content-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@edx/frontend-component-footer": "^14.0.3",
         "@edx/frontend-component-header": "^5.3.3",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
-        "@edx/frontend-lib-content-components": "^2.4.2",
+        "@edx/frontend-lib-content-components": "^2.5.0",
         "@edx/frontend-platform": "^8.0.3",
         "@edx/openedx-atlas": "^0.6.0",
         "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.4.2.tgz",
-      "integrity": "sha512-99SPZDiO3bu6/3zpcqFL2QYINL21vOrHSjPAUQFjoDf8gKSWu4yd9jy4NcVXgtfQnwiVD7MPdOQ0ommtGX/S0Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.5.0.tgz",
+      "integrity": "sha512-J2tyVb1oYmY9Ebhht4gmVyavpcw5CPVig9rbELS5H7i49gpIVhxggXC/pE+WbiWoZJtLBQu+XLvb+4geDQxX+Q==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@edx/frontend-component-footer": "^14.0.3",
     "@edx/frontend-component-header": "^5.3.3",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
-    "@edx/frontend-lib-content-components": "^2.4.2",
+    "@edx/frontend-lib-content-components": "^2.5.0",
     "@edx/frontend-platform": "^8.0.3",
     "@edx/openedx-atlas": "^0.6.0",
     "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",


### PR DESCRIPTION
This PR upgrades @edx/frontend-lib-content-components to 2.5.0. This upgrade includes the following changes:

- [#491](https://github.com/openedx/frontend-lib-content-components/pull/491)
- [#492](https://github.com/openedx/frontend-lib-content-components/pull/492)