### PR TITLE
feat: fixed height for prerequisite course dropdown list

### DIFF
--- a/src/schedule-and-details/requirements-section/RequirementsSection.scss
+++ b/src/schedule-and-details/requirements-section/RequirementsSection.scss
@@ -2,4 +2,11 @@
   .form-group-custom:not(:last-child) {
     margin-bottom: 2rem;
   }
+
+  .dropdown-prerequisite {
+    .dropdown-menu {
+      overflow: auto;
+      height: 20rem;
+    }
+  }
 }


### PR DESCRIPTION
## Description

- made fixed height for the prerequisite course dropdown list. 

Note: same height is set for the course language dropdown list.

## Steps to reproduce

1. add waffle flag `contentstore.new_studio_mfe.use_new_grading_page` (in /admin/waffle/flag);
2. go to `studio -> Settings -> Schedule & details`;
3. scroll page till the end and click on Prerequisite course drop-down

## BEFORE
Drop-down list goes beyond footer
![infinite-dropdown-list](https://github.com/user-attachments/assets/4753c5dd-083c-44c1-bbd9-8c66f2f021ed)

## AFTER 
Drop-down list has the same height as Course language
<img width="1314" alt="fix-prerequisite-course-dropdown" src="https://github.com/user-attachments/assets/055377ac-3f23-49c8-bfd5-172440ab1213">


**Course language example**
![course-language-dropdown](https://github.com/user-attachments/assets/6edb8e91-da5b-42bf-a6e3-4479c34f7822)
