### PR TITLE
feat: Add cancel create library button

### DIFF
--- a/src/library-authoring/create-library/CreateLibrary.test.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.test.tsx
@@ -128,4 +128,13 @@ describe('<CreateLibrary />', () => {
       expect(getByRole('alert')).toHaveTextContent('{"field":"Error message"}');
     });
   });
+
+  test('cancel creating library navigates to libraries page', async () => {
+    const { getByRole } = render(<RootWrapper />);
+
+    fireEvent.click(getByRole('button', { name: /cancel/i }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/libraries');
+    });
+  });
 });

--- a/src/library-authoring/create-library/CreateLibrary.tsx
+++ b/src/library-authoring/create-library/CreateLibrary.tsx
@@ -4,7 +4,9 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Container,
   Form,
+  Button,
   StatefulButton,
+  ActionRow,
 } from '@openedx/paragon';
 import { Formik } from 'formik';
 import { useNavigate } from 'react-router-dom';
@@ -39,6 +41,10 @@ const CreateLibrary = () => {
     data: organizationListData,
     isLoading: isOrganizationListLoading,
   } = useOrganizationListData();
+
+  const handleOnClickCancel = () => {
+    navigate('/libraries');
+  };
 
   if (data) {
     navigate(`/library/${data.id}`);
@@ -114,17 +120,25 @@ const CreateLibrary = () => {
                 className=""
                 controlClasses="pb-2"
               />
-              <StatefulButton
-                type="submit"
-                variant="primary"
-                className="action btn-primary"
-                state={isLoading ? 'disabled' : 'enabled'}
-                disabledStates={['disabled']}
-                labels={{
-                  enabled: intl.formatMessage(messages.createLibraryButton),
-                  disabled: intl.formatMessage(messages.createLibraryButtonPending),
-                }}
-              />
+              <ActionRow className="justify-content-start">
+                <Button
+                  variant="outline-primary"
+                  onClick={handleOnClickCancel}
+                >
+                  {intl.formatMessage(messages.cancelCreateLibraryButton)}
+                </Button>
+                <StatefulButton
+                  type="submit"
+                  variant="primary"
+                  className="action btn-primary"
+                  state={isLoading ? 'disabled' : 'enabled'}
+                  disabledStates={['disabled']}
+                  labels={{
+                    enabled: intl.formatMessage(messages.createLibraryButton),
+                    disabled: intl.formatMessage(messages.createLibraryButtonPending),
+                  }}
+                />
+              </ActionRow>
             </Form>
           )}
         </Formik>

--- a/src/library-authoring/create-library/messages.ts
+++ b/src/library-authoring/create-library/messages.ts
@@ -83,6 +83,11 @@ const messages = defineMessages({
     defaultMessage: 'Creating..',
     description: 'Button text while the library is being created.',
   },
+  cancelCreateLibraryButton: {
+    id: 'course-authoring.library-authoring.create-library.form.create-library.cancel.button',
+    defaultMessage: 'Cancel',
+    description: 'Button text to cancel creating a new library.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

This PR adds the missing "Cancel" button from the "Create Library" form.

<img width="1371" alt="Screenshot 2024-07-26 at 10 53 51 AM" src="https://github.com/user-attachments/assets/915ec97a-bdbd-4d66-b4ee-367debe09532">

## Testing instructions

1. Run this branch in your local env
2. Click on the "New library" button on the top right to open the "create a new library" form
3. Confirm that the "Cancel" button is there
4. Confirm that clicking on the cancel button takes you to the `/libraries` page

---
Private-ref: [FAL-3779](https://tasks.opencraft.com/browse/FAL-3779)