### PR TITLE
chore: add ts* files to lint --fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "i18n_extract": "fedx-scripts formatjs extract",
     "stylelint": "stylelint \"plugins/**/*.scss\" \"src/**/*.scss\" \"scss/**/*.scss\" --config .stylelintrc.json",
     "lint": "npm run stylelint && fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
-    "lint:fix": "npm run stylelint -- --fix && fedx-scripts eslint --fix --ext .js --ext .jsx .",
+    "lint:fix": "npm run stylelint -- --fix && fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "snapshot": "TZ=UTC fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",


### PR DESCRIPTION
## Description

This PR adds the `.ts` and `.tsx` extensions to the `lint:fix` script.

## Testing instructions
- Using `master`, edit a `.ts` or `.tsx` file introducing an auto fixable lint error (i.e. replacing `'` with `"` as string delimiter)
- Run `npm run lint:fix` and check that the file still contains the error
- Checkout this branch
- Run `npm run lint:fix` and check that the error is fixed

---
Private ref: [FAL-3779](https://tasks.opencraft.com/browse/FAL-3779)