### PR TITLE
feat: replace ai-translations component with a plugin slot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
-        "@edx/frontend-component-ai-translations": "^2.1.0",
         "@edx/frontend-component-footer": "^14.0.3",
         "@edx/frontend-component-header": "^5.3.3",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
@@ -2375,82 +2374,6 @@
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.18.0",
         "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-ai-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-ai-translations/-/frontend-component-ai-translations-2.1.0.tgz",
-      "integrity": "sha512-odH8QxBYtanMMoPXiNYljcI4jTWi80NTYGJXm18M3OvIdQ4sL415KheBk73Za0ZVFHFzOs7zpFO9ZU0UgcXFVQ==",
-      "dependencies": {
-        "babel-polyfill": "6.26.0",
-        "prop-types": "^15.5.10",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-responsive": "8.2.0",
-        "react-router-dom": "6.16.0",
-        "ts-jest": "^29.1.2"
-      },
-      "peerDependencies": {
-        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "@openedx/paragon": "^21.5.7 || ^22.0.0",
-        "prop-types": "^15.5.10",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-ai-translations/node_modules/@remix-run/router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
-      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-ai-translations/node_modules/react-responsive": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
-      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1",
-        "shallow-equal": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-ai-translations/node_modules/react-router-dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0.tgz",
-      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
-      "dependencies": {
-        "@remix-run/router": "1.9.0",
-        "react-router": "6.16.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@edx/frontend-component-ai-translations/node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
-      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
-      "dependencies": {
-        "@remix-run/router": "1.9.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "node_modules/@edx/frontend-component-footer": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
-    "@edx/frontend-component-ai-translations": "^2.1.0",
     "@edx/frontend-component-footer": "^14.0.3",
     "@edx/frontend-component-header": "^5.3.3",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -114,20 +114,19 @@ const TranscriptSettings = ({
             </TransitionReplace>
           </>
         )}
-        {(!transcriptType && isAiTranslationsEnabled) && (
-          <TransitionReplace>
-            <div data-testid="ai-translations-component">
-              <PluginSlot
-                id="ai_translations_ui_component_slot"
-                pluginProps={{
-                  setIsAiTranslations,
-                  closeTranscriptSettings,
-                  courseId,
-                }}
-              />
-            </div>
-          </TransitionReplace>
-        )}
+        <TransitionReplace>
+          <div data-testid="translations-component">
+            <PluginSlot
+              id="additonal_translations_component_slot"
+              pluginProps={{
+                setIsAiTranslations,
+                closeTranscriptSettings,
+                courseId,
+                additionalProps: { transcriptType, isAiTranslationsEnabled },
+              }}
+            />
+          </div>
+        </TransitionReplace>
       </div>
     </Sheet>
   );

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.jsx
@@ -11,7 +11,7 @@ import {
   TransitionReplace,
 } from '@openedx/paragon';
 import { ChevronLeft, ChevronRight, Close } from '@openedx/paragon/icons';
-import AITranslationsComponent from '@edx/frontend-component-ai-translations';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import OrderTranscriptForm from './OrderTranscriptForm';
 import messages from './messages';
 import {
@@ -117,11 +117,13 @@ const TranscriptSettings = ({
         {(!transcriptType && isAiTranslationsEnabled) && (
           <TransitionReplace>
             <div data-testid="ai-translations-component">
-              <AITranslationsComponent
-                setIsAiTranslations={setIsAiTranslations}
-                closeTranscriptSettings={closeTranscriptSettings}
-                courseId={courseId}
-                key="ai-component"
+              <PluginSlot
+                id="ai_translations_ui_component_slot"
+                pluginProps={{
+                  setIsAiTranslations,
+                  closeTranscriptSettings,
+                  courseId,
+                }}
               />
             </div>
           </TransitionReplace>

--- a/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
+++ b/src/files-and-videos/videos-page/transcript-settings/TranscriptSettings.test.jsx
@@ -616,36 +616,7 @@ describe('TranscriptSettings', () => {
     });
   });
 
-  describe('Ai translations component fails', () => {
-    beforeEach(async () => {
-      initializeMockApp({
-        authenticatedUser: {
-          userId: 3,
-          username: 'abc123',
-          administrator: false,
-          roles: [],
-        },
-      });
-      store = initializeStore({
-        ...initialState,
-        videos: {
-          ...initialState.videos,
-          pageSettings: {
-            ...initialState.videos.pageSettings,
-          },
-        },
-      });
-      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-
-      renderComponent(defaultProps);
-    });
-
-    it('doesn\'t display AI translations component if not enabled', () => {
-      expect(screen.queryByTestId('ai-translations-component')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Ai translations component success', () => {
+  describe('Translations component success', () => {
     beforeEach(async () => {
       initializeMockApp({
         authenticatedUser: {
@@ -671,7 +642,7 @@ describe('TranscriptSettings', () => {
     });
 
     it('displays AI translations component if enabled', () => {
-      const component = screen.getByTestId('ai-translations-component');
+      const component = screen.getByTestId('translations-component');
       expect(component).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
### Summary

This PR replaces ai-translations component with a plugin slot from the @openedx/frontend-plugin-framework

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.