### PR TITLE
test: fix flaky library-authoring test [FC-0059]

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.test.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.test.tsx
@@ -313,7 +313,7 @@ describe('<LibraryAuthoringPage />', () => {
     expect(getByText('Content library')).toBeInTheDocument();
     expect(getByText(libraryData.title)).toBeInTheDocument();
 
-    expect(getByText('Recently Modified')).toBeInTheDocument();
+    await waitFor(() => { expect(getByText('Recently Modified')).toBeInTheDocument(); });
     expect(getByText('Collections (0)')).toBeInTheDocument();
     expect(getByText('Components (6)')).toBeInTheDocument();
     expect(getAllByText('Test HTML Block')[0]).toBeInTheDocument();
@@ -355,11 +355,10 @@ describe('<LibraryAuthoringPage />', () => {
     expect(getByText('Content library')).toBeInTheDocument();
     expect(getByText(libraryData.title)).toBeInTheDocument();
 
-    expect(getByText('Recently Modified')).toBeInTheDocument();
+    await waitFor(() => { expect(getByText('Recently Modified')).toBeInTheDocument(); });
     expect(getByText('Collections (0)')).toBeInTheDocument();
     expect(getByText('Components (2)')).toBeInTheDocument();
     expect(getAllByText('Test HTML Block')[0]).toBeInTheDocument();
-
     expect(queryByText('You have not added any content to this library yet.')).not.toBeInTheDocument();
 
     // There should not be any "View All" button on page since Components count


### PR DESCRIPTION
## Description

Fixes flaky test after merging https://github.com/openedx/frontend-app-course-authoring/pull/1147

cf https://github.com/openedx/frontend-app-course-authoring/actions/runs/10166343467/job/28116281335

## Supporting information

Private-ref: [FAL-3758](https://tasks.opencraft.com/browse/FAL-3758)

## Testing instructions

Testing change only; no manual testing required.