### PR TITLE
fix: package.json out of sync with package-lock.json and upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@edx/frontend-component-footer": "^14.0.3",
         "@edx/frontend-component-header": "^5.3.3",
         "@edx/frontend-enterprise-hotjar": "^2.0.0",
-        "@edx/frontend-lib-content-components": "^2.4.2",
+        "@edx/frontend-lib-content-components": "^2.6.0",
         "@edx/frontend-platform": "^8.0.3",
         "@edx/openedx-atlas": "^0.6.0",
         "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",
@@ -2713,10 +2713,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.5.2.tgz",
-      "integrity": "sha512-O7KMRBgZbrLeeUqQ4CF4Cp5xO/jFqxyh9Nj5rmSOMzpkxvaUOWkp6Wn2TW3C1Vohr8H1FJ2ytSbYeaoNN/6kRw==",
-      "license": "AGPL-3.0",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.6.0.tgz",
+      "integrity": "sha512-dqx94SSbaVSztkyInNH7GbBzMSyFvKdx1zFWa4itWeSf1cUlfvD7QBZfHC5US8kh+CHW7YvrQg6whaF2F2neNg==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@edx/frontend-component-footer": "^14.0.3",
     "@edx/frontend-component-header": "^5.3.3",
     "@edx/frontend-enterprise-hotjar": "^2.0.0",
-    "@edx/frontend-lib-content-components": "^2.4.2",
+    "@edx/frontend-lib-content-components": "^2.6.0",
     "@edx/frontend-platform": "^8.0.3",
     "@edx/openedx-atlas": "^0.6.0",
     "@openedx-plugins/course-app-calculator": "file:plugins/course-apps/calculator",


### PR DESCRIPTION
## Description

This PR fixes the package.json to match the version in package-lock.json. When the  versions do not match it sometimes does not pick up the most recent upgrades for the package. This was found on the edX production environment when locally the static asset link replacement was working locally, but was rewriting the links with a buggy function from a previous `frontend-lib-content-components` version. This change impacts "Developers" and "Authors"