### PR TITLE
[FC-0059] feat: add copy to clipboard feature to library authoring

### DIFF
--- a/src/library-authoring/components/ComponentCard.test.tsx
+++ b/src/library-authoring/components/ComponentCard.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { AppProvider } from '@edx/frontend-platform/react';
+import { initializeMockApp } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import type { Store } from 'redux';
+
+import { ToastProvider } from '../../generic/toast-context';
+import { getClipboardUrl } from '../../generic/data/api';
+import { ContentHit } from '../../search-manager';
+import initializeStore from '../../store';
+import ComponentCard from './ComponentCard';
+
+let store: Store;
+let axiosMock: MockAdapter;
+
+const contentHit: ContentHit = {
+  id: '1',
+  usageKey: 'lb:org1:demolib:html:a1fa8bdd-dc67-4976-9bf5-0ea75a9bca3d',
+  type: 'library_block',
+  blockId: 'a1fa8bdd-dc67-4976-9bf5-0ea75a9bca3d',
+  contextKey: 'lb:org1:Demo_Course',
+  org: 'org1',
+  breadcrumbs: [{ displayName: 'Demo Lib' }],
+  displayName: 'Text Display Name',
+  formatted: {
+    displayName: 'Text Display Formated Name',
+    content: {
+      htmlContent: 'This is a text: ID=1',
+    },
+  },
+  tags: {
+    level0: ['1', '2', '3'],
+  },
+  blockType: 'text',
+  created: 1722434322294,
+  modified: 1722434322294,
+  lastPublished: null,
+};
+
+const RootWrapper = () => (
+  <AppProvider store={store}>
+    <IntlProvider locale="en">
+      <ToastProvider>
+        <ComponentCard
+          contentHit={contentHit}
+          blockTypeDisplayName="text"
+        />
+      </ToastProvider>
+    </IntlProvider>
+  </AppProvider>
+);
+
+describe('<ComponentCard />', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+    store = initializeStore();
+
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    axiosMock.restore();
+  });
+
+  it('should render the card with title and description', () => {
+    const { getByText } = render(<RootWrapper />);
+
+    expect(getByText('Text Display Formated Name')).toBeInTheDocument();
+    expect(getByText('This is a text: ID=1')).toBeInTheDocument();
+  });
+
+  it('should call the updateClipboard function when the copy button is clicked', async () => {
+    axiosMock.onPost(getClipboardUrl()).reply(200, {});
+    const { getByRole, getByTestId, getByText } = render(<RootWrapper />);
+
+    // Open menu
+    expect(getByTestId('component-card-menu-toggle')).toBeInTheDocument();
+    fireEvent.click(getByTestId('component-card-menu-toggle'));
+
+    // Click copy to clipboard
+    expect(getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+    fireEvent.click(getByRole('button', { name: 'Copy to clipboard' }));
+
+    expect(axiosMock.history.post.length).toBe(1);
+    expect(axiosMock.history.post[0].data).toBe(
+      JSON.stringify({ usage_key: contentHit.usageKey }),
+    );
+
+    await waitFor(() => {
+      expect(getByText('Component copied to clipboard')).toBeInTheDocument();
+    });
+  });
+
+  it('should show error message if the api call fails', async () => {
+    axiosMock.onPost(getClipboardUrl()).reply(400);
+    const { getByRole, getByTestId, getByText } = render(<RootWrapper />);
+
+    // Open menu
+    expect(getByTestId('component-card-menu-toggle')).toBeInTheDocument();
+    fireEvent.click(getByTestId('component-card-menu-toggle'));
+
+    // Click copy to clipboard
+    expect(getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
+    fireEvent.click(getByRole('button', { name: 'Copy to clipboard' }));
+
+    expect(axiosMock.history.post.length).toBe(1);
+    expect(axiosMock.history.post[0].data).toBe(
+      JSON.stringify({ usage_key: contentHit.usageKey }),
+    );
+
+    await waitFor(() => {
+      expect(getByText('Failed to copy component to clipboard')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -40,7 +40,7 @@ const ComponentCardMenu = ({ usageKey }: { usageKey: string }) => {
         src={MoreVert}
         iconAs={Icon}
         variant="primary"
-        alt="component-card-menu-toggle" // FixMe: Add alt text
+        alt={intl.formatMessage(messages.componentCardMenuAlt)}
         data-testid="component-card-menu-toggle"
       />
       <Dropdown.Menu>

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -47,7 +47,7 @@ const ComponentCardMenu = ({ usageKey }: { usageKey: string }) => {
         <Dropdown.Item disabled>
           {intl.formatMessage(messages.menuEdit)}
         </Dropdown.Item>
-        <Dropdown.Item onClick={updateClipboardClick} data-testid="component-card-menu-copy-clipboard">
+        <Dropdown.Item onClick={updateClipboardClick}>
           {intl.formatMessage(messages.menuCopyToClipboard)}
         </Dropdown.Item>
         <Dropdown.Item disabled>

--- a/src/library-authoring/components/messages.ts
+++ b/src/library-authoring/components/messages.ts
@@ -1,4 +1,5 @@
 import { defineMessages as _defineMessages } from '@edx/frontend-platform/i18n';
+
 import type { defineMessages as defineMessagesType } from 'react-intl';
 
 // frontend-platform currently doesn't provide types... do it ourselves.
@@ -12,13 +13,23 @@ const messages = defineMessages({
   },
   menuCopyToClipboard: {
     id: 'course-authoring.library-authoring.component.menu.copy',
-    defaultMessage: 'Copy to Clipboard',
+    defaultMessage: 'Copy to clipboard',
     description: 'Menu item for copy a component.',
   },
   menuAddToCollection: {
     id: 'course-authoring.library-authoring.component.menu.add',
-    defaultMessage: 'Add to Collection',
+    defaultMessage: 'Add to collection',
     description: 'Menu item for add a component to collection.',
+  },
+  copyToClipboardSuccess: {
+    id: 'course-authoring.library-authoring.component.copyToClipboardSuccess',
+    defaultMessage: 'Component copied to clipboard',
+    description: 'Message for successful copy component to clipboard.',
+  },
+  copyToClipboardError: {
+    id: 'course-authoring.library-authoring.component.copyToClipboardError',
+    defaultMessage: 'Failed to copy component to clipboard',
+    description: 'Message for failed to copy component to clipboard.',
   },
 });
 

--- a/src/library-authoring/components/messages.ts
+++ b/src/library-authoring/components/messages.ts
@@ -6,6 +6,11 @@ import type { defineMessages as defineMessagesType } from 'react-intl';
 const defineMessages = _defineMessages as typeof defineMessagesType;
 
 const messages = defineMessages({
+  componentCardMenuAlt: {
+    id: 'course-authoring.library-authoring.component.menu',
+    defaultMessage: 'Component actions menu',
+    description: 'Alt/title text for the component card menu button.',
+  },
   menuEdit: {
     id: 'course-authoring.library-authoring.component.menu.edit',
     defaultMessage: 'Edit',

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -81,6 +81,17 @@ function formatTagsFilter(tagsFilter?: string[]): string[] {
 }
 
 /**
+ * The tags that are associated with a search result, at various levels of the tag hierarchy.
+ */
+interface ContentHitTags {
+  taxonomy?: string[];
+  level0?: string[];
+  level1?: string[];
+  level2?: string[];
+  level3?: string[];
+}
+
+/**
  * Information about a single XBlock returned in the search results
  * Defined in edx-platform/openedx/core/djangoapps/content/search/documents.py
  */
@@ -101,13 +112,13 @@ export interface ContentHit {
    * - After that is the name and usage key of any parent Section/Subsection/Unit/etc.
    */
   breadcrumbs: [{ displayName: string }, ...Array<{ displayName: string, usageKey: string }>];
-  tags: Record<'taxonomy' | 'level0' | 'level1' | 'level2' | 'level3', string[]>;
+  tags: ContentHitTags;
   content?: ContentDetails;
   /** Same fields with <mark>...</mark> highlights */
   formatted: { displayName: string, content?: ContentDetails };
   created: number;
   modified: number;
-  last_published: number;
+  lastPublished: number | null;
 }
 
 /**


### PR DESCRIPTION
## Description
This PR adds the feature to copy library components to the clipboard to be later pasted into a course or another library (in progress https://github.com/openedx/frontend-app-course-authoring/issues/1176)

![copy-to-clipboard_](https://github.com/user-attachments/assets/372e3797-9396-4d7f-86ee-6b1b9ce8fec8)

**Note:** Drag and Drop blocks will be supported in a follow up task

## Support information

Closes https://github.com/openedx/frontend-app-course-authoring/issues/1104

Depends on:
- https://github.com/openedx/edx-platform/pull/35211

## Testing Instructions
- Create a new library v2
- Add components to this library (Text, Problems or Video; Drag and Drop is NOT supported right now)
- Select the "Copy to clipboard" option in the card menu
- A toast must show "Component copied to clipboard"
- Go to a course of your choice
- Open a Unit
- Paste the block and check the results
- You can check the error toast trying to copy a Drag and Drop component.
---
Private ref: [FAL-3769](https://tasks.opencraft.com/browse/FAL-3769)