### PR TITLE
Revert "fix(deps): update dependency @edx/frontend-lib-content-components to v2.6.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,10 +2636,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-content-components": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.6.4.tgz",
-      "integrity": "sha512-lFpiHFaNDzT4QKtMhHJ29QrgXNwYB6T6Zg4TCEYDqAAuM6LU6Prc0AwCYZg20ycWn6dvzVzJ2GDS1/4ZuPPkTQ==",
-      "license": "AGPL-3.0",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-content-components/-/frontend-lib-content-components-2.6.0.tgz",
+      "integrity": "sha512-dqx94SSbaVSztkyInNH7GbBzMSyFvKdx1zFWa4itWeSf1cUlfvD7QBZfHC5US8kh+CHW7YvrQg6whaF2F2neNg==",
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",


### PR DESCRIPTION
Reverts openedx/frontend-app-course-authoring#1184

This upgrade contains a bug that prevents images from rendering properly in the text and simple problem editor.
<img width="842" alt="Screenshot 2024-08-06 at 9 34 08 AM" src="https://github.com/user-attachments/assets/149b5084-e8f5-4ee5-9996-32ca51134c70">
