### PR TITLE
refactor: change toast component [FC-0059]

### DIFF
--- a/src/generic/processing-notification/index.jsx
+++ b/src/generic/processing-notification/index.jsx
@@ -5,8 +5,6 @@ import { Badge, Icon } from '@openedx/paragon';
 import { Settings as IconSettings } from '@openedx/paragon/icons';
 import { capitalize } from 'lodash';
 
-import { NOTIFICATION_MESSAGES } from '../../constants';
-
 const ProcessingNotification = ({ isShow, title }) => (
   <Badge
     className={classNames('processing-notification', {
@@ -24,7 +22,7 @@ const ProcessingNotification = ({ isShow, title }) => (
 
 ProcessingNotification.propTypes = {
   isShow: PropTypes.bool.isRequired,
-  title: PropTypes.oneOf(Object.values(NOTIFICATION_MESSAGES)).isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default ProcessingNotification;

--- a/src/generic/toast-context/index.test.tsx
+++ b/src/generic/toast-context/index.test.tsx
@@ -50,6 +50,7 @@ describe('<ToastProvider />', () => {
       },
     });
     store = initializeStore();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -59,6 +60,13 @@ describe('<ToastProvider />', () => {
   it('should show toast', async () => {
     render(<RootWrapper><TestComponentToShow /></RootWrapper>);
     expect(await screen.findByText('This is the toast!')).toBeInTheDocument();
+  });
+
+  it('should close toast after 5000ms', async () => {
+    render(<RootWrapper><TestComponentToShow /></RootWrapper>);
+    expect(await screen.findByText('This is the toast!')).toBeInTheDocument();
+    jest.advanceTimersByTime(6000);
+    expect(screen.queryByText('This is the toast!')).not.toBeInTheDocument();
   });
 
   it('should close toast', async () => {

--- a/src/generic/toast-context/index.tsx
+++ b/src/generic/toast-context/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Toast } from '@openedx/paragon';
+
+import ProcessingNotification from '../processing-notification';
 
 export interface ToastContextData {
   toastMessage: string | null;
@@ -35,7 +36,13 @@ export const ToastProvider = (props: ToastProviderProps) => {
     setToastMessage(null);
   }, []);
 
-  const showToast = React.useCallback((message) => setToastMessage(message), [setToastMessage]);
+  const showToast = React.useCallback((message) => {
+    setToastMessage(message);
+    // Close the toast after 5 seconds
+    setTimeout(() => {
+      setToastMessage(null);
+    }, 5000);
+  }, [setToastMessage]);
   const closeToast = React.useCallback(() => setToastMessage(null), [setToastMessage]);
 
   const context = React.useMemo(() => ({
@@ -48,9 +55,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
     <ToastContext.Provider value={context}>
       {props.children}
       { toastMessage && (
-        <Toast show={toastMessage !== null} onClose={closeToast}>
-          {toastMessage}
-        </Toast>
+        <ProcessingNotification isShow={toastMessage !== null} title={toastMessage} />
       )}
     </ToastContext.Provider>
   );


### PR DESCRIPTION
## Description

Change the `Toast` component used in our `toast-context` to match the existing element in course authoring.

## More information

This change came from a UI/UX review [comment](https://github.com/openedx/frontend-app-course-authoring/issues/1104#issuecomment-2286722658).

## Testing Instructions

- Create a new library v2
- Add components to this library (Text, Problems or Video; Drag and Drop is NOT supported right now)
- Select the "Copy to clipboard" option in the card menu
- A toast must show "Component copied to clipboard"

---
Private ref: [FAL-3769](https://tasks.opencraft.com/browse/FAL-3769)

**Settings**

```yaml
TUTOR_GROVE_MFE_LMS_COMMON_SETTINGS: |
  MFE_CONFIG["LIBRARY_MODE"] = "mixed"

PLUGINS:
- mfe
- grove
- meilisearch
- s3
```

**Tutor requirements**

```
git+https://github.com/overhangio/tutor.git@nightly
git+https://github.com/overhangio/tutor-mfe@nightly
git+https://github.com/open-craft/tutor-contrib-meilisearch.git@main
git+https://github.com/hastexo/tutor-contrib-s3.git@v1.5.0
git+https://gitlab.com/opencraft/dev/tutor-contrib-grove.git@main
```