### PR TITLE
fix: discard button  [FC-0062]

### DIFF
--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -121,6 +121,7 @@ export const useRevertLibraryChanges = () => {
     mutationFn: revertLibraryChanges,
     onSettled: (_data, _error, libraryId) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
+      queryClient.invalidateQueries({ queryKey: ['content_search'] });
     },
   });
 };

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -124,7 +124,12 @@ export const useRevertLibraryChanges = () => {
     onSettled: (_data, _error, libraryId) => {
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.contentLibrary(libraryId) });
       queryClient.invalidateQueries({
-        // Invalidate all content queries related to this library
+        // Invalidate all content queries related to this library.
+        // If we allow searching "all courses and libraries" in the future,
+        // then we'd have to invalidate all `["content_search", "results"]`
+        // queries, and not just the ones for this library, because items from
+        // this library could be included in an "all courses and libraries"
+        // search. For now we only allow searching individual libraries.
         predicate: /* istanbul ignore next */ (query: Query): boolean => {
           // extraFilter contains library id
           const extraFilter = query.queryKey[5];

--- a/src/library-authoring/library-info/LibraryInfo.test.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.test.tsx
@@ -204,4 +204,30 @@ describe('<LibraryInfo />', () => {
 
     await waitFor(() => expect(axiosMock.history.post[0].url).toEqual(url));
   });
+
+  it('should discard changes', async () => {
+    const url = getCommitLibraryChangesUrl(libraryData.id);
+    axiosMock.onDelete(url).reply(200);
+
+    render(<RootWrapper data={libraryData} />);
+    const discardButton = screen.getByRole('button', { name: /discard changes/i });
+    fireEvent.click(discardButton);
+
+    expect(await screen.findByText('Library changes reverted successfully')).toBeInTheDocument();
+
+    await waitFor(() => expect(axiosMock.history.delete[0].url).toEqual(url));
+  });
+
+  it('should show error on discard changes', async () => {
+    const url = getCommitLibraryChangesUrl(libraryData.id);
+    axiosMock.onDelete(url).reply(500);
+
+    render(<RootWrapper data={libraryData} />);
+    const discardButton = screen.getByRole('button', { name: /discard changes/i });
+    fireEvent.click(discardButton);
+
+    expect(await screen.findByText('There was an error reverting changes in the library.')).toBeInTheDocument();
+
+    await waitFor(() => expect(axiosMock.history.delete[0].url).toEqual(url));
+  });
 });

--- a/src/library-authoring/library-info/LibraryInfo.test.tsx
+++ b/src/library-authoring/library-info/LibraryInfo.test.tsx
@@ -230,4 +230,18 @@ describe('<LibraryInfo />', () => {
 
     await waitFor(() => expect(axiosMock.history.delete[0].url).toEqual(url));
   });
+
+  it('discard changes btn should be disabled for new libraries', async () => {
+    render(<RootWrapper data={{ ...libraryData, lastPublished: null, numBlocks: 0 }} />);
+    const discardButton = screen.getByRole('button', { name: /discard changes/i });
+
+    expect(discardButton).toBeDisabled();
+  });
+
+  it('discard changes btn should be enabled for new libraries if components are added', async () => {
+    render(<RootWrapper data={{ ...libraryData, lastPublished: null, numBlocks: 2 }} />);
+    const discardButton = screen.getByRole('button', { name: /discard changes/i });
+
+    expect(discardButton).not.toBeDisabled();
+  });
 });

--- a/src/library-authoring/library-info/LibraryPublishStatus.tsx
+++ b/src/library-authoring/library-info/LibraryPublishStatus.tsx
@@ -37,11 +37,13 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
 
   const {
     isPublished,
+    isNew,
     statusMessage,
     extraStatusMessage,
     bodyMessage,
   } = useMemo(() => {
     let isPublishedResult: boolean;
+    let isNewResult = false;
     let statusMessageResult : string;
     let extraStatusMessageResult : string | undefined;
     let bodyMessageResult : string | undefined;
@@ -91,6 +93,7 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
 
     if (!library.lastPublished) {
       // Library is never published (new)
+      isNewResult = library.numBlocks === 0; // allow discarding if components are added
       isPublishedResult = false;
       statusMessageResult = intl.formatMessage(messages.draftStatusLabel);
       extraStatusMessageResult = intl.formatMessage(messages.neverPublishedLabel);
@@ -120,6 +123,7 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
     }
     return {
       isPublished: isPublishedResult,
+      isNew: isNewResult,
       statusMessage: statusMessageResult,
       extraStatusMessage: extraStatusMessageResult,
       bodyMessage: bodyMessageResult,
@@ -151,7 +155,7 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
             {intl.formatMessage(messages.publishButtonLabel)}
           </Button>
           <div className="d-flex justify-content-end">
-            <Button disabled={isPublished} variant="link" onClick={revert}>
+            <Button disabled={isPublished || isNew} variant="link" onClick={revert}>
               {intl.formatMessage(messages.discardChangesButtonLabel)}
             </Button>
           </div>

--- a/src/library-authoring/library-info/LibraryPublishStatus.tsx
+++ b/src/library-authoring/library-info/LibraryPublishStatus.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { Button, Container, Stack } from '@openedx/paragon';
 import { FormattedDate, FormattedTime, useIntl } from '@edx/frontend-platform/i18n';
-import { useCommitLibraryChanges } from '../data/apiHooks';
+import { useCommitLibraryChanges, useRevertLibraryChanges } from '../data/apiHooks';
 import { ContentLibrary } from '../data/api';
 import { ToastContext } from '../../generic/toast-context';
 import messages from './messages';
@@ -14,6 +14,7 @@ type LibraryPublishStatusProps = {
 const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
   const intl = useIntl();
   const commitLibraryChanges = useCommitLibraryChanges();
+  const revertLibraryChanges = useRevertLibraryChanges();
   const { showToast } = useContext(ToastContext);
 
   const commit = useCallback(() => {
@@ -25,9 +26,6 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
       });
   }, []);
 
-  /**
-   * TODO, the discard changes breaks the library.
-   * Discomment this when discard changes is fixed.
   const revert = useCallback(() => {
     revertLibraryChanges.mutateAsync(library.id)
       .then(() => {
@@ -36,7 +34,6 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
         showToast(intl.formatMessage(messages.revertErrorMsg));
       });
   }, []);
-  */
 
   const {
     isPublished,
@@ -153,15 +150,11 @@ const LibraryPublishStatus = ({ library } : LibraryPublishStatusProps) => {
           <Button disabled={isPublished} onClick={commit}>
             {intl.formatMessage(messages.publishButtonLabel)}
           </Button>
-          { /*
-             * TODO, the discard changes breaks the library.
-             * Discomment this when discard changes is fixed.
-            <div className="d-flex justify-content-end">
-              <Button disabled={isPublished} variant="link" onClick={revert}>
-                {intl.formatMessage(messages.discardChangesButtonLabel)}
-              </Button>
-            </div>
-          */ }
+          <div className="d-flex justify-content-end">
+            <Button disabled={isPublished} variant="link" onClick={revert}>
+              {intl.formatMessage(messages.discardChangesButtonLabel)}
+            </Button>
+          </div>
         </Stack>
       </Container>
     </Stack>


### PR DESCRIPTION
**Related PRs**:

* https://github.com/openedx/edx-platform/pull/35243
* https://github.com/openedx/openedx-learning/pull/207

Issue: #1200

**Test instructions:**

* Setup latest tutor nightly locally.
* Install https://github.com/open-craft/tutor-contrib-meilisearch and enable the plugin
* Checkout above PRs from edx-platform and openedx-learning.
* Mount both the directories in tutor using `tutor mounts add <path>`.
* Start tutor using `tutor dev launch -I`
* Go to studio -> Libraries and create a new library.
* Create some components and click on publish button in the sidebar.
* Verify that everything is saved.
* Add some more components and click on `Discard changes` button in sidebar.
* Verify that newly created components are not visible.

**Original PR and comments:** https://github.com/open-craft/frontend-app-course-authoring/pull/58

Settings

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/openedx/edx-platform.git
EDX_PLATFORM_VERSION: master

GROVE_REDIRECTS:
 - domain: {{ LMS_HOST }}
 - domain: cms.{{ LMS_HOST }}
 - domain: app.{{ LMS_HOST }}
 - domain: meilsearch.{{ LMS_HOST }}

PLUGINS:
- mfe
- grove
- s3
- meilisearch

OPENEDX_EXTRA_PIP_REQUIREMENTS:
- dnspython
- openedx-scorm-xblock<13.0.0,>=12.0.0
- git+https://github.com/openedx/openedx-learning@main
```

Tutor requirements

```
git+https://github.com/overhangio/tutor.git@nightly
git+https://github.com/overhangio/tutor-mfe@nightly
git+https://gitlab.com/opencraft/dev/tutor-contrib-grove.git@main
git+https://github.com/open-craft/tutor-contrib-meilisearch.git@main
git+https://github.com/hastexo/tutor-contrib-s3.git@v1.5.0
```
