### PR TITLE
feat: remove new library button if user does not have create access for v1 libraries

### DIFF
--- a/src/studio-home/StudioHome.jsx
+++ b/src/studio-home/StudioHome.jsx
@@ -52,6 +52,7 @@ const StudioHome = ({ intl }) => {
   const libMode = getConfig().LIBRARY_MODE;
 
   const v1LibraryTab = isMixedOrV1LibrariesMode(libMode) && location?.pathname.split('/').pop() === 'libraries-v1';
+  const showV2LibraryURL = isMixedOrV2LibrariesMode(libMode) && !v1LibraryTab;
 
   const {
     userIsActive,
@@ -89,9 +90,9 @@ const StudioHome = ({ intl }) => {
       );
     }
 
-    if (showNewLibraryButton) {
+    if (showNewLibraryButton || showV2LibraryURL) {
       const newLibraryClick = () => {
-        if (isMixedOrV2LibrariesMode(libMode) && !v1LibraryTab) {
+        if (showV2LibraryURL) {
           if (libraryAuthoringMfeUrl && redirectToLibraryAuthoringMfe) {
             // Library authoring MFE
             window.open(constructLibraryAuthoringURL(libraryAuthoringMfeUrl, 'create'));

--- a/src/studio-home/StudioHome.jsx
+++ b/src/studio-home/StudioHome.jsx
@@ -59,6 +59,7 @@ const StudioHome = ({ intl }) => {
     studioRequestEmail,
     libraryAuthoringMfeUrl,
     redirectToLibraryAuthoringMfe,
+    showNewLibraryButton,
   } = studioHomeData;
 
   const getHeaderButtons = useCallback(() => {
@@ -88,33 +89,35 @@ const StudioHome = ({ intl }) => {
       );
     }
 
-    const newLibraryClick = () => {
-      if (isMixedOrV2LibrariesMode(libMode) && !v1LibraryTab) {
-        if (libraryAuthoringMfeUrl && redirectToLibraryAuthoringMfe) {
-          // Library authoring MFE
-          window.open(constructLibraryAuthoringURL(libraryAuthoringMfeUrl, 'create'));
+    if (showNewLibraryButton) {
+      const newLibraryClick = () => {
+        if (isMixedOrV2LibrariesMode(libMode) && !v1LibraryTab) {
+          if (libraryAuthoringMfeUrl && redirectToLibraryAuthoringMfe) {
+            // Library authoring MFE
+            window.open(constructLibraryAuthoringURL(libraryAuthoringMfeUrl, 'create'));
+          } else {
+            // Use course-authoring route
+            navigate('/library/create');
+          }
         } else {
-          // Use course-authoring route
-          navigate('/library/create');
+          // Studio home library for legacy libraries
+          window.open(`${getConfig().STUDIO_BASE_URL}/home_library`);
         }
-      } else {
-        // Studio home library for legacy libraries
-        window.open(`${getConfig().STUDIO_BASE_URL}/home_library`);
-      }
-    };
+      };
 
-    headerButtons.push(
-      <Button
-        variant="outline-primary"
-        iconBefore={AddIcon}
-        size="sm"
-        disabled={showNewCourseContainer}
-        onClick={newLibraryClick}
-        data-testid="new-library-button"
-      >
-        {intl.formatMessage(messages.addNewLibraryBtnText)}
-      </Button>,
-    );
+      headerButtons.push(
+        <Button
+          variant="outline-primary"
+          iconBefore={AddIcon}
+          size="sm"
+          disabled={showNewCourseContainer}
+          onClick={newLibraryClick}
+          data-testid="new-library-button"
+        >
+          {intl.formatMessage(messages.addNewLibraryBtnText)}
+        </Button>,
+      );
+    }
 
     return headerButtons;
   }, [location, userIsActive, isFailedLoadingPage]);

--- a/src/studio-home/StudioHome.test.jsx
+++ b/src/studio-home/StudioHome.test.jsx
@@ -228,13 +228,30 @@ describe('<StudioHome />', () => {
       });
     });
 
-    it('do not render new library button if showNewLibraryButton is False', () => {
+    it('do not render new library button for "v1 only" mode if showNewLibraryButton is False', () => {
+      setConfig({
+        ...getConfig(),
+        LIBRARY_MODE: 'v1 only',
+      });
       useSelector.mockReturnValue({
         ...studioHomeMock,
         showNewLibraryButton: false,
       });
       const { queryByTestId } = render(<RootWrapper />);
       expect(queryByTestId('new-library-button')).not.toBeInTheDocument();
+    });
+
+    it('render new library button for "v2 only" mode even if showNewLibraryButton is False', () => {
+      setConfig({
+        ...getConfig(),
+        LIBRARY_MODE: 'v2 only',
+      });
+      useSelector.mockReturnValue({
+        ...studioHomeMock,
+        showNewLibraryButton: false,
+      });
+      const { queryByTestId } = render(<RootWrapper />);
+      expect(queryByTestId('new-library-button')).toBeInTheDocument();
     });
 
     it('should render create new course container', async () => {

--- a/src/studio-home/StudioHome.test.jsx
+++ b/src/studio-home/StudioHome.test.jsx
@@ -228,6 +228,15 @@ describe('<StudioHome />', () => {
       });
     });
 
+    it('do not render new library button if showNewLibraryButton is False', () => {
+      useSelector.mockReturnValue({
+        ...studioHomeMock,
+        showNewLibraryButton: false,
+      });
+      const { queryByTestId } = render(<RootWrapper />);
+      expect(queryByTestId('new-library-button')).not.toBeInTheDocument();
+    });
+
     it('should render create new course container', async () => {
       useSelector.mockReturnValue({
         ...studioHomeMock,


### PR DESCRIPTION
## Description

Currently the `New Library` button is shown to studio users even if they don't have the required access to create a library. This creates a confusing user experince for the user, since if such an user tries to create a library, they get a error down the UI flow.

This PR fixes this behavior for V1 libraries inline with the the legacy Studio UI

## Testing instructions

1. Setup this PR branch in a local or sandbox environment.
2. Login to studio through a user account without any staff access
3. Ensure New Library button is missing there.

## Other information

Private Ref: [BB-9077](https://tasks.opencraft.com/browse/BB-9077)