### PR TITLE
Hide "Advanced Settings" settings item [BB-9081]

### DIFF
--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -11,6 +11,7 @@ import { fetchCourseDetail } from './data/thunks';
 import { useModel } from './generic/model-store';
 import NotFoundAlert from './generic/NotFoundAlert';
 import PermissionDeniedAlert from './generic/PermissionDeniedAlert';
+import { fetchStudioHomeData } from './studio-home/data/thunks';
 import { getCourseAppsApiStatus } from './pages-and-resources/data/selectors';
 import { RequestStatus } from './data/constants';
 import Loading from './generic/Loading';
@@ -21,6 +22,10 @@ const CourseAuthoringPage = ({ courseId, children }) => {
   useEffect(() => {
     dispatch(fetchCourseDetail(courseId));
   }, [courseId]);
+
+  useEffect(() => {
+    dispatch(fetchStudioHomeData());
+  }, []);
 
   const courseDetail = useModel('courseDetails', courseId);
 

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -7,7 +7,7 @@ import { useToggle } from '@openedx/paragon';
 import { generatePath, useHref } from 'react-router-dom';
 
 import { SearchModal } from '../search-modal';
-import { getContentMenuItems, getSettingMenuItems, getToolsMenuItems } from './utils';
+import { useContentMenuItems, useSettingMenuItems, useToolsMenuItems } from './hooks';
 import messages from './messages';
 
 interface HeaderProps {
@@ -34,23 +34,28 @@ const Header = ({
 
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
   const meiliSearchEnabled = [true, 'true'].includes(getConfig().MEILISEARCH_ENABLED);
+
+  const contentMenuItems = useContentMenuItems(contextId);
+  const settingMenuItems = useSettingMenuItems(contextId);
+  const toolsMenuItems = useToolsMenuItems(contextId);
   const mainMenuDropdowns = !isLibrary ? [
     {
       id: `${intl.formatMessage(messages['header.links.content'])}-dropdown-menu`,
       buttonTitle: intl.formatMessage(messages['header.links.content']),
-      items: getContentMenuItems({ studioBaseUrl, courseId: contextId, intl }),
+      items: contentMenuItems,
     },
     {
       id: `${intl.formatMessage(messages['header.links.settings'])}-dropdown-menu`,
       buttonTitle: intl.formatMessage(messages['header.links.settings']),
-      items: getSettingMenuItems({ studioBaseUrl, courseId: contextId, intl }),
+      items: settingMenuItems,
     },
     {
       id: `${intl.formatMessage(messages['header.links.tools'])}-dropdown-menu`,
       buttonTitle: intl.formatMessage(messages['header.links.tools']),
-      items: getToolsMenuItems({ studioBaseUrl, courseId: contextId, intl }),
+      items: toolsMenuItems,
     },
   ] : [];
+
   const outlineLink = !isLibrary
     ? `${studioBaseUrl}/course/${contextId}`
     : generatePath(libraryHref, { libraryId: contextId });

--- a/src/header/hooks.js
+++ b/src/header/hooks.js
@@ -1,6 +1,8 @@
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { useSelector } from 'react-redux';
 import { getPagePath } from '../utils';
+import { getStudioHomeData } from '../studio-home/data/selectors';
 import messages from './messages';
 
 export const useContentMenuItems = courseId => {
@@ -38,6 +40,7 @@ export const useContentMenuItems = courseId => {
 export const useSettingMenuItems = courseId => {
   const intl = useIntl();
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+  const { canAccessAdvancedSettings } = useSelector(getStudioHomeData);
 
   const items = [
     {
@@ -56,10 +59,12 @@ export const useSettingMenuItems = courseId => {
       href: `${studioBaseUrl}/group_configurations/${courseId}`,
       title: intl.formatMessage(messages['header.links.groupConfigurations']),
     },
-    {
-      href: `${studioBaseUrl}/settings/advanced/${courseId}`,
-      title: intl.formatMessage(messages['header.links.advancedSettings']),
-    },
+    ...(canAccessAdvancedSettings === true
+      ? [{
+        href: `${studioBaseUrl}/settings/advanced/${courseId}`,
+        title: intl.formatMessage(messages['header.links.advancedSettings']),
+      }] : []
+    ),
   ];
   if (getConfig().ENABLE_CERTIFICATE_PAGE === 'true') {
     items.push({

--- a/src/header/hooks.js
+++ b/src/header/hooks.js
@@ -1,8 +1,12 @@
 import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { getPagePath } from '../utils';
 import messages from './messages';
 
-export const getContentMenuItems = ({ studioBaseUrl, courseId, intl }) => {
+export const useContentMenuItems = courseId => {
+  const intl = useIntl();
+  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+
   const items = [
     {
       href: `${studioBaseUrl}/course/${courseId}`,
@@ -31,7 +35,10 @@ export const getContentMenuItems = ({ studioBaseUrl, courseId, intl }) => {
   return items;
 };
 
-export const getSettingMenuItems = ({ studioBaseUrl, courseId, intl }) => {
+export const useSettingMenuItems = courseId => {
+  const intl = useIntl();
+  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+
   const items = [
     {
       href: `${studioBaseUrl}/settings/details/${courseId}`,
@@ -63,23 +70,29 @@ export const getSettingMenuItems = ({ studioBaseUrl, courseId, intl }) => {
   return items;
 };
 
-export const getToolsMenuItems = ({ studioBaseUrl, courseId, intl }) => ([
-  {
-    href: `${studioBaseUrl}/import/${courseId}`,
-    title: intl.formatMessage(messages['header.links.import']),
-  },
-  {
-    href: `${studioBaseUrl}/export/${courseId}`,
-    title: intl.formatMessage(messages['header.links.exportCourse']),
-  },
-  ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
-    ? [{
-      href: '#export-tags',
-      title: intl.formatMessage(messages['header.links.exportTags']),
-    }] : []
-  ),
-  {
-    href: `${studioBaseUrl}/checklists/${courseId}`,
-    title: intl.formatMessage(messages['header.links.checklists']),
-  },
-]);
+export const useToolsMenuItems = courseId => {
+  const intl = useIntl();
+  const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+
+  const items = [
+    {
+      href: `${studioBaseUrl}/import/${courseId}`,
+      title: intl.formatMessage(messages['header.links.import']),
+    },
+    {
+      href: `${studioBaseUrl}/export/${courseId}`,
+      title: intl.formatMessage(messages['header.links.exportCourse']),
+    },
+    ...(getConfig().ENABLE_TAGGING_TAXONOMY_PAGES === 'true'
+      ? [{
+        href: '#export-tags',
+        title: intl.formatMessage(messages['header.links.exportTags']),
+      }] : []
+    ),
+    {
+      href: `${studioBaseUrl}/checklists/${courseId}`,
+      title: intl.formatMessage(messages['header.links.checklists']),
+    },
+  ];
+  return items;
+};

--- a/src/header/hooks.test.js
+++ b/src/header/hooks.test.js
@@ -1,3 +1,4 @@
+import { useSelector } from 'react-redux';
 import { getConfig, setConfig } from '@edx/frontend-platform';
 import { renderHook } from '@testing-library/react-hooks';
 import { useContentMenuItems, useToolsMenuItems, useSettingMenuItems } from './hooks';
@@ -7,6 +8,11 @@ jest.mock('@edx/frontend-platform/i18n', () => ({
   useIntl: () => ({
     formatMessage: jest.fn(message => message.defaultMessage),
   }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
 }));
 
 describe('header utils', () => {
@@ -30,6 +36,8 @@ describe('header utils', () => {
   });
 
   describe('getSettingsMenuitems', () => {
+    useSelector.mockReturnValue({ canAccessAdvancedSettings: true });
+
     it('should include certificates option', () => {
       setConfig({
         ...getConfig(),
@@ -45,6 +53,15 @@ describe('header utils', () => {
       });
       const actualItems = renderHook(() => useSettingMenuItems('course-123')).result.current;
       expect(actualItems).toHaveLength(5);
+    });
+    it('should include advanced settings option', () => {
+      const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123')).result.current.map((item) => item.title);
+      expect(actualItemsTitle).toContain('Advanced Settings');
+    });
+    it('should not include advanced settings option', () => {
+      useSelector.mockReturnValue({ canAccessAdvancedSettings: false });
+      const actualItemsTitle = renderHook(() => useSettingMenuItems('course-123')).result.current.map((item) => item.title);
+      expect(actualItemsTitle).not.toContain('Advanced Settings');
     });
   });
 

--- a/src/header/hooks.test.js
+++ b/src/header/hooks.test.js
@@ -1,13 +1,13 @@
 import { getConfig, setConfig } from '@edx/frontend-platform';
-import { getContentMenuItems, getToolsMenuItems, getSettingMenuItems } from './utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { useContentMenuItems, useToolsMenuItems, useSettingMenuItems } from './hooks';
 
-const props = {
-  studioBaseUrl: 'UrLSTuiO',
-  courseId: '123',
-  intl: {
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  useIntl: () => ({
     formatMessage: jest.fn(message => message.defaultMessage),
-  },
-};
+  }),
+}));
 
 describe('header utils', () => {
   describe('getContentMenuItems', () => {
@@ -16,7 +16,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'true',
       });
-      const actualItems = getContentMenuItems(props);
+      const actualItems = renderHook(() => useContentMenuItems('course-123')).result.current;
       expect(actualItems).toHaveLength(5);
     });
     it('should not include Video Uploads option', () => {
@@ -24,7 +24,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN: 'false',
       });
-      const actualItems = getContentMenuItems(props);
+      const actualItems = renderHook(() => useContentMenuItems('course-123')).result.current;
       expect(actualItems).toHaveLength(4);
     });
   });
@@ -35,7 +35,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_CERTIFICATE_PAGE: 'true',
       });
-      const actualItems = getSettingMenuItems(props);
+      const actualItems = renderHook(() => useSettingMenuItems('course-123')).result.current;
       expect(actualItems).toHaveLength(6);
     });
     it('should not include certificates option', () => {
@@ -43,7 +43,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_CERTIFICATE_PAGE: 'false',
       });
-      const actualItems = getSettingMenuItems(props);
+      const actualItems = renderHook(() => useSettingMenuItems('course-123')).result.current;
       expect(actualItems).toHaveLength(5);
     });
   });
@@ -54,7 +54,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_TAGGING_TAXONOMY_PAGES: 'true',
       });
-      const actualItemsTitle = getToolsMenuItems(props).map((item) => item.title);
+      const actualItemsTitle = renderHook(() => useToolsMenuItems('course-123')).result.current.map((item) => item.title);
       expect(actualItemsTitle).toEqual([
         'Import',
         'Export Course',
@@ -67,7 +67,7 @@ describe('header utils', () => {
         ...getConfig(),
         ENABLE_TAGGING_TAXONOMY_PAGES: 'false',
       });
-      const actualItemsTitle = getToolsMenuItems(props).map((item) => item.title);
+      const actualItemsTitle = renderHook(() => useToolsMenuItems('course-123')).result.current.map((item) => item.title);
       expect(actualItemsTitle).toEqual([
         'Import',
         'Export Course',


### PR DESCRIPTION
## Description

Hides the "Advanced Settings" item from the "Settings" drop-down if the studio home endpoint's response contains `can_access_advanced_settings: false`.

## Testing instructions

Re-use the testing steps from https://github.com/openedx/edx-platform/pull/35426. As a test user, go to Studio and make sure you don't see the "Advanced Settings" drop-down menu item anywhere.