### PR TITLE
fix: create course button inactive after using org drop-down

### DIFF
--- a/src/generic/create-or-rerun-course/hooks.jsx
+++ b/src/generic/create-or-rerun-course/hooks.jsx
@@ -84,7 +84,11 @@ const useCreateOrRerunCourse = (initialValues) => {
   }, []);
 
   useEffect(() => {
-    setFormFilled(Object.values(values).every((i) => i));
+    setFormFilled(
+      Object.entries(values)
+        ?.filter(([key]) => key !== 'undefined')
+        .every(([, value]) => value),
+    );
     dispatch(updatePostErrors({}));
   }, [values]);
 


### PR DESCRIPTION
## Description

This concerns fixing a bug from [**this issue**](https://github.com/openedx/frontend-app-course-authoring/issues/1199)